### PR TITLE
fix: subagent data flow escape (R3-291)

### DIFF
--- a/internal/hooks/handler.go
+++ b/internal/hooks/handler.go
@@ -117,6 +117,22 @@ func (h *Handler) handleSessionStart(input *aflock.HookInput) error {
 
 	// Initialize session state
 	sessionState := h.stateManager.Initialize(input.SessionID, pol, policyPath)
+
+	// Check for propagation from a parent session (sublayout delegation).
+	// If found, inherit materials and attenuate limits.
+	if prop, propErr := h.stateManager.ReadPropagation(policyPath); propErr != nil {
+		fmt.Fprintf(os.Stderr, "[aflock] Warning: failed to read propagation: %v\n", propErr)
+	} else if prop != nil {
+		sessionState.ParentSessionID = prop.ParentSessionID
+		sessionState.Materials = prop.Materials
+		if prop.ParentLimits != nil && prop.ParentMetrics != nil {
+			sessionState.Policy.Limits = attenuateLimits(
+				sessionState.Policy.Limits, prop.ParentLimits, prop.ParentMetrics)
+		}
+		fmt.Fprintf(os.Stderr, "[aflock] Inherited %d materials from parent session %s\n",
+			len(prop.Materials), prop.ParentSessionID)
+	}
+
 	if err := h.stateManager.Save(sessionState); err != nil {
 		output.ExitWithWarning(fmt.Sprintf("Failed to save session state: %v", err))
 		return nil
@@ -272,6 +288,14 @@ func (h *Handler) handlePreToolUse(input *aflock.HookInput) error {
 		output.ExitWithWarning(fmt.Sprintf("Failed to save session state: %v", err))
 	}
 
+	// If this is a subagent spawn, write propagation file so the child
+	// session inherits materials and attenuated limits (Section 5: sublayout delegation).
+	if isSubagentSpawn(input.ToolName) && sessionState.PolicyPath != "" {
+		if err := h.stateManager.WritePropagation(sessionState); err != nil {
+			fmt.Fprintf(os.Stderr, "[aflock] Warning: failed to write propagation: %v\n", err)
+		}
+	}
+
 	// Return decision as proper JSON response
 	switch decision {
 	case aflock.DecisionDeny:
@@ -395,9 +419,42 @@ func (h *Handler) handleStop(input *aflock.HookInput) error {
 	return output.Write(output.StopAllow())
 }
 
-// handleSubagentStop checks sublayout constraints.
-func (h *Handler) handleSubagentStop(_ *aflock.HookInput) error {
-	// Similar to Stop, but for subagents
+// handleSubagentStop merges the child session's actions, metrics, and materials
+// back into the parent session and checks post-hoc limits on the child.
+func (h *Handler) handleSubagentStop(input *aflock.HookInput) error {
+	// Load child session state
+	if input.SessionID == "" {
+		return output.Write(output.StopAllow())
+	}
+	childState, err := h.stateManager.Load(input.SessionID)
+	if err != nil || childState == nil {
+		return output.Write(output.StopAllow())
+	}
+
+	// If child has a parent, merge results back
+	if childState.ParentSessionID != "" {
+		parentState, loadErr := h.stateManager.Load(childState.ParentSessionID)
+		if loadErr != nil {
+			fmt.Fprintf(os.Stderr, "[aflock] Warning: failed to load parent session %s: %v\n",
+				childState.ParentSessionID, loadErr)
+		} else if parentState != nil {
+			mergeChildIntoParent(parentState, childState)
+			if saveErr := h.stateManager.Save(parentState); saveErr != nil {
+				fmt.Fprintf(os.Stderr, "[aflock] Warning: failed to save parent session: %v\n", saveErr)
+			}
+		}
+	}
+
+	// Check post-hoc limits on the child session
+	if childState.Policy != nil && childState.Policy.Limits != nil {
+		evaluator := policy.NewEvaluator(childState.Policy, filepath.Dir(childState.PolicyPath))
+		exceeded, limitName, msg := evaluator.CheckLimits(childState.Metrics, "post-hoc")
+		if exceeded {
+			return output.Write(output.StopBlock(
+				fmt.Sprintf("[aflock] Subagent limit exceeded: %s - %s", limitName, msg)))
+		}
+	}
+
 	return output.Write(output.StopAllow())
 }
 
@@ -521,6 +578,98 @@ func attestationMatchesName(path, name string) bool {
 	}
 
 	return strings.EqualFold(predicate.ToolName, name) || strings.EqualFold(predicate.Action, name)
+}
+
+// isSubagentSpawn returns true if the tool triggers a subagent spawn.
+func isSubagentSpawn(toolName string) bool {
+	return toolName == "Agent" || toolName == "Task"
+}
+
+// attenuateLimits computes effective limits for a child session.
+// For each limit field: child effective = min(child policy limit, parent remaining).
+// If a parent has exhausted its budget, the child gets 0.
+func attenuateLimits(childLimits, parentLimits *aflock.LimitsPolicy, parentMetrics *aflock.SessionMetrics) *aflock.LimitsPolicy {
+	if parentLimits == nil {
+		return childLimits
+	}
+
+	result := &aflock.LimitsPolicy{}
+	if childLimits != nil {
+		*result = *childLimits
+	}
+
+	attenuate := func(childLimit, parentLimit *aflock.Limit, parentUsed float64) *aflock.Limit {
+		if parentLimit == nil {
+			return childLimit
+		}
+		remaining := parentLimit.Value - parentUsed
+		if remaining < 0 {
+			remaining = 0
+		}
+		enforcement := parentLimit.Enforcement
+		if childLimit != nil {
+			if childLimit.Value < remaining {
+				remaining = childLimit.Value
+			}
+			if childLimit.Enforcement != "" {
+				enforcement = childLimit.Enforcement
+			}
+		}
+		return &aflock.Limit{Value: remaining, Enforcement: enforcement}
+	}
+
+	result.MaxSpendUSD = attenuate(result.MaxSpendUSD, parentLimits.MaxSpendUSD, parentMetrics.CostUSD)
+	result.MaxTokensIn = attenuate(result.MaxTokensIn, parentLimits.MaxTokensIn, float64(parentMetrics.TokensIn))
+	result.MaxTokensOut = attenuate(result.MaxTokensOut, parentLimits.MaxTokensOut, float64(parentMetrics.TokensOut))
+	result.MaxTurns = attenuate(result.MaxTurns, parentLimits.MaxTurns, float64(parentMetrics.Turns))
+	result.MaxToolCalls = attenuate(result.MaxToolCalls, parentLimits.MaxToolCalls, float64(parentMetrics.ToolCalls))
+	// MaxWallTimeSeconds is per-session, not inherited
+	if childLimits != nil {
+		result.MaxWallTimeSeconds = childLimits.MaxWallTimeSeconds
+	}
+
+	return result
+}
+
+// mergeChildIntoParent merges the child session's actions, metrics, and
+// materials back into the parent session state.
+func mergeChildIntoParent(parent, child *aflock.SessionState) {
+	// Annotate and append child actions
+	for _, action := range child.Actions {
+		annotated := action
+		annotated.Reason = fmt.Sprintf("[subagent:%s] %s", child.SessionID, action.Reason)
+		parent.Actions = append(parent.Actions, annotated)
+	}
+
+	// Add child metrics to parent
+	if child.Metrics != nil && parent.Metrics != nil {
+		parent.Metrics.TokensIn += child.Metrics.TokensIn
+		parent.Metrics.TokensOut += child.Metrics.TokensOut
+		parent.Metrics.CostUSD += child.Metrics.CostUSD
+		parent.Metrics.ToolCalls += child.Metrics.ToolCalls
+		for tool, count := range child.Metrics.Tools {
+			if parent.Metrics.Tools == nil {
+				parent.Metrics.Tools = make(map[string]int)
+			}
+			parent.Metrics.Tools[tool] += count
+		}
+	}
+
+	// Merge child materials into parent (deduplicated by label+source)
+	existing := make(map[string]bool)
+	for _, m := range parent.Materials {
+		existing[m.Label+"\x00"+m.Source] = true
+	}
+	for _, m := range child.Materials {
+		key := m.Label + "\x00" + m.Source
+		if !existing[key] {
+			parent.Materials = append(parent.Materials, m)
+			existing[key] = true
+		}
+	}
+
+	// Track child session ID
+	parent.ChildSessionIDs = append(parent.ChildSessionIDs, child.SessionID)
 }
 
 func isFileOperation(toolName string) bool {

--- a/internal/hooks/handler_sublayout_test.go
+++ b/internal/hooks/handler_sublayout_test.go
@@ -1,0 +1,744 @@
+package hooks
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/aflock-ai/aflock/pkg/aflock"
+)
+
+// dataFlowPolicy returns a policy with internal->public data flow blocking.
+func dataFlowPolicy() *aflock.Policy {
+	return &aflock.Policy{
+		Name:    "test-sublayout",
+		Version: "1.0",
+		Tools: &aflock.ToolsPolicy{
+			Allow: []string{"Read", "Write", "Edit", "Bash", "Agent", "Task"},
+		},
+		DataFlow: &aflock.DataFlowPolicy{
+			Classify: map[string][]string{
+				"internal": {"Read:**/internal/**"},
+				"public":   {"Write:**/public/**", "Bash:*curl*public*"},
+			},
+			FlowRules: []aflock.DataFlowRule{
+				{Deny: "internal->public", Message: "Cannot send internal data to public destinations"},
+			},
+		},
+	}
+}
+
+// ----- PreToolUse: Agent tool triggers propagation write -----
+
+func TestSublayout_AgentToolWritesPropagation(t *testing.T) {
+	h := newTestHandler(t)
+	pol := dataFlowPolicy()
+	pol.Limits = &aflock.LimitsPolicy{
+		MaxSpendUSD:  &aflock.Limit{Value: 1.0, Enforcement: "fail-fast"},
+		MaxToolCalls: &aflock.Limit{Value: 50, Enforcement: "post-hoc"},
+	}
+
+	ss := seedSession(t, h, "parent-1", pol)
+	// Add materials to the parent (simulate reading internal data)
+	ss.Materials = append(ss.Materials, aflock.MaterialClassification{
+		Label: "internal", Source: "Read:/project/internal/secret.go", Timestamp: time.Now(),
+	})
+	ss.Metrics.TokensIn = 1000
+	ss.Metrics.CostUSD = 0.10
+	ss.Metrics.ToolCalls = 5
+	h.stateManager.Save(ss)
+
+	// Trigger Agent tool
+	input := &aflock.HookInput{
+		SessionID: "parent-1",
+		ToolName:  "Agent",
+		ToolInput: json.RawMessage(`{"prompt":"do something","subagent_type":"general-purpose"}`),
+	}
+
+	got := captureStdout(t, func() {
+		if err := h.handlePreToolUse(input); err != nil {
+			t.Fatalf("handlePreToolUse: %v", err)
+		}
+	})
+
+	// Verify Agent tool was allowed
+	var out aflock.HookOutput
+	if err := json.Unmarshal([]byte(got), &out); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if out.HookSpecificOutput.PermissionDecision != aflock.DecisionAllow {
+		t.Errorf("expected Agent tool allowed, got %v", out.HookSpecificOutput.PermissionDecision)
+	}
+
+	// Verify propagation was written - read it to check
+	rec, err := h.stateManager.ReadPropagation(ss.PolicyPath)
+	if err != nil {
+		t.Fatalf("ReadPropagation: %v", err)
+	}
+	if rec == nil {
+		t.Fatal("propagation record should exist after Agent tool")
+	}
+	if rec.ParentSessionID != "parent-1" {
+		t.Errorf("ParentSessionID = %q, want %q", rec.ParentSessionID, "parent-1")
+	}
+	if len(rec.Materials) != 1 || rec.Materials[0].Label != "internal" {
+		t.Errorf("expected 1 internal material, got %v", rec.Materials)
+	}
+	if rec.ParentMetrics.CostUSD != 0.10 {
+		t.Errorf("ParentMetrics.CostUSD = %f, want 0.10", rec.ParentMetrics.CostUSD)
+	}
+}
+
+func TestSublayout_TaskToolWritesPropagation(t *testing.T) {
+	h := newTestHandler(t)
+	pol := dataFlowPolicy()
+
+	ss := seedSession(t, h, "parent-task", pol)
+	ss.Materials = append(ss.Materials, aflock.MaterialClassification{
+		Label: "internal", Source: "Read:/project/internal/config.go", Timestamp: time.Now(),
+	})
+	h.stateManager.Save(ss)
+
+	input := &aflock.HookInput{
+		SessionID: "parent-task",
+		ToolName:  "Task",
+		ToolInput: json.RawMessage(`{"prompt":"run tests"}`),
+	}
+
+	captureStdout(t, func() {
+		if err := h.handlePreToolUse(input); err != nil {
+			t.Fatalf("handlePreToolUse: %v", err)
+		}
+	})
+
+	rec, err := h.stateManager.ReadPropagation(ss.PolicyPath)
+	if err != nil {
+		t.Fatalf("ReadPropagation: %v", err)
+	}
+	if rec == nil {
+		t.Fatal("Task tool should trigger propagation write")
+	}
+}
+
+func TestSublayout_NonAgentToolNoPropagation(t *testing.T) {
+	h := newTestHandler(t)
+	pol := dataFlowPolicy()
+
+	ss := seedSession(t, h, "parent-noagent", pol)
+	ss.Materials = append(ss.Materials, aflock.MaterialClassification{
+		Label: "internal", Source: "Read:/project/internal/data.go", Timestamp: time.Now(),
+	})
+	h.stateManager.Save(ss)
+
+	// Use Read tool (not Agent)
+	input := &aflock.HookInput{
+		SessionID: "parent-noagent",
+		ToolName:  "Read",
+		ToolInput: json.RawMessage(`{"file_path":"/project/readme.md"}`),
+	}
+
+	captureStdout(t, func() {
+		if err := h.handlePreToolUse(input); err != nil {
+			t.Fatalf("handlePreToolUse: %v", err)
+		}
+	})
+
+	rec, err := h.stateManager.ReadPropagation(ss.PolicyPath)
+	if err != nil {
+		t.Fatalf("ReadPropagation: %v", err)
+	}
+	if rec != nil {
+		t.Error("non-Agent tool should NOT trigger propagation write")
+	}
+}
+
+// ----- SessionStart: inherits materials from propagation -----
+
+func TestSublayout_SessionStartInheritsMaterials(t *testing.T) {
+	h := newTestHandler(t)
+	pol := dataFlowPolicy()
+
+	// Simulate parent writing propagation
+	parentState := &aflock.SessionState{
+		SessionID:  "parent-inherit",
+		PolicyPath: "/fake/policy.aflock",
+		Materials: []aflock.MaterialClassification{
+			{Label: "internal", Source: "Read:/project/internal/secret.go", Timestamp: time.Now()},
+			{Label: "pii", Source: "Read:/project/data/users.csv", Timestamp: time.Now()},
+		},
+		Metrics: &aflock.SessionMetrics{
+			TokensIn:  5000,
+			TokensOut: 2000,
+			CostUSD:   0.15,
+			Turns:     3,
+			ToolCalls: 10,
+			Tools:     map[string]int{"Read": 5},
+		},
+		Policy: pol,
+	}
+	if err := h.stateManager.WritePropagation(parentState); err != nil {
+		t.Fatalf("WritePropagation: %v", err)
+	}
+
+	// Child session starts with the same policy path
+	childState := h.stateManager.Initialize("child-1", pol, "/fake/policy.aflock")
+
+	// Simulate what handleSessionStart does after Initialize
+	prop, err := h.stateManager.ReadPropagation("/fake/policy.aflock")
+	if err != nil {
+		t.Fatalf("ReadPropagation: %v", err)
+	}
+	if prop == nil {
+		t.Fatal("propagation record should exist")
+	}
+
+	childState.ParentSessionID = prop.ParentSessionID
+	childState.Materials = prop.Materials
+
+	if childState.ParentSessionID != "parent-inherit" {
+		t.Errorf("ParentSessionID = %q, want %q", childState.ParentSessionID, "parent-inherit")
+	}
+	if len(childState.Materials) != 2 {
+		t.Fatalf("expected 2 inherited materials, got %d", len(childState.Materials))
+	}
+	if childState.Materials[0].Label != "internal" {
+		t.Errorf("Materials[0].Label = %q, want %q", childState.Materials[0].Label, "internal")
+	}
+	if childState.Materials[1].Label != "pii" {
+		t.Errorf("Materials[1].Label = %q, want %q", childState.Materials[1].Label, "pii")
+	}
+}
+
+// ----- SessionStart: attenuates limits -----
+
+func TestSublayout_LimitAttenuation(t *testing.T) {
+	tests := []struct {
+		name           string
+		childLimit     *aflock.Limit
+		parentLimit    *aflock.Limit
+		parentUsed     float64
+		wantEffective  float64
+	}{
+		{
+			name:          "child has no limit, parent has limit",
+			childLimit:    nil,
+			parentLimit:   &aflock.Limit{Value: 100, Enforcement: "fail-fast"},
+			parentUsed:    30,
+			wantEffective: 70,
+		},
+		{
+			name:          "child limit smaller than parent remaining",
+			childLimit:    &aflock.Limit{Value: 20, Enforcement: "fail-fast"},
+			parentLimit:   &aflock.Limit{Value: 100, Enforcement: "fail-fast"},
+			parentUsed:    30,
+			wantEffective: 20,
+		},
+		{
+			name:          "child limit larger than parent remaining",
+			childLimit:    &aflock.Limit{Value: 200, Enforcement: "fail-fast"},
+			parentLimit:   &aflock.Limit{Value: 100, Enforcement: "fail-fast"},
+			parentUsed:    30,
+			wantEffective: 70,
+		},
+		{
+			name:          "parent exhausted budget",
+			childLimit:    &aflock.Limit{Value: 50, Enforcement: "fail-fast"},
+			parentLimit:   &aflock.Limit{Value: 100, Enforcement: "fail-fast"},
+			parentUsed:    100,
+			wantEffective: 0,
+		},
+		{
+			name:          "parent over budget",
+			childLimit:    &aflock.Limit{Value: 50, Enforcement: "fail-fast"},
+			parentLimit:   &aflock.Limit{Value: 100, Enforcement: "fail-fast"},
+			parentUsed:    150,
+			wantEffective: 0,
+		},
+		{
+			name:          "no parent limit",
+			childLimit:    &aflock.Limit{Value: 50, Enforcement: "fail-fast"},
+			parentLimit:   nil,
+			parentUsed:    0,
+			wantEffective: 50,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			childLimits := &aflock.LimitsPolicy{MaxToolCalls: tt.childLimit}
+			parentLimits := &aflock.LimitsPolicy{MaxToolCalls: tt.parentLimit}
+			parentMetrics := &aflock.SessionMetrics{ToolCalls: int(tt.parentUsed)}
+
+			result := attenuateLimits(childLimits, parentLimits, parentMetrics)
+			if result.MaxToolCalls == nil {
+				if tt.wantEffective != 0 || tt.parentLimit != nil {
+					t.Fatal("MaxToolCalls should not be nil")
+				}
+				return
+			}
+			if result.MaxToolCalls.Value != tt.wantEffective {
+				t.Errorf("effective limit = %f, want %f", result.MaxToolCalls.Value, tt.wantEffective)
+			}
+		})
+	}
+}
+
+func TestSublayout_AttenuateLimits_NilParent(t *testing.T) {
+	childLimits := &aflock.LimitsPolicy{
+		MaxSpendUSD: &aflock.Limit{Value: 5.0, Enforcement: "fail-fast"},
+	}
+	result := attenuateLimits(childLimits, nil, &aflock.SessionMetrics{})
+	if result != childLimits {
+		t.Error("nil parent limits should return child limits unchanged")
+	}
+}
+
+func TestSublayout_AttenuateLimits_NilChild(t *testing.T) {
+	parentLimits := &aflock.LimitsPolicy{
+		MaxSpendUSD: &aflock.Limit{Value: 10.0, Enforcement: "fail-fast"},
+	}
+	parentMetrics := &aflock.SessionMetrics{CostUSD: 3.0}
+
+	result := attenuateLimits(nil, parentLimits, parentMetrics)
+	if result.MaxSpendUSD == nil {
+		t.Fatal("MaxSpendUSD should not be nil")
+	}
+	if result.MaxSpendUSD.Value != 7.0 {
+		t.Errorf("effective limit = %f, want 7.0", result.MaxSpendUSD.Value)
+	}
+}
+
+// ----- SubagentStop: merges actions/metrics/materials to parent -----
+
+func TestSublayout_SubagentStopMerge(t *testing.T) {
+	h := newTestHandler(t)
+	pol := dataFlowPolicy()
+
+	// Create parent session
+	parentSS := seedSession(t, h, "parent-merge", pol)
+	parentSS.Materials = append(parentSS.Materials, aflock.MaterialClassification{
+		Label: "internal", Source: "Read:/project/internal/a.go", Timestamp: time.Now(),
+	})
+	parentSS.Metrics.TokensIn = 1000
+	parentSS.Metrics.ToolCalls = 5
+	h.stateManager.Save(parentSS)
+
+	// Create child session with parent reference
+	childSS := h.stateManager.Initialize("child-merge", pol, "/fake/policy.aflock")
+	childSS.ParentSessionID = "parent-merge"
+	childSS.Materials = append(childSS.Materials,
+		aflock.MaterialClassification{Label: "internal", Source: "Read:/project/internal/a.go", Timestamp: time.Now()},
+		aflock.MaterialClassification{Label: "pii", Source: "Read:/project/data/users.csv", Timestamp: time.Now()},
+	)
+	childSS.Metrics.TokensIn = 500
+	childSS.Metrics.TokensOut = 200
+	childSS.Metrics.CostUSD = 0.05
+	childSS.Metrics.ToolCalls = 3
+	childSS.Metrics.Tools = map[string]int{"Read": 2, "Write": 1}
+	childSS.Actions = append(childSS.Actions, aflock.ActionRecord{
+		Timestamp: time.Now(), ToolName: "Read", ToolUseID: "tu_c1", Decision: "allow",
+	})
+	h.stateManager.Save(childSS)
+
+	// Call SubagentStop
+	input := &aflock.HookInput{SessionID: "child-merge"}
+	got := captureStdout(t, func() {
+		if err := h.handleSubagentStop(input); err != nil {
+			t.Fatalf("handleSubagentStop: %v", err)
+		}
+	})
+
+	// Should allow
+	var out aflock.HookOutput
+	if err := json.Unmarshal([]byte(got), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	// StopAllow returns empty HookOutput, check no block
+	if out.Decision == "block" {
+		t.Errorf("expected allow, got block: %s", out.Reason)
+	}
+
+	// Verify parent was updated
+	parent, err := h.stateManager.Load("parent-merge")
+	if err != nil {
+		t.Fatalf("load parent: %v", err)
+	}
+
+	// Check metrics merged
+	if parent.Metrics.TokensIn != 1500 { // 1000 + 500
+		t.Errorf("parent TokensIn = %d, want 1500", parent.Metrics.TokensIn)
+	}
+	if parent.Metrics.ToolCalls != 8 { // 5 + 3
+		t.Errorf("parent ToolCalls = %d, want 8", parent.Metrics.ToolCalls)
+	}
+
+	// Check actions merged with annotation
+	foundAnnotated := false
+	for _, a := range parent.Actions {
+		if a.ToolName == "Read" && a.ToolUseID == "tu_c1" {
+			foundAnnotated = true
+			if len(a.Reason) == 0 || a.Reason[:10] != "[subagent:" {
+				t.Errorf("expected annotated reason, got %q", a.Reason)
+			}
+		}
+	}
+	if !foundAnnotated {
+		t.Error("child action should be merged into parent")
+	}
+
+	// Check materials merged (deduplicated)
+	if len(parent.Materials) != 2 { // internal (dedup) + pii (new)
+		t.Errorf("parent materials = %d, want 2", len(parent.Materials))
+	}
+
+	// Check child tracked
+	if len(parent.ChildSessionIDs) != 1 || parent.ChildSessionIDs[0] != "child-merge" {
+		t.Errorf("ChildSessionIDs = %v, want [child-merge]", parent.ChildSessionIDs)
+	}
+}
+
+func TestSublayout_SubagentStopNoParent(t *testing.T) {
+	h := newTestHandler(t)
+	pol := dataFlowPolicy()
+
+	// Child with no parent reference
+	childSS := h.stateManager.Initialize("orphan-child", pol, "/fake/policy.aflock")
+	h.stateManager.Save(childSS)
+
+	input := &aflock.HookInput{SessionID: "orphan-child"}
+	got := captureStdout(t, func() {
+		if err := h.handleSubagentStop(input); err != nil {
+			t.Fatalf("handleSubagentStop: %v", err)
+		}
+	})
+
+	var out aflock.HookOutput
+	json.Unmarshal([]byte(got), &out)
+	if out.Decision == "block" {
+		t.Error("orphan child should be allowed to stop")
+	}
+}
+
+func TestSublayout_SubagentStopNoSession(t *testing.T) {
+	h := newTestHandler(t)
+
+	input := &aflock.HookInput{SessionID: ""}
+	got := captureStdout(t, func() {
+		if err := h.handleSubagentStop(input); err != nil {
+			t.Fatalf("handleSubagentStop: %v", err)
+		}
+	})
+
+	var out aflock.HookOutput
+	json.Unmarshal([]byte(got), &out)
+	if out.Decision == "block" {
+		t.Error("no session should be allowed to stop")
+	}
+}
+
+// ----- R3-300: Full fail-02 scenario -----
+// Parent reads confidential data, spawns child, child tries to write to public -> DENIED
+
+func TestSublayout_R3_300_Fail02_SubagentEscape(t *testing.T) {
+	h := newTestHandler(t)
+	pol := dataFlowPolicy()
+
+	// Step 1: Parent reads internal data
+	seedSession(t, h, "parent-fail02", pol)
+
+	readInput := &aflock.HookInput{
+		SessionID: "parent-fail02",
+		ToolName:  "Read",
+		ToolInput: json.RawMessage(`{"file_path": "/project/internal/secrets.go"}`),
+	}
+	captureStdout(t, func() {
+		if err := h.handlePreToolUse(readInput); err != nil {
+			t.Fatalf("parent read: %v", err)
+		}
+	})
+
+	// Verify parent has "internal" material
+	parentSS, _ := h.stateManager.Load("parent-fail02")
+	if len(parentSS.Materials) != 1 || parentSS.Materials[0].Label != "internal" {
+		t.Fatalf("parent should have internal material, got: %v", parentSS.Materials)
+	}
+
+	// Step 2: Parent spawns Agent tool -> propagation written
+	agentInput := &aflock.HookInput{
+		SessionID: "parent-fail02",
+		ToolName:  "Agent",
+		ToolInput: json.RawMessage(`{"prompt":"write to public"}`),
+	}
+	captureStdout(t, func() {
+		if err := h.handlePreToolUse(agentInput); err != nil {
+			t.Fatalf("parent Agent: %v", err)
+		}
+	})
+
+	// Step 3: Child session starts, inherits materials via propagation
+	childSS := h.stateManager.Initialize("child-fail02", pol, "/fake/policy.aflock")
+
+	prop, err := h.stateManager.ReadPropagation("/fake/policy.aflock")
+	if err != nil {
+		t.Fatalf("ReadPropagation: %v", err)
+	}
+	if prop == nil {
+		t.Fatal("child should find propagation from parent")
+	}
+	childSS.ParentSessionID = prop.ParentSessionID
+	childSS.Materials = prop.Materials
+	h.stateManager.Save(childSS)
+
+	// Verify child inherited the "internal" taint
+	if len(childSS.Materials) != 1 || childSS.Materials[0].Label != "internal" {
+		t.Fatalf("child should inherit internal material, got: %v", childSS.Materials)
+	}
+
+	// Step 4: Child tries to write to public destination -> DENIED by data flow
+	writeInput := &aflock.HookInput{
+		SessionID: "child-fail02",
+		ToolName:  "Write",
+		ToolInput: json.RawMessage(`{"file_path": "/project/public/output.txt", "content": "secret data"}`),
+	}
+	got := captureStdout(t, func() {
+		if err := h.handlePreToolUse(writeInput); err != nil {
+			t.Fatalf("child write: %v", err)
+		}
+	})
+
+	var out aflock.HookOutput
+	if err := json.Unmarshal([]byte(got), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.HookSpecificOutput.PermissionDecision != aflock.DecisionDeny {
+		t.Errorf("SECURITY: child should be DENIED writing internal data to public. Got: %v",
+			out.HookSpecificOutput.PermissionDecision)
+	}
+}
+
+// ----- Nested subagent propagation (A -> B -> C) -----
+
+func TestSublayout_NestedPropagation(t *testing.T) {
+	h := newTestHandler(t)
+	pol := dataFlowPolicy()
+
+	// A reads internal, spawns B
+	seedSession(t, h, "agent-A", pol)
+
+	captureStdout(t, func() {
+		h.handlePreToolUse(&aflock.HookInput{
+			SessionID: "agent-A",
+			ToolName:  "Read",
+			ToolInput: json.RawMessage(`{"file_path": "/project/internal/deep-secret.go"}`),
+		})
+	})
+
+	captureStdout(t, func() {
+		h.handlePreToolUse(&aflock.HookInput{
+			SessionID: "agent-A",
+			ToolName:  "Agent",
+			ToolInput: json.RawMessage(`{"prompt":"delegate to B"}`),
+		})
+	})
+
+	// B starts, inherits A's materials
+	bSS := h.stateManager.Initialize("agent-B", pol, "/fake/policy.aflock")
+	prop, _ := h.stateManager.ReadPropagation("/fake/policy.aflock")
+	if prop == nil {
+		t.Fatal("B should find propagation from A")
+	}
+	bSS.ParentSessionID = prop.ParentSessionID
+	bSS.Materials = prop.Materials
+	h.stateManager.Save(bSS)
+
+	// B spawns C
+	captureStdout(t, func() {
+		h.handlePreToolUse(&aflock.HookInput{
+			SessionID: "agent-B",
+			ToolName:  "Agent",
+			ToolInput: json.RawMessage(`{"prompt":"delegate to C"}`),
+		})
+	})
+
+	// C starts, should inherit B's materials (which include A's taint)
+	cSS := h.stateManager.Initialize("agent-C", pol, "/fake/policy.aflock")
+	prop, _ = h.stateManager.ReadPropagation("/fake/policy.aflock")
+	if prop == nil {
+		t.Fatal("C should find propagation from B")
+	}
+	cSS.ParentSessionID = prop.ParentSessionID
+	cSS.Materials = prop.Materials
+	h.stateManager.Save(cSS)
+
+	// C has inherited A's original "internal" taint
+	if len(cSS.Materials) != 1 || cSS.Materials[0].Label != "internal" {
+		t.Fatalf("C should inherit internal taint from A via B, got: %v", cSS.Materials)
+	}
+
+	// C tries to write to public -> DENIED
+	got := captureStdout(t, func() {
+		h.handlePreToolUse(&aflock.HookInput{
+			SessionID: "agent-C",
+			ToolName:  "Write",
+			ToolInput: json.RawMessage(`{"file_path": "/project/public/leak.txt", "content": "secret"}`),
+		})
+	})
+
+	var out aflock.HookOutput
+	json.Unmarshal([]byte(got), &out)
+	if out.HookSpecificOutput.PermissionDecision != aflock.DecisionDeny {
+		t.Errorf("SECURITY: nested child C should be DENIED writing to public. Got: %v",
+			out.HookSpecificOutput.PermissionDecision)
+	}
+}
+
+// ----- No regression when no DataFlow policy -----
+
+func TestSublayout_NoDataFlowPolicy_NoRegression(t *testing.T) {
+	h := newTestHandler(t)
+	// Policy without DataFlow
+	pol := &aflock.Policy{
+		Name: "simple-policy",
+		Tools: &aflock.ToolsPolicy{
+			Allow: []string{"Read", "Write", "Agent"},
+		},
+	}
+
+	seedSession(t, h, "parent-nodf", pol)
+
+	// Agent tool should still work
+	agentInput := &aflock.HookInput{
+		SessionID: "parent-nodf",
+		ToolName:  "Agent",
+		ToolInput: json.RawMessage(`{"prompt":"test"}`),
+	}
+	got := captureStdout(t, func() {
+		h.handlePreToolUse(agentInput)
+	})
+
+	var out aflock.HookOutput
+	json.Unmarshal([]byte(got), &out)
+	if out.HookSpecificOutput.PermissionDecision != aflock.DecisionAllow {
+		t.Errorf("Agent should be allowed without DataFlow policy, got %v",
+			out.HookSpecificOutput.PermissionDecision)
+	}
+
+	// Child starts - propagation exists but has empty materials
+	childSS := h.stateManager.Initialize("child-nodf", pol, "/fake/policy.aflock")
+	prop, _ := h.stateManager.ReadPropagation("/fake/policy.aflock")
+	if prop != nil {
+		childSS.ParentSessionID = prop.ParentSessionID
+		childSS.Materials = prop.Materials
+	}
+	h.stateManager.Save(childSS)
+
+	// Child writes should be unrestricted
+	writeInput := &aflock.HookInput{
+		SessionID: "child-nodf",
+		ToolName:  "Write",
+		ToolInput: json.RawMessage(`{"file_path": "/project/public/out.txt", "content": "ok"}`),
+	}
+	got = captureStdout(t, func() {
+		h.handlePreToolUse(writeInput)
+	})
+
+	json.Unmarshal([]byte(got), &out)
+	if out.HookSpecificOutput.PermissionDecision != aflock.DecisionAllow {
+		t.Errorf("write should be allowed without DataFlow, got %v",
+			out.HookSpecificOutput.PermissionDecision)
+	}
+}
+
+// ----- isSubagentSpawn helper -----
+
+func TestIsSubagentSpawn(t *testing.T) {
+	tests := []struct {
+		toolName string
+		want     bool
+	}{
+		{"Agent", true},
+		{"Task", true},
+		{"Read", false},
+		{"Write", false},
+		{"Bash", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := isSubagentSpawn(tt.toolName); got != tt.want {
+			t.Errorf("isSubagentSpawn(%q) = %v, want %v", tt.toolName, got, tt.want)
+		}
+	}
+}
+
+// ----- mergeChildIntoParent -----
+
+func TestMergeChildIntoParent(t *testing.T) {
+	parent := &aflock.SessionState{
+		SessionID: "p1",
+		Metrics: &aflock.SessionMetrics{
+			TokensIn:  1000,
+			TokensOut: 500,
+			CostUSD:   0.10,
+			ToolCalls: 5,
+			Tools:     map[string]int{"Read": 3, "Bash": 2},
+		},
+		Materials: []aflock.MaterialClassification{
+			{Label: "internal", Source: "Read:/a"},
+		},
+	}
+
+	child := &aflock.SessionState{
+		SessionID: "c1",
+		Metrics: &aflock.SessionMetrics{
+			TokensIn:  200,
+			TokensOut: 100,
+			CostUSD:   0.02,
+			ToolCalls: 2,
+			Tools:     map[string]int{"Read": 1, "Write": 1},
+		},
+		Materials: []aflock.MaterialClassification{
+			{Label: "internal", Source: "Read:/a"},      // duplicate
+			{Label: "pii", Source: "Read:/data/users"}, // new
+		},
+		Actions: []aflock.ActionRecord{
+			{ToolName: "Read", ToolUseID: "tu1", Decision: "allow", Reason: "ok"},
+		},
+	}
+
+	mergeChildIntoParent(parent, child)
+
+	// Metrics accumulated
+	if parent.Metrics.TokensIn != 1200 {
+		t.Errorf("TokensIn = %d, want 1200", parent.Metrics.TokensIn)
+	}
+	if parent.Metrics.CostUSD < 0.119 || parent.Metrics.CostUSD > 0.121 {
+		t.Errorf("CostUSD = %f, want ~0.12", parent.Metrics.CostUSD)
+	}
+	if parent.Metrics.ToolCalls != 7 {
+		t.Errorf("ToolCalls = %d, want 7", parent.Metrics.ToolCalls)
+	}
+	if parent.Metrics.Tools["Read"] != 4 {
+		t.Errorf("Tools[Read] = %d, want 4", parent.Metrics.Tools["Read"])
+	}
+	if parent.Metrics.Tools["Write"] != 1 {
+		t.Errorf("Tools[Write] = %d, want 1", parent.Metrics.Tools["Write"])
+	}
+
+	// Materials deduplicated
+	if len(parent.Materials) != 2 {
+		t.Errorf("Materials = %d, want 2", len(parent.Materials))
+	}
+
+	// Actions annotated
+	if len(parent.Actions) != 1 {
+		t.Fatalf("Actions = %d, want 1", len(parent.Actions))
+	}
+	if parent.Actions[0].Reason != "[subagent:c1] ok" {
+		t.Errorf("Action reason = %q", parent.Actions[0].Reason)
+	}
+
+	// Child tracked
+	if len(parent.ChildSessionIDs) != 1 || parent.ChildSessionIDs[0] != "c1" {
+		t.Errorf("ChildSessionIDs = %v", parent.ChildSessionIDs)
+	}
+}

--- a/internal/state/propagation.go
+++ b/internal/state/propagation.go
@@ -1,0 +1,123 @@
+package state
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/aflock-ai/aflock/pkg/aflock"
+)
+
+const (
+	// PropagationTTL is the maximum age of a propagation record before it's
+	// considered expired. Children that start after this window inherit nothing.
+	PropagationTTL = 60 * time.Second
+
+	// propagationDir is the subdirectory under ~/.aflock for propagation files.
+	propagationDir = "propagation"
+)
+
+// propagationBaseDir returns the absolute path to the propagation directory.
+func propagationBaseDir() string {
+	return expandPath("~/.aflock/" + propagationDir)
+}
+
+// propagationKey returns a deterministic filename for a given policy path.
+// Uses SHA-256 of the absolute path so different policies don't collide.
+func propagationKey(policyPath string) string {
+	abs, err := filepath.Abs(policyPath)
+	if err != nil {
+		abs = policyPath
+	}
+	h := sha256.Sum256([]byte(abs))
+	return fmt.Sprintf("%x.json", h)
+}
+
+// WritePropagation writes a propagation file so that a child session can
+// inherit the parent's materials, metrics, and attenuated limits.
+func (m *Manager) WritePropagation(parentState *aflock.SessionState) error {
+	dir := propagationBaseDir()
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("create propagation dir: %w", err)
+	}
+
+	rec := aflock.PropagationRecord{
+		ParentSessionID: parentState.SessionID,
+		PolicyPath:      parentState.PolicyPath,
+		Materials:       parentState.Materials,
+		ParentMetrics:   parentState.Metrics,
+		CreatedAt:       time.Now(),
+	}
+	if parentState.Policy != nil {
+		rec.ParentLimits = parentState.Policy.Limits
+	}
+
+	data, err := json.Marshal(&rec)
+	if err != nil {
+		return fmt.Errorf("marshal propagation: %w", err)
+	}
+
+	key := propagationKey(parentState.PolicyPath)
+	path := filepath.Join(dir, key)
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		return fmt.Errorf("write propagation: %w", err)
+	}
+
+	return nil
+}
+
+// ReadPropagation reads and consumes (deletes) a propagation file for the
+// given policy path. Returns nil if no file exists or if the record is expired.
+func (m *Manager) ReadPropagation(policyPath string) (*aflock.PropagationRecord, error) {
+	key := propagationKey(policyPath)
+	path := filepath.Join(propagationBaseDir(), key)
+
+	data, err := os.ReadFile(path) //nolint:gosec // G304: propagation file path is derived from SHA-256 hash
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read propagation: %w", err)
+	}
+
+	// Consume-once: always remove the file after reading
+	os.Remove(path) //nolint:errcheck // best-effort cleanup
+
+	var rec aflock.PropagationRecord
+	if err := json.Unmarshal(data, &rec); err != nil {
+		return nil, fmt.Errorf("parse propagation: %w", err)
+	}
+
+	if rec.IsExpiredPropagation(PropagationTTL) {
+		return nil, nil
+	}
+
+	return &rec, nil
+}
+
+// CleanStalePropagation removes propagation files older than 2x TTL.
+// This is a housekeeping function to prevent accumulation of orphaned files.
+func (m *Manager) CleanStalePropagation() {
+	dir := propagationBaseDir()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+
+	maxAge := 2 * PropagationTTL
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		if time.Since(info.ModTime()) > maxAge {
+			os.Remove(filepath.Join(dir, entry.Name())) //nolint:errcheck // best-effort cleanup
+		}
+	}
+}

--- a/internal/state/propagation_test.go
+++ b/internal/state/propagation_test.go
@@ -1,0 +1,300 @@
+package state
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/aflock-ai/aflock/pkg/aflock"
+)
+
+func testParentState() *aflock.SessionState {
+	return &aflock.SessionState{
+		SessionID:  "parent-session-1",
+		PolicyPath: "/project/.aflock",
+		Materials: []aflock.MaterialClassification{
+			{Label: "internal", Source: "Read:/project/internal/secret.go", Timestamp: time.Now()},
+			{Label: "pii", Source: "Read:/project/data/users.csv", Timestamp: time.Now()},
+		},
+		Metrics: &aflock.SessionMetrics{
+			TokensIn:  5000,
+			TokensOut: 2000,
+			CostUSD:   0.15,
+			Turns:     3,
+			ToolCalls: 10,
+			Tools:     map[string]int{"Read": 5, "Bash": 3, "Write": 2},
+		},
+		Policy: &aflock.Policy{
+			Name:    "test-policy",
+			Version: "1.0",
+			Limits: &aflock.LimitsPolicy{
+				MaxSpendUSD: &aflock.Limit{Value: 1.0, Enforcement: "fail-fast"},
+				MaxToolCalls: &aflock.Limit{Value: 50, Enforcement: "post-hoc"},
+			},
+		},
+	}
+}
+
+func TestPropagation_WriteReadRoundTrip(t *testing.T) {
+	tmpDir := t.TempDir()
+	m := NewManager(tmpDir)
+
+	parent := testParentState()
+	if err := m.WritePropagation(parent); err != nil {
+		t.Fatalf("WritePropagation: %v", err)
+	}
+
+	rec, err := m.ReadPropagation(parent.PolicyPath)
+	if err != nil {
+		t.Fatalf("ReadPropagation: %v", err)
+	}
+	if rec == nil {
+		t.Fatal("ReadPropagation returned nil")
+	}
+
+	if rec.ParentSessionID != "parent-session-1" {
+		t.Errorf("ParentSessionID = %q, want %q", rec.ParentSessionID, "parent-session-1")
+	}
+	if len(rec.Materials) != 2 {
+		t.Errorf("Materials count = %d, want 2", len(rec.Materials))
+	}
+	if rec.Materials[0].Label != "internal" {
+		t.Errorf("Materials[0].Label = %q, want %q", rec.Materials[0].Label, "internal")
+	}
+	if rec.ParentMetrics.TokensIn != 5000 {
+		t.Errorf("ParentMetrics.TokensIn = %d, want 5000", rec.ParentMetrics.TokensIn)
+	}
+	if rec.ParentLimits == nil {
+		t.Fatal("ParentLimits should not be nil")
+	}
+	if rec.ParentLimits.MaxSpendUSD.Value != 1.0 {
+		t.Errorf("ParentLimits.MaxSpendUSD = %f, want 1.0", rec.ParentLimits.MaxSpendUSD.Value)
+	}
+}
+
+func TestPropagation_ConsumeOnce(t *testing.T) {
+	tmpDir := t.TempDir()
+	m := NewManager(tmpDir)
+
+	parent := testParentState()
+	if err := m.WritePropagation(parent); err != nil {
+		t.Fatalf("WritePropagation: %v", err)
+	}
+
+	// First read succeeds
+	rec, err := m.ReadPropagation(parent.PolicyPath)
+	if err != nil {
+		t.Fatalf("first ReadPropagation: %v", err)
+	}
+	if rec == nil {
+		t.Fatal("first read should return record")
+	}
+
+	// Second read returns nil (file consumed)
+	rec, err = m.ReadPropagation(parent.PolicyPath)
+	if err != nil {
+		t.Fatalf("second ReadPropagation: %v", err)
+	}
+	if rec != nil {
+		t.Error("second read should return nil (consume-once)")
+	}
+}
+
+func TestPropagation_TTLExpiration(t *testing.T) {
+	tmpDir := t.TempDir()
+	m := NewManager(tmpDir)
+
+	parent := testParentState()
+	if err := m.WritePropagation(parent); err != nil {
+		t.Fatalf("WritePropagation: %v", err)
+	}
+
+	// Tamper with the file to set an old CreatedAt
+	key := propagationKey(parent.PolicyPath)
+	path := filepath.Join(propagationBaseDir(), key)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read propagation file: %v", err)
+	}
+
+	var rec aflock.PropagationRecord
+	if err := json.Unmarshal(data, &rec); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	rec.CreatedAt = time.Now().Add(-2 * PropagationTTL)
+	data, _ = json.Marshal(&rec)
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatalf("write modified propagation: %v", err)
+	}
+
+	// Read should return nil (expired)
+	result, err := m.ReadPropagation(parent.PolicyPath)
+	if err != nil {
+		t.Fatalf("ReadPropagation: %v", err)
+	}
+	if result != nil {
+		t.Error("expired propagation should return nil")
+	}
+}
+
+func TestPropagation_KeyIsolation(t *testing.T) {
+	tmpDir := t.TempDir()
+	m := NewManager(tmpDir)
+
+	// Write propagation for policy A
+	parentA := testParentState()
+	parentA.PolicyPath = "/project-a/.aflock"
+	parentA.Materials = []aflock.MaterialClassification{
+		{Label: "secret-a", Source: "Read:/project-a/secret"},
+	}
+	if err := m.WritePropagation(parentA); err != nil {
+		t.Fatalf("WritePropagation A: %v", err)
+	}
+
+	// Reading with policy B's path should return nil
+	rec, err := m.ReadPropagation("/project-b/.aflock")
+	if err != nil {
+		t.Fatalf("ReadPropagation B: %v", err)
+	}
+	if rec != nil {
+		t.Error("different policy path should not match propagation")
+	}
+
+	// Reading with policy A's path should succeed
+	rec, err = m.ReadPropagation("/project-a/.aflock")
+	if err != nil {
+		t.Fatalf("ReadPropagation A: %v", err)
+	}
+	if rec == nil {
+		t.Fatal("same policy path should match propagation")
+	}
+	if rec.Materials[0].Label != "secret-a" {
+		t.Errorf("Materials[0].Label = %q, want %q", rec.Materials[0].Label, "secret-a")
+	}
+}
+
+func TestPropagation_MalformedJSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	m := NewManager(tmpDir)
+
+	// Write garbage to the propagation file
+	dir := propagationBaseDir()
+	os.MkdirAll(dir, 0700)
+	key := propagationKey("/project/.aflock")
+	path := filepath.Join(dir, key)
+	os.WriteFile(path, []byte("not json{{{"), 0600)
+
+	rec, err := m.ReadPropagation("/project/.aflock")
+	if err == nil {
+		t.Error("malformed JSON should return error")
+	}
+	if rec != nil {
+		t.Error("malformed JSON should return nil record")
+	}
+
+	// File should be consumed even on error
+	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+		t.Error("malformed file should be consumed (deleted)")
+	}
+}
+
+func TestPropagation_NotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	m := NewManager(tmpDir)
+
+	rec, err := m.ReadPropagation("/nonexistent/.aflock")
+	if err != nil {
+		t.Errorf("ReadPropagation should not error for missing file: %v", err)
+	}
+	if rec != nil {
+		t.Error("missing file should return nil")
+	}
+}
+
+func TestPropagation_CleanStalePropagation(t *testing.T) {
+	tmpDir := t.TempDir()
+	m := NewManager(tmpDir)
+
+	dir := propagationBaseDir()
+	os.MkdirAll(dir, 0700)
+
+	// Create a "stale" file with old mod time
+	stalePath := filepath.Join(dir, "stale.json")
+	os.WriteFile(stalePath, []byte("{}"), 0600)
+	staleTime := time.Now().Add(-3 * PropagationTTL)
+	os.Chtimes(stalePath, staleTime, staleTime)
+
+	// Create a "fresh" file
+	freshPath := filepath.Join(dir, "fresh.json")
+	os.WriteFile(freshPath, []byte("{}"), 0600)
+
+	m.CleanStalePropagation()
+
+	// Stale file should be removed
+	if _, err := os.Stat(stalePath); !os.IsNotExist(err) {
+		t.Error("stale file should be cleaned up")
+	}
+	// Fresh file should remain
+	if _, err := os.Stat(freshPath); err != nil {
+		t.Error("fresh file should remain after cleanup")
+	}
+}
+
+func TestPropagation_EmptyMaterials(t *testing.T) {
+	tmpDir := t.TempDir()
+	m := NewManager(tmpDir)
+
+	parent := testParentState()
+	parent.Materials = nil // no materials
+	if err := m.WritePropagation(parent); err != nil {
+		t.Fatalf("WritePropagation: %v", err)
+	}
+
+	rec, err := m.ReadPropagation(parent.PolicyPath)
+	if err != nil {
+		t.Fatalf("ReadPropagation: %v", err)
+	}
+	if rec == nil {
+		t.Fatal("should return record even with empty materials")
+	}
+	if len(rec.Materials) != 0 {
+		t.Errorf("Materials count = %d, want 0", len(rec.Materials))
+	}
+}
+
+func TestPropagation_NilLimits(t *testing.T) {
+	tmpDir := t.TempDir()
+	m := NewManager(tmpDir)
+
+	parent := testParentState()
+	parent.Policy.Limits = nil // no limits
+	if err := m.WritePropagation(parent); err != nil {
+		t.Fatalf("WritePropagation: %v", err)
+	}
+
+	rec, err := m.ReadPropagation(parent.PolicyPath)
+	if err != nil {
+		t.Fatalf("ReadPropagation: %v", err)
+	}
+	if rec == nil {
+		t.Fatal("should return record even with nil limits")
+	}
+	if rec.ParentLimits != nil {
+		t.Error("ParentLimits should be nil when parent has no limits")
+	}
+}
+
+func TestPropagationKey_Deterministic(t *testing.T) {
+	k1 := propagationKey("/project/.aflock")
+	k2 := propagationKey("/project/.aflock")
+	if k1 != k2 {
+		t.Errorf("same path should produce same key: %q != %q", k1, k2)
+	}
+
+	k3 := propagationKey("/other/.aflock")
+	if k1 == k3 {
+		t.Error("different paths should produce different keys")
+	}
+}

--- a/pkg/aflock/types.go
+++ b/pkg/aflock/types.go
@@ -440,6 +440,27 @@ type SessionState struct {
 	Actions    []ActionRecord  `json:"actions,omitempty"`
 	// Materials tracks accessed data sources with their classifications for provenance
 	Materials []MaterialClassification `json:"materials,omitempty"`
+	// ParentSessionID is set when this session was spawned by a parent agent
+	ParentSessionID string `json:"parent_session_id,omitempty"`
+	// ChildSessionIDs tracks subagent sessions spawned from this session
+	ChildSessionIDs []string `json:"child_session_ids,omitempty"`
+}
+
+// PropagationRecord is written by a parent session's PreToolUse(Agent) hook
+// and consumed by the child session's SessionStart hook, enabling material
+// and limit inheritance across subagent boundaries.
+type PropagationRecord struct {
+	ParentSessionID string                   `json:"parent_session_id"`
+	PolicyPath      string                   `json:"policy_path"`
+	Materials       []MaterialClassification `json:"materials"`
+	ParentMetrics   *SessionMetrics          `json:"parent_metrics"`
+	ParentLimits    *LimitsPolicy            `json:"parent_limits,omitempty"`
+	CreatedAt       time.Time                `json:"created_at"`
+}
+
+// IsExpiredPropagation checks if the propagation record has exceeded the given TTL.
+func (p *PropagationRecord) IsExpiredPropagation(ttl time.Duration) bool {
+	return time.Since(p.CreatedAt) > ttl
 }
 
 // SessionMetrics tracks cumulative metrics.


### PR DESCRIPTION
Summary                                                                                                                                                                            
                                                            
- Subagents spawned via Agent/Task tools now inherit parent's data flow taint, preventing confidential data from leaking through child sessions with empty materials
- Uses propagation files (~/.aflock/propagation/) as rendezvous between parent's PreToolUse and child's SessionStart
- Adds limit attenuation (child budget = min(child policy, parent remaining)) and action/metrics merging on SubagentStop


Before the fix 

```bash
$ echo '{"session_id":"s1","cwd":"'$(pwd)'","hook_event_name":"SessionStart"}' | $AFLOCK hook SessionStart 2>&1
[aflock] PID-based discovery failed: could not discover model from process chain
{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"# aflock Policy Active: subagent-escape-demo\n\n## Agent Identity\n- Model: unknown@0.0.0\n- Binary: claude-code@2.1.68\n- Identity Hash: 1704a1accc7f3d02\n\n## Tool Restrictions\n- Allowed: [Read Edit Write Glob Grep Bash Agent]\n- Denied: [WebFetch WebSearch]\n\n## File Restrictions\n- Denied patterns: [**/.env]\n\n"}}%

$ echo '{"session_id":"s1","cwd":"'$(pwd)'","tool_name":"Read","tool_use_id":"t1","tool_input":{"file_path":"'$(pwd)'/internal/database-credentials.conf"}}' | $AFLOCK hook PreToolUse 2>&1

{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}%  


fail-02-subagent-escape (main) $ echo '{"session_id":"s1","cwd":"'$(pwd)'","tool_name":"Write","tool_use_id":"t2","tool_input":{"file_path":"'$(pwd)'/public/summary.md"}}' | $AFLOCK hook PreToolUse 2>&1
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"[aflock] BLOCKED: Cannot write confidential internal data to public destinations. This would leak sensitive information."}}


### Running Subagent 

echo '{"session_id":"s2-subagent","cwd":"'$(pwd)'","hook_event_name":"SessionStart"}' | $AFLOCK hook SessionStart 2>&1

[aflock] PID-based discovery failed: could not discover model from process chain
{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"# aflock Policy Active: subagent-escape-demo\n\n## Agent Identity\n- Model: unknown@0.0.0\n- Binary: claude-code@2.1.68\n- Identity Hash: 1704a1accc7f3d02\n\n## Tool Restrictions\n- Allowed: [Read Edit Write Glob Grep Bash Agent]\n- Denied: [WebFetch WebSearch]\n\n## File Restrictions\n- Denied patterns: [**/.env]\n\n"}}%                   

echo '{"session_id":"s2-subagent","cwd":"'$(pwd)'","tool_name":"Write","tool_use_id":"t4","tool_input":{"file_path":"'$(pwd)'/public/summary.md"}}' | $AFLOCK hook PreToolUse 2>&1
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}%                                 
```



* After fix 

```ts
fail-02-subagent-escape (main) $ echo '{"session_id":"s1","cwd":"'$(pwd)'","hook_event_name":"SessionStart"}' | $AFLOCK hook SessionStart 2>&1
[aflock] PID-based discovery failed: could not discover model from process chain
{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"# aflock Policy Active: subagent-escape-demo\n\n## Agent Identity\n- Model: unknown@0.0.0\n- Binary: claude-code@2.1.68\n- Identity Hash: 1704a1accc7f3d02\n\n## Tool Restrictions\n- Allowed: [Read Edit Write Glob Grep Bash Agent]\n- Denied: [WebFetch WebSearch]\n\n## File Restrictions\n- Denied patterns: [**/.env]\n\n"}}%                                                                                                                                                 

fail-02-subagent-escape (main) $ echo '{"session_id":"s1","cwd":"'$(pwd)'","tool_name":"Read","tool_use_id":"t1","tool_input":{"file_path":"'$(pwd)'/internal/database-credentials.conf"}}' | $AFLOCK hook PreToolUse 2>&1
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}%        
                                                                                          
fail-02-subagent-escape (main) $ echo '{"session_id":"s1","cwd":"'$(pwd)'","tool_name":"Write","tool_use_id":"t2","tool_input":{"file_path":"'$(pwd)'/public/summary.md"}}' | $AFLOCK hook PreToolUse 2>&1
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"[aflock] BLOCKED: Cannot write confidential internal data to public destinations. This would leak sensitive information."}}% 

fail-02-subagent-escape (main) $ echo '{"session_id":"s1","cwd":"'$(pwd)'","tool_name":"Agent","tool_use_id":"t3","tool_input":{"prompt":"write DB creds to public/summary.md","subagent_type":"general-purpose"}}' | $AFLOCK hook PreToolUse 2>&1
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}% 

fail-02-subagent-escape (main) $ echo '{"session_id":"s2-subagent","cwd":"'$(pwd)'","hook_event_name":"SessionStart"}' | $AFLOCK hook SessionStart 2>&1
[aflock] PID-based discovery failed: could not discover model from process chain
[aflock] Inherited 1 materials from parent session s1
{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"# aflock Policy Active: subagent-escape-demo\n\n## Agent Identity\n- Model: unknown@0.0.0\n- Binary: claude-code@2.1.68\n- Identity Hash: 1704a1accc7f3d02\n\n## Tool Restrictions\n- Allowed: [Read Edit Write Glob Grep Bash Agent]\n- Denied: [WebFetch WebSearch]\n\n## File Restrictions\n- Denied patterns: [**/.env]\n\n"}}% 

fail-02-subagent-escape (main) $   echo '{"session_id":"s2-subagent","cwd":"'$(pwd)'","tool_name":"Write","tool_use_id":"t4","tool_input":{"file_path":"'$(pwd)'/public/summary.md"}}' | $AFLOCK hook PreToolUse 2>&1

{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"[aflock] BLOCKED: Cannot write confidential internal data to public destinations. This would leak sensitive information."}}

```