### PR TITLE
fix: path traversal via symlinks and Bash file-reading commands

### DIFF
--- a/internal/policy/bash_analyzer.go
+++ b/internal/policy/bash_analyzer.go
@@ -2,6 +2,7 @@
 package policy
 
 import (
+	"path/filepath"
 	"slices"
 	"strings"
 	"unicode"
@@ -522,4 +523,86 @@ func containsAnyWord(s string, words []string) bool {
 		}
 	}
 	return false
+}
+
+// fileReadingCommands is the set of common commands that read file contents.
+// Used to extract file arguments from Bash commands for deny-list checking.
+var fileReadingCommands = map[string]bool{
+	"cat": true, "head": true, "tail": true, "less": true, "more": true,
+	"xxd": true, "strings": true, "od": true, "hexdump": true, "file": true,
+	"wc": true, "stat": true, "base64": true, "tac": true, "nl": true,
+	"sort": true, "uniq": true, "cut": true,
+}
+
+// ExtractFileArgs extracts file path arguments from a bash command string.
+// It splits the command into sub-commands and pipeline segments, then parses
+// each for file-reading commands and collects their file arguments.
+func (a *BashAnalyzer) ExtractFileArgs(command string) []string {
+	seen := make(map[string]bool)
+	var result []string
+
+	addPath := func(p string) {
+		if p != "" && !seen[p] {
+			seen[p] = true
+			result = append(result, p)
+		}
+	}
+
+	// Process sub-commands (split on ;, &&, ||)
+	for _, subCmd := range splitShellCommands(command) {
+		// Also process pipeline segments within each sub-command
+		for _, seg := range splitPipeline(subCmd) {
+			for _, p := range extractFileArgsFromSingleCmd(seg) {
+				addPath(p)
+			}
+		}
+	}
+
+	return result
+}
+
+// extractFileArgsFromSingleCmd extracts file arguments from a single command
+// (no pipes, no chaining). It checks if the command is a file-reading command
+// and collects non-flag arguments as file paths.
+func extractFileArgsFromSingleCmd(cmd string) []string {
+	cmd = strings.TrimSpace(cmd)
+	if cmd == "" {
+		return nil
+	}
+
+	cmdName := extractCommandName(cmd)
+	if cmdName == "" {
+		return nil
+	}
+
+	// Check if the base name (without path) is a file-reading command
+	if !fileReadingCommands[filepath.Base(cmdName)] {
+		return nil
+	}
+
+	// Collect non-flag arguments as file paths
+	var paths []string
+	fields := strings.Fields(cmd)
+	pastCommand := false
+	for _, f := range fields {
+		// Skip variable assignments and command name
+		if !pastCommand {
+			if strings.Contains(f, "=") && !strings.HasPrefix(f, "-") && !strings.HasPrefix(f, "$") {
+				continue // skip env var assignment
+			}
+			pastCommand = true
+			continue // skip the command name itself
+		}
+		// Skip flags (e.g., -n, --lines, -20)
+		if strings.HasPrefix(f, "-") {
+			continue
+		}
+		// Skip shell redirections and special chars
+		if f == ">" || f == ">>" || f == "<" || f == "2>" || f == "2>>" || f == "&>" {
+			continue
+		}
+		paths = append(paths, f)
+	}
+
+	return paths
 }

--- a/internal/policy/evaluator.go
+++ b/internal/policy/evaluator.go
@@ -85,6 +85,21 @@ func (e *Evaluator) EvaluatePreToolUse(toolName string, toolInput json.RawMessag
 		}
 	}
 
+	// 3b. Check Bash commands for file-reading operations against files.deny.
+	// This catches "cat restricted/credentials.json" which bypasses the file
+	// access check above because isFileOperation("Bash") is false.
+	if toolName == "Bash" && e.policy.Files != nil && len(e.policy.Files.Deny) > 0 {
+		var input aflock.BashToolInput
+		if err := json.Unmarshal(toolInput, &input); err == nil && input.Command != "" {
+			fileArgs := e.bashAnalyzer.ExtractFileArgs(input.Command)
+			for _, filePath := range fileArgs {
+				if decision, reason := e.evaluateBashFilePathDeny(filePath); decision != aflock.DecisionAllow {
+					return decision, reason
+				}
+			}
+		}
+	}
+
 	// 4. Check domain access for network tools
 	// WebSearch doesn't have a target URL (only a search query), so domain
 	// restrictions don't apply — the search engine itself picks which sites
@@ -331,6 +346,18 @@ func (e *Evaluator) filePathVariants(filePath string) []string {
 		if err == nil && relPath != filePath && !strings.HasPrefix(relPath, "..") {
 			variants = append(variants, relPath)
 		}
+
+		// Security: resolve symlinks to catch path traversal via symlinked files.
+		// If the resolved path differs from the original, add it and its relative
+		// form as additional variants so deny patterns match the real target.
+		resolved, err := filepath.EvalSymlinks(absPath)
+		if err == nil && resolved != absPath {
+			variants = append(variants, resolved, filepath.Base(resolved))
+			resolvedRel, err := filepath.Rel(e.projectRoot, resolved)
+			if err == nil && !strings.HasPrefix(resolvedRel, "..") {
+				variants = append(variants, resolvedRel)
+			}
+		}
 	}
 
 	return variants
@@ -444,6 +471,23 @@ func (e *Evaluator) evaluateFileAccess(toolName string, toolInput json.RawMessag
 
 		if !allowed {
 			return aflock.DecisionDeny, fmt.Sprintf("File '%s' not in allow list", filePath)
+		}
+	}
+
+	return aflock.DecisionAllow, ""
+}
+
+// evaluateBashFilePathDeny checks a file path from a Bash command against
+// files.deny patterns only. We intentionally skip files.allow here — enforcing
+// an allow list would break legitimate tools (grep, git, build commands) that
+// access many files. The threat model is to block known-sensitive files.
+func (e *Evaluator) evaluateBashFilePathDeny(filePath string) (aflock.PermissionDecision, string) {
+	variants := e.filePathVariants(filePath)
+
+	for _, pattern := range e.policy.Files.Deny {
+		if e.matchFilePattern(pattern, variants) {
+			return aflock.DecisionDeny, fmt.Sprintf(
+				"Bash command accesses file '%s' matching deny pattern '%s'", filePath, pattern)
 		}
 	}
 

--- a/internal/policy/evaluator_path_traversal_test.go
+++ b/internal/policy/evaluator_path_traversal_test.go
@@ -1,0 +1,280 @@
+package policy
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/aflock-ai/aflock/pkg/aflock"
+)
+
+// ---------------------------------------------------------------------------
+// Path traversal via symlinks (fail-05, Vector 1)
+//
+// A symlink src/config.json → ../../restricted/credentials.json passes the
+// deny check because filePathVariants only examines the symlink path, never
+// the resolved target. After the fix, EvalSymlinks adds the real target to
+// the variant list so deny patterns match.
+// ---------------------------------------------------------------------------
+
+func pathTraversalPolicy() *aflock.Policy {
+	return &aflock.Policy{
+		Tools: &aflock.ToolsPolicy{
+			Allow: []string{"Read", "Write", "Edit", "Bash", "Glob", "Grep"},
+		},
+		Files: &aflock.FilesPolicy{
+			Allow: []string{"src/**", "*.md"},
+			Deny:  []string{"restricted/**", "**/credentials*"},
+		},
+	}
+}
+
+func TestSymlink_ToDeniedPath_Denied(t *testing.T) {
+	// Setup: create a temp dir with restricted/credentials.json and a symlink
+	tmpDir := t.TempDir()
+	restricted := filepath.Join(tmpDir, "restricted")
+	src := filepath.Join(tmpDir, "src")
+	if err := os.MkdirAll(restricted, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	credFile := filepath.Join(restricted, "credentials.json")
+	if err := os.WriteFile(credFile, []byte(`{"key":"secret"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create symlink: src/config.json → ../restricted/credentials.json
+	symlink := filepath.Join(src, "config.json")
+	if err := os.Symlink(filepath.Join("..", "restricted", "credentials.json"), symlink); err != nil {
+		t.Fatal(err)
+	}
+
+	pol := pathTraversalPolicy()
+	evaluator := NewEvaluator(pol, tmpDir)
+
+	toolInput, _ := json.Marshal(aflock.FileToolInput{FilePath: symlink})
+	decision, reason := evaluator.EvaluatePreToolUse("Read", toolInput)
+	if decision != aflock.DecisionDeny {
+		t.Errorf("symlink to denied file should be DENIED, got %s (reason: %s)", decision, reason)
+	}
+}
+
+func TestSymlink_ToAllowedPath_Allowed(t *testing.T) {
+	tmpDir := t.TempDir()
+	src := filepath.Join(tmpDir, "src")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a real file in allowed path
+	realFile := filepath.Join(src, "utils.go")
+	if err := os.WriteFile(realFile, []byte("package main"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create symlink: src/helper.go → src/utils.go (both in allowed area)
+	symlink := filepath.Join(src, "helper.go")
+	if err := os.Symlink("utils.go", symlink); err != nil {
+		t.Fatal(err)
+	}
+
+	pol := pathTraversalPolicy()
+	evaluator := NewEvaluator(pol, tmpDir)
+
+	toolInput, _ := json.Marshal(aflock.FileToolInput{FilePath: symlink})
+	decision, reason := evaluator.EvaluatePreToolUse("Read", toolInput)
+	if decision != aflock.DecisionAllow {
+		t.Errorf("symlink to allowed file should be ALLOWED, got %s (reason: %s)", decision, reason)
+	}
+}
+
+func TestSymlink_RegularFileInAllowedPath_Allowed(t *testing.T) {
+	tmpDir := t.TempDir()
+	src := filepath.Join(tmpDir, "src")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	realFile := filepath.Join(src, "main.go")
+	if err := os.WriteFile(realFile, []byte("package main"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	pol := pathTraversalPolicy()
+	evaluator := NewEvaluator(pol, tmpDir)
+
+	toolInput, _ := json.Marshal(aflock.FileToolInput{FilePath: realFile})
+	decision, reason := evaluator.EvaluatePreToolUse("Read", toolInput)
+	if decision != aflock.DecisionAllow {
+		t.Errorf("regular file in allowed path should be ALLOWED, got %s (reason: %s)", decision, reason)
+	}
+}
+
+func TestSymlink_NonExistentFile_NoCrash(t *testing.T) {
+	tmpDir := t.TempDir()
+	pol := pathTraversalPolicy()
+	evaluator := NewEvaluator(pol, tmpDir)
+
+	// Non-existent file — EvalSymlinks will error, should not crash
+	toolInput, _ := json.Marshal(aflock.FileToolInput{FilePath: filepath.Join(tmpDir, "src", "nonexistent.go")})
+	// Should not panic — decision doesn't matter as long as it doesn't crash
+	evaluator.EvaluatePreToolUse("Read", toolInput)
+}
+
+// ---------------------------------------------------------------------------
+// Path traversal via Bash file-reading commands (fail-05, Vector 2)
+//
+// "cat restricted/credentials.json" via Bash bypasses file deny because
+// isFileOperation("Bash") returns false. After the fix, file arguments are
+// extracted from Bash commands and checked against files.deny.
+// ---------------------------------------------------------------------------
+
+func TestBashFileRead_DeniedFile_Denied(t *testing.T) {
+	pol := pathTraversalPolicy()
+	evaluator := NewEvaluator(pol, "/project")
+
+	tests := []struct {
+		name    string
+		command string
+	}{
+		{"cat denied file", "cat restricted/credentials.json"},
+		{"head denied file", "head restricted/credentials.json"},
+		{"tail denied file", "tail -20 restricted/credentials.json"},
+		{"cat credentials by name", "cat src/credentials.bak"},
+		{"less denied file", "less restricted/secrets.txt"},
+		{"base64 denied file", "base64 restricted/credentials.json"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			toolInput, _ := json.Marshal(aflock.BashToolInput{Command: tt.command})
+			decision, reason := evaluator.EvaluatePreToolUse("Bash", toolInput)
+			if decision != aflock.DecisionDeny {
+				t.Errorf("bash %q should be DENIED, got %s (reason: %s)", tt.command, decision, reason)
+			}
+		})
+	}
+}
+
+func TestBashFileRead_AllowedFile_Allowed(t *testing.T) {
+	pol := pathTraversalPolicy()
+	evaluator := NewEvaluator(pol, "/project")
+
+	tests := []struct {
+		name    string
+		command string
+	}{
+		{"cat readme", "cat README.md"},
+		{"head src file", "head -20 src/app.py"},
+		{"ls directory", "ls -la"},
+		{"grep in src", "grep -r 'pattern' src/"},
+		{"git status", "git status"},
+		{"piping to sort", "cat data.csv | sort | head -10"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			toolInput, _ := json.Marshal(aflock.BashToolInput{Command: tt.command})
+			decision, reason := evaluator.EvaluatePreToolUse("Bash", toolInput)
+			if decision != aflock.DecisionAllow {
+				t.Errorf("bash %q should be ALLOWED, got %s (reason: %s)", tt.command, decision, reason)
+			}
+		})
+	}
+}
+
+func TestBashFileRead_NoDenyList_NotChecked(t *testing.T) {
+	// When there are no files.deny patterns, bash file reading should not be blocked
+	pol := &aflock.Policy{
+		Tools: &aflock.ToolsPolicy{
+			Allow: []string{"Bash"},
+		},
+		Files: &aflock.FilesPolicy{
+			Allow: []string{"src/**"},
+			// No Deny patterns
+		},
+	}
+	evaluator := NewEvaluator(pol, "/project")
+
+	toolInput, _ := json.Marshal(aflock.BashToolInput{Command: "cat restricted/credentials.json"})
+	decision, reason := evaluator.EvaluatePreToolUse("Bash", toolInput)
+	if decision != aflock.DecisionAllow {
+		t.Errorf("should be allowed when no deny list, got %s (reason: %s)", decision, reason)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ExtractFileArgs unit tests
+// ---------------------------------------------------------------------------
+
+func TestExtractFileArgs_SingleFile(t *testing.T) {
+	a := NewBashAnalyzer()
+	args := a.ExtractFileArgs("cat file.txt")
+	if len(args) != 1 || args[0] != "file.txt" {
+		t.Errorf("expected [file.txt], got %v", args)
+	}
+}
+
+func TestExtractFileArgs_WithFlags(t *testing.T) {
+	a := NewBashAnalyzer()
+	args := a.ExtractFileArgs("head -20 src/app.py")
+	if len(args) != 1 || args[0] != "src/app.py" {
+		t.Errorf("expected [src/app.py], got %v", args)
+	}
+}
+
+func TestExtractFileArgs_Pipeline(t *testing.T) {
+	a := NewBashAnalyzer()
+	args := a.ExtractFileArgs("cat secrets.txt | grep password")
+	if len(args) != 1 || args[0] != "secrets.txt" {
+		t.Errorf("expected [secrets.txt], got %v", args)
+	}
+}
+
+func TestExtractFileArgs_Chaining(t *testing.T) {
+	a := NewBashAnalyzer()
+	args := a.ExtractFileArgs("echo done; cat restricted/creds.json && head other.txt")
+	if len(args) != 2 {
+		t.Fatalf("expected 2 args, got %v", args)
+	}
+	expected := map[string]bool{"restricted/creds.json": true, "other.txt": true}
+	for _, a := range args {
+		if !expected[a] {
+			t.Errorf("unexpected arg %q", a)
+		}
+	}
+}
+
+func TestExtractFileArgs_Dedup(t *testing.T) {
+	a := NewBashAnalyzer()
+	args := a.ExtractFileArgs("cat file.txt; cat file.txt")
+	if len(args) != 1 {
+		t.Errorf("expected dedup to 1 arg, got %v", args)
+	}
+}
+
+func TestExtractFileArgs_NonFileCommand(t *testing.T) {
+	a := NewBashAnalyzer()
+	args := a.ExtractFileArgs("ls -la")
+	if len(args) != 0 {
+		t.Errorf("ls should not extract file args, got %v", args)
+	}
+}
+
+func TestExtractFileArgs_GrepNotFileCommand(t *testing.T) {
+	a := NewBashAnalyzer()
+	args := a.ExtractFileArgs("grep -r pattern src/")
+	if len(args) != 0 {
+		t.Errorf("grep should not extract file args, got %v", args)
+	}
+}
+
+func TestExtractFileArgs_EmptyCommand(t *testing.T) {
+	a := NewBashAnalyzer()
+	args := a.ExtractFileArgs("")
+	if len(args) != 0 {
+		t.Errorf("empty command should return no args, got %v", args)
+	}
+}


### PR DESCRIPTION
- Resolve symlinks in filePathVariants() so files.deny patterns match the real target, not just the symlink path
- Extract file arguments from Bash file-reading commands (cat, head, tail, etc.) and check them against files.deny patterns
- Add 18 security tests covering both vectors


* After the fix 

<img width="1470" height="923" alt="Screenshot 2026-03-04 at 11 41 19 PM" src="https://github.com/user-attachments/assets/ce378bbe-4bc3-4e1e-ac8d-69786b5140e8" />

<img width="1470" height="923" alt="Screenshot 2026-03-04 at 11 41 37 PM" src="https://github.com/user-attachments/assets/54774ac7-23e7-4d53-8434-144e4828c536" />

