### PR TITLE
feat: attestation generation in hooks mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ Thumbs.db
 docs-website/node_modules/
 docs-website/build/
 docs-website/.docusaurus/
+
+*.crt
+*.key   

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,8 @@ services:
     hostname: spire-server
     volumes:
       - ./docker/spire/server:/opt/spire/conf/server
-      - spire-data:/opt/spire/data
+    tmpfs:
+      - /opt/spire/data:uid=0,gid=0
     command: ["-config", "/opt/spire/conf/server/server.conf"]
     ports:
       - "8081:8081"
@@ -26,9 +27,10 @@ services:
         condition: service_healthy
     volumes:
       - ./docker/spire/agent:/opt/spire/conf/agent
-      - spire-socket:/tmp/spire-agent/public
-      - /var/run/docker.sock:/var/run/docker.sock
-    command: ["-config", "/opt/spire/conf/agent/agent.conf"]
+      - /tmp/spire-agent/public:/tmp/spire-agent/public
+    tmpfs:
+      - /opt/spire/data:uid=0,gid=0
+    command: ["-config", "/opt/spire/conf/agent/agent.conf", "-joinToken", "${SPIRE_JOIN_TOKEN:-}"]
     pid: "host"
     healthcheck:
       test: ["CMD", "/opt/spire/bin/spire-agent", "healthcheck", "-socketPath", "/tmp/spire-agent/public/api.sock"]

--- a/docker/spire/agent/agent.conf
+++ b/docker/spire/agent/agent.conf
@@ -5,6 +5,7 @@ agent {
     server_port = "8081"
     socket_path = "/tmp/spire-agent/public/api.sock"
     trust_domain = "aflock.ai"
+    insecure_bootstrap = true
 }
 
 plugins {
@@ -20,9 +21,10 @@ plugins {
         plugin_data {}
     }
 
-    WorkloadAttestor "docker" {
-        plugin_data {
-            docker_socket_path = "/var/run/docker.sock"
-        }
-    }
+    # Docker attestor disabled on macOS (socket path differs)
+    # WorkloadAttestor "docker" {
+    #     plugin_data {
+    #         docker_socket_path = "/var/run/docker.sock"
+    #     }
+    # }
 }

--- a/docs/concepts/attestations.md
+++ b/docs/concepts/attestations.md
@@ -4,8 +4,8 @@ sidebar_position: 2
 
 # Attestations
 
-:::caution Active Development
-Attestation signing using DSSE envelopes is implemented. However, **JWT-based agent authorization** ([#19](https://github.com/aflock-ai/aflock/issues/19)) and the **JWT + Signing Key Separation** model described below are not yet implemented — the current implementation has the agent directly holding the signing key. **Attestation generation in hooks mode** is also WIP ([#17](https://github.com/aflock-ai/aflock/issues/17)). Session Merkle trees are designed but not yet implemented. **We're looking for contributors in these areas.**
+:::info Implementation Status
+Attestation signing using DSSE envelopes is implemented in both **MCP server mode** and **hooks mode** ([#17](https://github.com/aflock-ai/aflock/issues/17)). Every `PostToolUse` hook generates a signed in-toto v1 attestation with the `action/v0.1` predicate type. Signing uses SPIRE X509-SVIDs when available, or an ephemeral ECDSA key as fallback. **JWT-based agent authorization** ([#19](https://github.com/aflock-ai/aflock/issues/19)) and the **JWT + Signing Key Separation** model described below are not yet implemented. Session Merkle trees are designed but not yet implemented. **We're looking for contributors in these areas.**
 :::
 
 Every agent action produces a **cryptographically signed attestation** — an unforgeable record of what happened. aflock uses the [in-toto](https://in-toto.io/) attestation format wrapped in DSSE envelopes.

--- a/docs/examples/attestation-lifecycle.md
+++ b/docs/examples/attestation-lifecycle.md
@@ -84,12 +84,27 @@ Create `.claude/settings.local.json` in your project:
 
 ### Run with Claude Code
 
+A ready-to-use demo is included at `examples/attestation-demo/` with the `.aflock` policy and `.claude/settings.local.json` already configured:
+
 ```bash
-cd your-project/   # directory with .aflock and .claude/settings.local.json
-claude              # hooks auto-attach
+cd examples/attestation-demo
+claude
 ```
 
-Every tool call will produce a signed attestation in `~/.aflock/sessions/<id>/attestations/`.
+Hooks auto-attach via `.claude/settings.local.json`. Try:
+- `Read src/main.go` — allowed, creates attestation
+- `Read .env` — denied, no attestation
+- `Run: ls src/` — allowed, creates attestation
+
+Every allowed tool call produces a signed attestation in `~/.aflock/sessions/<id>/attestations/`.
+
+After exiting Claude Code, inspect the session:
+
+```bash
+cd examples/scripts
+./audit-session.sh --list
+./audit-session.sh <session-id>
+```
 
 ## Inspecting Attestations
 
@@ -160,19 +175,34 @@ print('SPIRE' if 'ephemeral' not in keyid else 'Ephemeral', '-', keyid)
 "
 ```
 
-## Full Automated Test
+## Testing
 
-Clone [aflock-example](https://github.com/aflock-ai/aflock) and run:
+### Automated demo (9 steps, 12 DSSE checks)
 
 ```bash
-cd aflock-example/attestation-demo
+cd examples/attestation-demo
 ./run-demo.sh
 ```
 
-Or run the audit script on any session:
+### Audit a session
 
 ```bash
-cd aflock-example
-./scripts/audit-session.sh --list
-./scripts/audit-session.sh <session-id>
+cd examples/scripts
+./audit-session.sh --list
+./audit-session.sh <session-id>
+```
+
+### Inspect attestation files
+
+```bash
+cd examples/scripts
+./inspect-attestation.sh --list
+./inspect-attestation.sh <session-id>
+```
+
+### Run 28 automated attestation tests
+
+```bash
+cd examples/scripts
+./run-attestation-tests.sh
 ```

--- a/docs/examples/attestation-lifecycle.md
+++ b/docs/examples/attestation-lifecycle.md
@@ -1,0 +1,178 @@
+---
+sidebar_position: 3
+---
+
+# Example: Attestation Lifecycle
+
+A complete walkthrough of policy enforcement + attestation generation + verification using `requiredAttestations`.
+
+## Policy
+
+```json
+{
+  "version": "1.0",
+  "name": "attestation-demo",
+  "tools": {
+    "allow": ["Read", "Bash", "Edit", "Glob", "Grep"],
+    "deny": ["Task"]
+  },
+  "files": {
+    "allow": ["src/**", "tests/**", "README.md"],
+    "deny": ["**/.env", "**/secrets/**"]
+  },
+  "limits": {
+    "maxSpendUSD": { "value": 5.00, "enforcement": "fail-fast" },
+    "maxTurns": { "value": 20, "enforcement": "post-hoc" }
+  },
+  "requiredAttestations": ["Read", "Bash"]
+}
+```
+
+## What This Policy Does
+
+- **Tool enforcement**: Only Read, Bash, Edit, Glob, Grep are allowed
+- **File protection**: `.env` and `secrets/` are blocked
+- **Spend limit**: $5 max, abort immediately
+- **Attestation requirement**: Session cannot stop unless both `Read` and `Bash` tool calls have been attested
+
+## How Attestations Work
+
+Every `PostToolUse` hook generates a signed attestation:
+
+```
+PreToolUse (Read src/main.go)  → ALLOW
+[Tool executes]
+PostToolUse                    → Sign attestation → store .intoto.json
+
+PreToolUse (Read .env)         → DENY (no attestation — tool was blocked)
+
+PreToolUse (Bash: go test)     → ALLOW
+[Tool executes]
+PostToolUse                    → Sign attestation → store .intoto.json
+
+Stop                           → Check: Read attestation? ✓  Bash attestation? ✓  → OK
+```
+
+## Setup
+
+### Configure Claude Code hooks
+
+Create `.claude/settings.local.json` in your project:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [{
+      "matcher": "",
+      "hooks": [{"type": "command", "command": "aflock hook SessionStart", "timeout": 10}]
+    }],
+    "PreToolUse": [{
+      "matcher": "*",
+      "hooks": [{"type": "command", "command": "aflock hook PreToolUse", "timeout": 5}]
+    }],
+    "PostToolUse": [{
+      "matcher": "*",
+      "hooks": [{"type": "command", "command": "aflock hook PostToolUse", "timeout": 5}]
+    }],
+    "Stop": [{
+      "matcher": "",
+      "hooks": [{"type": "command", "command": "aflock hook Stop", "timeout": 10}]
+    }]
+  }
+}
+```
+
+### Run with Claude Code
+
+```bash
+cd your-project/   # directory with .aflock and .claude/settings.local.json
+claude              # hooks auto-attach
+```
+
+Every tool call will produce a signed attestation in `~/.aflock/sessions/<id>/attestations/`.
+
+## Inspecting Attestations
+
+### List sessions
+
+```bash
+ls ~/.aflock/sessions/*/attestations/
+```
+
+### Decode an attestation
+
+Each `.intoto.json` file is a DSSE envelope. Decode the payload:
+
+```bash
+ATTEST=$(ls ~/.aflock/sessions/<session-id>/attestations/*.intoto.json | head -1)
+python3 -c "
+import json, base64
+env = json.load(open('$ATTEST'))
+stmt = json.loads(base64.b64decode(env['payload']))
+print(json.dumps(stmt, indent=2))
+"
+```
+
+### Attestation structure
+
+```
+DSSE Envelope (.intoto.json)
+├── payloadType: "application/vnd.in-toto+json"
+├── payload: base64(in-toto Statement)
+└── signatures: [{keyid, sig, certificate}]
+        │
+        ▼  (base64 decode)
+in-toto v1 Statement
+├── _type: "https://in-toto.io/Statement/v1"
+├── subject: [{name: "session:<id>/action:<toolUseId>", digest: {sha256: "..."}}]
+├── predicateType: "https://aflock.ai/attestations/action/v0.1"
+└── predicate:
+    ├── toolName: "Read"
+    ├── toolInput: {"file_path": "src/main.go"}
+    ├── decision: "allow"
+    ├── timestamp: "2026-03-16T23:10:37+05:30"
+    ├── agentIdentity:
+    │   ├── model: "claude-opus-4-6"
+    │   ├── binary: "claude-code@2.1.76"
+    │   ├── binaryHash: "ffe922f4..."
+    │   └── identityHash: "193c9d34..."
+    └── metrics:
+        ├── cumulativeTokensIn: 15000
+        ├── cumulativeCostUSD: 0.42
+        └── turnNumber: 3
+```
+
+## Signing Modes
+
+| Mode | When | Key ID | Trust |
+|------|------|--------|-------|
+| **SPIRE** | SPIRE agent running | `spiffe://aflock.ai/agent/claude-*` | CA-chained X509-SVID |
+| **Ephemeral** | No SPIRE (default) | `spiffe://aflock.ai/agent/ephemeral/<hash>` | Self-signed ECDSA |
+
+Both produce identical DSSE envelopes. Check which mode was used:
+
+```bash
+python3 -c "
+import json
+env = json.load(open('$ATTEST'))
+keyid = env['signatures'][0]['keyid']
+print('SPIRE' if 'ephemeral' not in keyid else 'Ephemeral', '-', keyid)
+"
+```
+
+## Full Automated Test
+
+Clone [aflock-example](https://github.com/aflock-ai/aflock) and run:
+
+```bash
+cd aflock-example/attestation-demo
+./run-demo.sh
+```
+
+Or run the audit script on any session:
+
+```bash
+cd aflock-example
+./scripts/audit-session.sh --list
+./scripts/audit-session.sh <session-id>
+```

--- a/docs/examples/feature-development.md
+++ b/docs/examples/feature-development.md
@@ -5,7 +5,7 @@ sidebar_position: 0
 # Example: Feature Development
 
 :::info Implementation Status
-This example demonstrates the target policy format. **What works now:** tool allowlists, file access rules, resource limits (spend, tokens, turns, time), and `requireApproval` patterns. **Not yet implemented:** `requiredAttestations` enforcement, Rego evaluator execution, and AI evaluator execution. These are tracked in [#16](https://github.com/aflock-ai/aflock/issues/16) and [#17](https://github.com/aflock-ai/aflock/issues/17).
+This example demonstrates the target policy format. **What works now:** tool allowlists, file access rules, resource limits (spend, tokens, turns, time), `requireApproval` patterns, and **attestation generation** (every tool call produces a signed in-toto attestation). **Not yet implemented:** Rego evaluator execution and AI evaluator execution at verification time. These are tracked in [#16](https://github.com/aflock-ai/aflock/issues/16).
 :::
 
 A policy for constraining an AI agent implementing features in a todo app.

--- a/docs/tutorials/claude-code-integration.md
+++ b/docs/tutorials/claude-code-integration.md
@@ -4,8 +4,8 @@ sidebar_position: 1
 
 # Claude Code Integration
 
-:::caution Active Development
-Hook-based constraint enforcement (tool allowlists, file access, limits) is working. **Attestation generation in hooks mode** is not yet implemented ([#17](https://github.com/aflock-ai/aflock/issues/17)). The MCP server exposes tools and identity discovery, but note that HTTP mode currently has no authentication ([#27](https://github.com/aflock-ai/aflock/issues/27)) — use stdio mode for now. Policy expiration is not yet enforced at runtime ([#18](https://github.com/aflock-ai/aflock/issues/18)).
+:::info Implementation Status
+Hook-based constraint enforcement (tool allowlists, file access, limits) and **attestation generation** are working. Every allowed tool call produces a signed in-toto v1 attestation stored in `~/.aflock/sessions/<id>/attestations/`. The MCP server exposes tools and identity discovery, but note that HTTP mode currently has no authentication ([#27](https://github.com/aflock-ai/aflock/issues/27)) — use stdio mode for now.
 :::
 
 aflock integrates with Claude Code through two mechanisms: **hooks** and **MCP server**. This tutorial covers both approaches.
@@ -26,7 +26,7 @@ PreToolUse         Check: tool allowed? file access OK? limits OK?
      |
 [Tool Executes]
      |
-PostToolUse        Record attestation for the action
+PostToolUse        Sign & store in-toto attestation for the action
      |
 PermissionRequest  Auto-approve/deny based on policy
      |

--- a/examples/attestation-demo/.aflock
+++ b/examples/attestation-demo/.aflock
@@ -1,0 +1,17 @@
+{
+  "version": "1.0",
+  "name": "attestation-demo",
+  "tools": {
+    "allow": ["Read", "Bash", "Edit", "Glob", "Grep"],
+    "deny": ["Task"]
+  },
+  "files": {
+    "allow": ["src/**", "tests/**", "README.md"],
+    "deny": ["**/.env", "**/secrets/**"]
+  },
+  "limits": {
+    "maxSpendUSD": { "value": 5.00, "enforcement": "fail-fast" },
+    "maxTurns": { "value": 20, "enforcement": "post-hoc" }
+  },
+  "requiredAttestations": ["Read", "Bash"]
+}

--- a/examples/attestation-demo/.claude/settings.local.json
+++ b/examples/attestation-demo/.claude/settings.local.json
@@ -1,0 +1,52 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/Users/rahulxf/work-dir/aflock/bin/aflock hook SessionStart",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/Users/rahulxf/work-dir/aflock/bin/aflock hook PreToolUse",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/Users/rahulxf/work-dir/aflock/bin/aflock hook PostToolUse",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/Users/rahulxf/work-dir/aflock/bin/aflock hook Stop",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/examples/attestation-demo/README.md
+++ b/examples/attestation-demo/README.md
@@ -1,0 +1,170 @@
+# Attestation Demo
+
+Full lifecycle demo: policy enforcement + attestation generation + verification with `requiredAttestations`.
+
+## What's in here
+
+```
+attestation-demo/
+  .aflock                       ← Policy with requiredAttestations: ["Read", "Bash"]
+  .claude/settings.local.json   ← Hook config for Claude Code
+  src/main.go                   ← Dummy source (allowed by policy)
+  tests/main_test.go            ← Dummy test (allowed by policy)
+  run-demo.sh                   ← Full lifecycle test script
+  README.md                     ← This file
+```
+
+## Quick Run
+
+```bash
+cd /path/to/aflock-example/attestation-demo
+chmod +x run-demo.sh
+./run-demo.sh
+```
+
+## What the Demo Does
+
+```
+Step 1: SessionStart         → Load policy, discover identity
+Step 2: PreToolUse (Read)    → Policy says: ALLOW (src/** matches)
+Step 3: PostToolUse (Read)   → Sign attestation → store .intoto.json
+Step 4: PreToolUse (Bash)    → Policy says: ALLOW (Bash in tools.allow)
+Step 5: PostToolUse (Bash)   → Sign attestation → store .intoto.json
+Step 6: PreToolUse (.env)    → Policy says: DENY (**/.env in files.deny)
+Step 7: Stop                 → Check requiredAttestations: Read ✓, Bash ✓
+Step 8: Inspect              → Show attestation files and contents
+Step 9: Verify               → 12 structural checks on DSSE + in-toto v1
+```
+
+## The Policy
+
+```json
+{
+  "requiredAttestations": ["Read", "Bash"]
+}
+```
+
+This means: the session cannot stop unless attestation files exist for both `Read` and `Bash` tool calls. PostToolUse creates these attestations automatically.
+
+## Testing with Claude Code (Live)
+
+1. Open Claude Code in this directory:
+   ```bash
+   cd /path/to/aflock-example/attestation-demo
+   claude
+   ```
+
+2. The `.claude/settings.local.json` hooks are auto-detected. Every tool call will:
+   - Be checked against the `.aflock` policy (PreToolUse)
+   - Produce a signed attestation (PostToolUse)
+
+3. Ask Claude to read a file or run a command:
+   ```
+   > Read src/main.go
+   > Run: ls src/
+   ```
+
+4. Check attestations:
+   ```bash
+   ../scripts/inspect-attestation.sh --list
+   ```
+
+## Testing with SPIRE (Full Identity Chain)
+
+### Prerequisites
+
+SPIRE running via Docker:
+
+```bash
+cd /path/to/aflock
+
+# Start SPIRE (server + agent)
+docker compose up -d spire-server spire-agent
+
+# Wait for healthy
+docker compose ps
+
+# Generate join token (need new one each time agent restarts)
+TOKEN=$(docker compose exec spire-server \
+  /opt/spire/bin/spire-server token generate \
+  -spiffeID spiffe://aflock.ai/agent/local-dev 2>&1 | grep "Token:" | awk '{print $2}')
+
+# Restart agent with token
+SPIRE_JOIN_TOKEN=$TOKEN docker compose up -d spire-agent
+
+# Register your workload
+docker compose exec spire-server /opt/spire/bin/spire-server entry create \
+  -spiffeID spiffe://aflock.ai/agent/claude-opus-4-5 \
+  -parentID spiffe://aflock.ai/agent/local-dev \
+  -selector "unix:uid:$(id -u)" \
+  -x509SVIDTTL 3600
+```
+
+### Verify socket exists
+
+```bash
+ls -la /tmp/spire-agent/public/api.sock
+```
+
+### Run the demo
+
+```bash
+cd /path/to/aflock-example/attestation-demo
+./run-demo.sh
+```
+
+### Check signing mode
+
+If SPIRE is running and the model is in the trusted list:
+- `Signing mode: SPIRE`
+- `Key ID: spiffe://aflock.ai/agent/claude-opus-4-5`
+
+If SPIRE is not running or model not trusted:
+- `Signing mode: Ephemeral`
+- `Key ID: spiffe://aflock.ai/agent/ephemeral/<hash>`
+
+Both produce valid DSSE envelopes.
+
+### Stop SPIRE
+
+```bash
+cd /path/to/aflock && docker compose down
+```
+
+## How requiredAttestations Works
+
+1. Policy defines `"requiredAttestations": ["Read", "Bash"]`
+2. Each PostToolUse creates a `.intoto.json` file in `~/.aflock/sessions/<id>/attestations/`
+3. When Stop fires, `handleStop()` checks:
+   - For each required name, look for a file matching the tool name
+   - The file must pass structural validation (valid DSSE with non-empty signatures)
+4. If any required attestation is missing → Stop is **blocked**
+5. If all present → Stop succeeds
+
+## Attestation File Format
+
+Each `.intoto.json` is a DSSE envelope:
+
+```
+┌─────────────────────────────────────────┐
+│ DSSE Envelope                           │
+│  payloadType: application/vnd.in-toto+json │
+│  payload: base64(Statement)             │
+│  signatures: [{keyid, sig, certificate}]│
+└───────────────┬─────────────────────────┘
+                │ base64 decode
+┌───────────────▼─────────────────────────┐
+│ in-toto v1 Statement                    │
+│  _type: https://in-toto.io/Statement/v1 │
+│  subject: [{name, digest}]              │
+│  predicateType: action/v0.1             │
+│  predicate: ActionPredicate             │
+└───────────────┬─────────────────────────┘
+                │
+┌───────────────▼─────────────────────────┐
+│ ActionPredicate                         │
+│  toolName, toolInput, decision          │
+│  agentIdentity (model, hash, binary)    │
+│  metrics (tokens, cost, turns)          │
+└─────────────────────────────────────────┘
+```

--- a/examples/attestation-demo/run-demo.sh
+++ b/examples/attestation-demo/run-demo.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Attestation Demo — Full lifecycle with requiredAttestations
+#
+# Tests: SessionStart → PreToolUse → PostToolUse (attestation) → Stop (verify attestations)
+#
+# Usage: ./run-demo.sh [path-to-aflock-binary]
+
+set -euo pipefail
+
+AFLOCK="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/bin/aflock}"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SESSION_ID="demo-$(date +%s)"
+
+bold() { printf "\033[1m%s\033[0m\n" "$1"; }
+green() { printf "\033[32m%s\033[0m\n" "$1"; }
+red() { printf "\033[31m%s\033[0m\n" "$1"; }
+
+if [ ! -x "$AFLOCK" ]; then
+  red "Binary not found: $AFLOCK"
+  echo "Build: cd /Users/rahulxf/work-dir/aflock && make build"
+  exit 1
+fi
+
+bold ""
+bold "============================================"
+bold "  Attestation Demo (with requiredAttestations)"
+bold "  Session: $SESSION_ID"
+bold "============================================"
+
+# ============================================================
+bold ""
+bold "--- Step 1: SessionStart ---"
+echo '{"cwd":"'"$DIR"'","session_id":"'"$SESSION_ID"'"}' | \
+  bash -c "cd $DIR && $AFLOCK hook SessionStart 2>&1"
+
+# ============================================================
+bold ""
+bold "--- Step 2: PreToolUse (Read — allowed) ---"
+echo '{"tool_name":"Read","tool_input":{"file_path":"src/main.go"},"session_id":"'"$SESSION_ID"'","tool_use_id":"tu_read_1"}' | \
+  bash -c "cd $DIR && $AFLOCK hook PreToolUse 2>&1"
+
+# ============================================================
+bold ""
+bold "--- Step 3: PostToolUse (Read — creates attestation) ---"
+echo '{"tool_name":"Read","tool_input":{"file_path":"src/main.go"},"session_id":"'"$SESSION_ID"'","tool_use_id":"tu_read_1"}' | \
+  bash -c "cd $DIR && $AFLOCK hook PostToolUse 2>&1"
+
+# ============================================================
+bold ""
+bold "--- Step 4: PreToolUse (Bash — allowed) ---"
+echo '{"tool_name":"Bash","tool_input":{"command":"go test ./..."},"session_id":"'"$SESSION_ID"'","tool_use_id":"tu_bash_1"}' | \
+  bash -c "cd $DIR && $AFLOCK hook PreToolUse 2>&1"
+
+# ============================================================
+bold ""
+bold "--- Step 5: PostToolUse (Bash — creates attestation) ---"
+echo '{"tool_name":"Bash","tool_input":{"command":"go test ./..."},"session_id":"'"$SESSION_ID"'","tool_use_id":"tu_bash_1"}' | \
+  bash -c "cd $DIR && $AFLOCK hook PostToolUse 2>&1"
+
+# ============================================================
+bold ""
+bold "--- Step 6: PreToolUse (Read .env — DENIED) ---"
+echo '{"tool_name":"Read","tool_input":{"file_path":".env"},"session_id":"'"$SESSION_ID"'","tool_use_id":"tu_deny_1"}' | \
+  bash -c "cd $DIR && $AFLOCK hook PreToolUse 2>&1"
+
+# ============================================================
+bold ""
+bold "--- Step 7: Stop (checks requiredAttestations) ---"
+bold "  Policy requires attestations for: Read, Bash"
+OUT=$(echo '{"session_id":"'"$SESSION_ID"'"}' | \
+  bash -c "cd $DIR && $AFLOCK hook Stop 2>&1")
+echo "$OUT"
+if echo "$OUT" | grep -q "missing"; then
+  red "  FAIL: Stop reported missing attestations"
+else
+  green "  PASS: All required attestations found"
+fi
+
+# ============================================================
+bold ""
+bold "--- Step 8: Inspect Attestations ---"
+ATTEST_DIR="$HOME/.aflock/sessions/$SESSION_ID/attestations"
+echo "  Attestation directory: $ATTEST_DIR"
+echo ""
+
+if [ -d "$ATTEST_DIR" ]; then
+  echo "  Files:"
+  ls -1 "$ATTEST_DIR" | while read f; do echo "    $f"; done
+  echo ""
+
+  echo "  Summary:"
+  echo "  Tool        Decision  Timestamp            Signing Mode"
+  echo "  ----------  --------  -------------------  ------------------"
+  for f in "$ATTEST_DIR"/*.intoto.json; do
+python3 << PYEOF
+import json, base64
+env = json.load(open("$f"))
+stmt = json.loads(base64.b64decode(env["payload"]))
+p = stmt["predicate"]
+mode = "Ephemeral" if "ephemeral" in env["signatures"][0]["keyid"] else "SPIRE"
+print(f"  {p['toolName']:10}  {p['decision']:8}  {p['timestamp'][:19]}  {mode}")
+PYEOF
+  done
+
+  echo ""
+  bold "--- Step 9: Verify DSSE Structure ---"
+  FIRST=$(ls "$ATTEST_DIR"/*.intoto.json | head -1)
+python3 << PYEOF
+import json, base64
+
+env = json.load(open("$FIRST"))
+
+checks = []
+checks.append(("payloadType = application/vnd.in-toto+json", env.get("payloadType") == "application/vnd.in-toto+json"))
+checks.append(("payload is base64",                          len(env.get("payload", "")) > 0))
+checks.append(("has signatures",                             len(env.get("signatures", [])) > 0))
+
+sig = env["signatures"][0]
+checks.append(("sig is non-empty",                           len(sig.get("sig", "")) > 0))
+checks.append(("keyid is SPIFFE format",                     sig.get("keyid", "").startswith("spiffe://")))
+checks.append(("certificate present",                        sig.get("certificate", "").startswith("-----BEGIN")))
+
+stmt = json.loads(base64.b64decode(env["payload"]))
+checks.append(("Statement type = v1",                        stmt.get("_type") == "https://in-toto.io/Statement/v1"))
+checks.append(("predicateType = action/v0.1",                stmt.get("predicateType") == "https://aflock.ai/attestations/action/v0.1"))
+checks.append(("has subject",                                len(stmt.get("subject", [])) > 0))
+checks.append(("predicate has toolName",                     "toolName" in stmt.get("predicate", {})))
+checks.append(("predicate has agentIdentity",                "agentIdentity" in stmt.get("predicate", {})))
+checks.append(("predicate has metrics",                      "metrics" in stmt.get("predicate", {})))
+
+passed = sum(1 for _, ok in checks if ok)
+for name, ok in checks:
+    print(f"  {'PASS' if ok else 'FAIL'}: {name}")
+print(f"\n  {passed}/{len(checks)} checks passed")
+PYEOF
+
+else
+  red "  No attestations directory found!"
+fi
+
+bold ""
+bold "============================================"
+bold "  Demo complete. Session: $SESSION_ID"
+bold "============================================"
+bold ""
+echo "  To inspect further:"
+echo "    ../scripts/inspect-attestation.sh $SESSION_ID"
+echo ""
+echo "  To clean up:"
+echo "    rm -rf ~/.aflock/sessions/$SESSION_ID"

--- a/examples/attestation-demo/src/main.go
+++ b/examples/attestation-demo/src/main.go
@@ -1,0 +1,5 @@
+package main
+
+func main() {
+	println("hello")
+}

--- a/examples/attestation-demo/tests/main_test.go
+++ b/examples/attestation-demo/tests/main_test.go
@@ -1,0 +1,7 @@
+package main
+
+import "testing"
+
+func TestMain(t *testing.T) {
+	t.Log("ok")
+}

--- a/examples/scripts/audit-session.sh
+++ b/examples/scripts/audit-session.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# Audit a session — shows WHO did WHAT, WHEN, and the cryptographic proof
+#
+# Usage:
+#   ./audit-session.sh                    # auto-detect most recent session
+#   ./audit-session.sh <session-id>       # specific session
+#   ./audit-session.sh --list             # list all sessions
+
+set -euo pipefail
+
+SESSIONS_DIR="$HOME/.aflock/sessions"
+
+# --- List mode ---
+if [ "${1:-}" = "--list" ]; then
+  echo ""
+  echo "Sessions:"
+  echo ""
+  printf "  %-45s  %-8s  %-8s  %s\n" "SESSION ID" "ACTIONS" "ATTESTS" "POLICY"
+  printf "  %-45s  %-8s  %-8s  %s\n" "----------" "-------" "-------" "------"
+  for dir in "$SESSIONS_DIR"/*/; do
+    [ -d "$dir" ] || continue
+    sid=$(basename "$dir")
+    attest_count=0
+    [ -d "$dir/attestations" ] && attest_count=$(ls "$dir/attestations/"*.intoto.json 2>/dev/null | wc -l | tr -d ' ')
+python3 << PYEOF
+import json, os
+try:
+    s = json.load(open("$dir/state.json"))
+    actions = len(s.get("actions", []))
+    policy = s.get("policy", {}).get("name", "?")
+    print(f"  {'$sid':45}  {actions:<8}  {$attest_count:<8}  {policy}")
+except:
+    print(f"  {'$sid':45}  {'?':<8}  {$attest_count:<8}  ?")
+PYEOF
+  done
+  echo ""
+  exit 0
+fi
+
+# --- Resolve session ---
+if [ -n "${1:-}" ]; then
+  SESSION_ID="$1"
+else
+  SESSION_ID=$(ls -t "$SESSIONS_DIR"/*/state.json 2>/dev/null | head -1 | xargs dirname 2>/dev/null | xargs basename 2>/dev/null || true)
+  if [ -z "$SESSION_ID" ]; then
+    echo "No sessions found. Run aflock hooks first."
+    exit 1
+  fi
+fi
+
+STATE="$SESSIONS_DIR/$SESSION_ID/state.json"
+ATTEST_DIR="$SESSIONS_DIR/$SESSION_ID/attestations"
+
+if [ ! -f "$STATE" ]; then
+  echo "No state.json for session: $SESSION_ID"
+  exit 1
+fi
+
+# ============================================================
+echo ""
+echo "============================================"
+echo "  Session Audit: $SESSION_ID"
+echo "============================================"
+echo ""
+
+# --- WHO ---
+echo "--- WHO (Agent Identity) ---"
+echo ""
+python3 << PYEOF
+import json
+s = json.load(open("$STATE"))
+ai = s.get("agent_identity_meta", {})
+if ai:
+    print(f"  Model:        {ai.get('model', '?')}")
+    print(f"  Version:      {ai.get('model_version', '?')}")
+    print(f"  Binary:       {ai.get('binary_name', '?')}@{ai.get('binary_version', '?')}")
+    print(f"  Binary hash:  {ai.get('binary_digest', '?')[:32]}...")
+    print(f"  Environment:  {ai.get('environment', '?')}")
+    print(f"  Identity:     {ai.get('identity_hash', '?')}")
+else:
+    print("  (no identity recorded)")
+PYEOF
+
+# --- WHAT (actions) ---
+echo ""
+echo "--- WHAT (All Actions — allow + deny) ---"
+echo ""
+python3 << PYEOF
+import json
+s = json.load(open("$STATE"))
+actions = s.get("actions", [])
+if not actions:
+    print("  (no actions recorded)")
+else:
+    print(f"  {'#':>3}  {'TIME':19}  {'DECISION':8}  {'TOOL':12}  {'TOOL USE ID':25}  INPUT")
+    print(f"  {'─'*3}  {'─'*19}  {'─'*8}  {'─'*12}  {'─'*25}  {'─'*30}")
+    for i, a in enumerate(actions, 1):
+        ts = a.get("timestamp", "?")[:19]
+        dec = a.get("decision", "?")
+        tool = a.get("tool_name", "?")
+        tuid = a.get("tool_use_id", "")[:25]
+        inp = ""
+        try:
+            ti = json.loads(a.get("tool_input", "{}")) if isinstance(a.get("tool_input"), str) else a.get("tool_input", {})
+            if "file_path" in ti:
+                inp = ti["file_path"]
+            elif "command" in ti:
+                inp = ti["command"][:40]
+            elif "pattern" in ti:
+                inp = ti["pattern"]
+        except:
+            pass
+        color = "\033[32m" if dec == "allow" else "\033[31m"
+        reset = "\033[0m"
+        print(f"  {i:3}  {ts}  {color}{dec:8}{reset}  {tool:12}  {tuid:25}  {inp}")
+PYEOF
+
+# --- WHEN (metrics) ---
+echo ""
+echo "--- WHEN (Session Metrics) ---"
+echo ""
+python3 << PYEOF
+import json
+s = json.load(open("$STATE"))
+m = s.get("metrics", {})
+print(f"  Started:     {s.get('started_at', '?')}")
+print(f"  Turns:       {m.get('turns', 0)}")
+print(f"  Tool calls:  {m.get('toolCalls', 0)}")
+print(f"  Tokens in:   {m.get('tokensIn', 0)}")
+print(f"  Tokens out:  {m.get('tokensOut', 0)}")
+print(f"  Cost USD:    \${m.get('costUSD', 0):.4f}")
+tools = m.get("tools", {})
+if tools:
+    print(f"  By tool:     {', '.join(f'{k}={v}' for k,v in tools.items())}")
+PYEOF
+
+# --- PROOF (attestations) ---
+echo ""
+echo "--- PROOF (Signed Attestations) ---"
+echo ""
+
+if [ -d "$ATTEST_DIR" ] && ls "$ATTEST_DIR"/*.intoto.json >/dev/null 2>&1; then
+  COUNT=$(ls "$ATTEST_DIR"/*.intoto.json | wc -l | tr -d ' ')
+  echo "  $COUNT attestation(s) in $ATTEST_DIR"
+  echo ""
+  printf "  %-19s  %-10s  %-8s  %-18s  %s\n" "TIMESTAMP" "TOOL" "DECISION" "SIGNING MODE" "SUBJECT"
+  printf "  %-19s  %-10s  %-8s  %-18s  %s\n" "─────────────────" "──────────" "────────" "──────────────────" "───────────────────────────"
+
+  for f in "$ATTEST_DIR"/*.intoto.json; do
+python3 << PYEOF
+import json, base64
+env = json.load(open("$f"))
+stmt = json.loads(base64.b64decode(env["payload"]))
+p = stmt["predicate"]
+mode = "Ephemeral" if "ephemeral" in env["signatures"][0]["keyid"] else "SPIRE"
+subj = stmt["subject"][0]["name"]
+print(f"  {p['timestamp'][:19]}  {p['toolName']:10}  {p['decision']:8}  {mode:18}  {subj}")
+PYEOF
+  done
+
+  # Structural validation
+  echo ""
+  echo "  Structural checks on first attestation:"
+  FIRST=$(ls "$ATTEST_DIR"/*.intoto.json | head -1)
+python3 << PYEOF
+import json, base64
+env = json.load(open("$FIRST"))
+stmt = json.loads(base64.b64decode(env["payload"]))
+sig = env["signatures"][0]
+
+checks = [
+    ("DSSE payloadType",     env.get("payloadType") == "application/vnd.in-toto+json"),
+    ("DSSE payload",         len(env.get("payload", "")) > 0),
+    ("DSSE signature",       len(sig.get("sig", "")) > 0),
+    ("DSSE certificate",     sig.get("certificate", "").startswith("-----BEGIN")),
+    ("SPIFFE keyid",         sig.get("keyid", "").startswith("spiffe://")),
+    ("in-toto v1",           stmt.get("_type") == "https://in-toto.io/Statement/v1"),
+    ("action/v0.1 predicate",stmt.get("predicateType") == "https://aflock.ai/attestations/action/v0.1"),
+    ("subject present",      len(stmt.get("subject", [])) > 0),
+    ("toolName present",     "toolName" in stmt.get("predicate", {})),
+    ("agentIdentity",        "agentIdentity" in stmt.get("predicate", {})),
+    ("metrics",              "metrics" in stmt.get("predicate", {})),
+]
+passed = sum(1 for _, ok in checks if ok)
+for name, ok in checks:
+    mark = "\033[32mPASS\033[0m" if ok else "\033[31mFAIL\033[0m"
+    print(f"    {mark}: {name}")
+print(f"\n  {passed}/{len(checks)} valid")
+PYEOF
+
+else
+  echo "  (no attestations for this session)"
+fi
+
+# --- Policy ---
+echo ""
+echo "--- POLICY ---"
+echo ""
+python3 << PYEOF
+import json
+s = json.load(open("$STATE"))
+pol = s.get("policy", {})
+print(f"  Name:     {pol.get('name', '?')}")
+print(f"  Tools:    allow={pol.get('tools',{}).get('allow',[])}  deny={pol.get('tools',{}).get('deny',[])}")
+print(f"  Files:    deny={pol.get('files',{}).get('deny',[])}")
+ra = pol.get("requiredAttestations", [])
+if ra:
+    print(f"  Required: {ra}")
+limits = pol.get("limits", {})
+if limits:
+    parts = []
+    for k, v in limits.items():
+        if isinstance(v, dict):
+            parts.append(f"{k}={v.get('value','?')} ({v.get('enforcement','?')})")
+    print(f"  Limits:   {', '.join(parts)}")
+PYEOF
+
+echo ""
+echo "============================================"
+echo ""

--- a/examples/scripts/inspect-attestation.sh
+++ b/examples/scripts/inspect-attestation.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Inspect attestations for an aflock session
+#
+# Usage:
+#   ./inspect-attestation.sh                    # auto-detect most recent session
+#   ./inspect-attestation.sh <session-id>       # specific session
+#   ./inspect-attestation.sh --list             # list all sessions with attestations
+
+set -euo pipefail
+
+SESSIONS_DIR="$HOME/.aflock/sessions"
+
+# --- List mode ---
+if [ "${1:-}" = "--list" ]; then
+  echo "Sessions with attestations:"
+  echo ""
+  for dir in "$SESSIONS_DIR"/*/attestations; do
+    [ -d "$dir" ] || continue
+    sid=$(basename "$(dirname "$dir")")
+    count=$(ls "$dir"/*.intoto.json 2>/dev/null | wc -l | tr -d ' ')
+    echo "  $sid  ($count attestations)"
+  done
+  exit 0
+fi
+
+# --- Resolve session ---
+if [ -n "${1:-}" ]; then
+  SESSION_ID="$1"
+else
+  # Auto-detect most recent session with attestations
+  SESSION_ID=$(ls -t "$SESSIONS_DIR"/*/attestations/*.intoto.json 2>/dev/null | head -1 | xargs dirname 2>/dev/null | xargs dirname 2>/dev/null | xargs basename 2>/dev/null || true)
+  if [ -z "$SESSION_ID" ]; then
+    echo "No sessions with attestations found in $SESSIONS_DIR"
+    echo "Run some tool calls with aflock hooks first."
+    exit 1
+  fi
+fi
+
+ATTEST_DIR="$SESSIONS_DIR/$SESSION_ID/attestations"
+if [ ! -d "$ATTEST_DIR" ]; then
+  echo "No attestations directory for session: $SESSION_ID"
+  exit 1
+fi
+
+FILES=$(ls "$ATTEST_DIR"/*.intoto.json 2>/dev/null)
+COUNT=$(echo "$FILES" | wc -l | tr -d ' ')
+
+echo "============================================"
+echo "  Session: $SESSION_ID"
+echo "  Attestations: $COUNT"
+echo "============================================"
+echo ""
+
+# --- Summary table ---
+echo "Tool        Decision  Timestamp            Model"
+echo "----------  --------  -------------------  --------------------"
+for f in $FILES; do
+python3 << PYEOF
+import json, base64
+env = json.load(open("$f"))
+stmt = json.loads(base64.b64decode(env["payload"]))
+p = stmt["predicate"]
+model = p.get("agentIdentity", {}).get("model", "?")
+print(f"{p['toolName']:10}  {p['decision']:8}  {p['timestamp'][:19]}  {model}")
+PYEOF
+done
+
+echo ""
+
+# --- Signing mode ---
+FIRST=$(echo "$FILES" | head -1)
+python3 << PYEOF
+import json
+env = json.load(open("$FIRST"))
+keyid = env["signatures"][0]["keyid"]
+mode = "Ephemeral (self-signed)" if "ephemeral" in keyid else "SPIRE (X509-SVID)"
+print(f"Signing mode: {mode}")
+print(f"Key ID: {keyid}")
+PYEOF
+
+echo ""
+
+# --- Decode first attestation ---
+echo "============================================"
+echo "  First Attestation (decoded)"
+echo "============================================"
+echo ""
+
+echo "--- DSSE Envelope ---"
+python3 << PYEOF
+import json
+env = json.load(open("$FIRST"))
+print(f"payloadType: {env['payloadType']}")
+print(f"signatures:  {len(env['signatures'])}")
+sig = env["signatures"][0]
+print(f"keyid:       {sig['keyid']}")
+print(f"sig:         {sig['sig'][:40]}...")
+has_cert = sig.get("certificate", "").startswith("-----BEGIN")
+print(f"certificate: {'present' if has_cert else 'missing'}")
+PYEOF
+
+echo ""
+echo "--- in-toto Statement ---"
+python3 << PYEOF
+import json, base64
+env = json.load(open("$FIRST"))
+stmt = json.loads(base64.b64decode(env["payload"]))
+print(json.dumps(stmt, indent=2))
+PYEOF

--- a/examples/scripts/run-attestation-tests.sh
+++ b/examples/scripts/run-attestation-tests.sh
@@ -1,0 +1,297 @@
+#!/usr/bin/env bash
+# Attestation generation test runner for Issue #17
+# Tests both ephemeral signing (no SPIRE) and DSSE structural validity
+#
+# Usage: ./run-attestation-tests.sh [path-to-aflock-binary]
+
+set -euo pipefail
+
+AFLOCK="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/bin/aflock}"
+PASS=0
+FAIL=0
+TOTAL=0
+
+green() { printf "\033[32m%s\033[0m\n" "$1"; }
+red()   { printf "\033[31m%s\033[0m\n" "$1"; }
+bold()  { printf "\033[1m%s\033[0m\n" "$1"; }
+
+assert_contains() {
+  local label="$1" output="$2" expected="$3"
+  TOTAL=$((TOTAL + 1))
+  if echo "$output" | grep -q "$expected"; then
+    green "  PASS: $label"
+    PASS=$((PASS + 1))
+  else
+    red "  FAIL: $label"
+    echo "    Expected to contain: $expected"
+    echo "    Got: $(echo "$output" | head -3)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_not_contains() {
+  local label="$1" output="$2" unexpected="$3"
+  TOTAL=$((TOTAL + 1))
+  if echo "$output" | grep -q "$unexpected"; then
+    red "  FAIL: $label"
+    echo "    Should NOT contain: $unexpected"
+    FAIL=$((FAIL + 1))
+  else
+    green "  PASS: $label"
+    PASS=$((PASS + 1))
+  fi
+}
+
+assert_file_exists() {
+  local label="$1" pattern="$2"
+  TOTAL=$((TOTAL + 1))
+  if ls $pattern >/dev/null 2>&1; then
+    green "  PASS: $label"
+    PASS=$((PASS + 1))
+  else
+    red "  FAIL: $label (no files matching $pattern)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_file_count() {
+  local label="$1" dir="$2" expected="$3"
+  TOTAL=$((TOTAL + 1))
+  local count
+  count=$(ls "$dir"/*.intoto.json 2>/dev/null | wc -l | tr -d ' ')
+  if [ "$count" -eq "$expected" ]; then
+    green "  PASS: $label ($count files)"
+    PASS=$((PASS + 1))
+  else
+    red "  FAIL: $label (expected $expected files, got $count)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Resolve absolute path
+AFLOCK=$(cd "$(dirname "$AFLOCK")" && pwd)/$(basename "$AFLOCK")
+if [ ! -x "$AFLOCK" ]; then
+  red "Binary not found: $AFLOCK"
+  echo "Build first: cd ../aflock && make build"
+  exit 1
+fi
+
+# Clean up previous test sessions
+rm -rf ~/.aflock/sessions/att-run-*
+
+# ============================================================
+bold ""
+bold "============================================"
+bold "  Attestation Generation Tests (Issue #17)"
+bold "============================================"
+bold ""
+
+# ============================================================
+bold "--- Test Group 1: Basic Attestation Creation ---"
+
+TD1=$(mktemp -d)
+echo '{"version":"1.0","name":"basic-attest","tools":{"allow":["Read","Bash","Edit"]},"files":{"allow":["**/*"]}}' > "$TD1/.aflock"
+
+# SessionStart
+OUT=$(echo '{"cwd":"'"$TD1"'","session_id":"att-run-1"}' | bash -c "cd $TD1 && $AFLOCK hook SessionStart 2>&1")
+assert_contains "SessionStart loads policy" "$OUT" "basic-attest"
+
+# PostToolUse — creates attestation
+OUT=$(echo '{"tool_name":"Read","tool_input":{"file_path":"src/main.go"},"session_id":"att-run-1","tool_use_id":"tu_r1"}' | bash -c "cd $TD1 && $AFLOCK hook PostToolUse 2>&1")
+assert_contains "PostToolUse signs attestation" "$OUT" "Attestation signed"
+assert_not_contains "PostToolUse no PID warning" "$OUT" "PID-based discovery failed"
+
+# File exists
+assert_file_exists "Attestation file created" "$HOME/.aflock/sessions/att-run-1/attestations/*.intoto.json"
+
+rm -rf "$TD1"
+
+# ============================================================
+bold ""
+bold "--- Test Group 2: Multiple Tool Calls ---"
+
+TD2=$(mktemp -d)
+echo '{"version":"1.0","name":"multi-attest","tools":{"allow":["Read","Bash","Edit"]},"files":{"allow":["**/*"]}}' > "$TD2/.aflock"
+
+echo '{"cwd":"'"$TD2"'","session_id":"att-run-2"}' | bash -c "cd $TD2 && $AFLOCK hook SessionStart" >/dev/null 2>&1
+
+echo '{"tool_name":"Read","tool_input":{"file_path":"a.go"},"session_id":"att-run-2","tool_use_id":"tu_m1"}' | bash -c "cd $TD2 && $AFLOCK hook PostToolUse" >/dev/null 2>&1
+echo '{"tool_name":"Bash","tool_input":{"command":"ls"},"session_id":"att-run-2","tool_use_id":"tu_m2"}' | bash -c "cd $TD2 && $AFLOCK hook PostToolUse" >/dev/null 2>&1
+echo '{"tool_name":"Edit","tool_input":{"file_path":"b.go"},"session_id":"att-run-2","tool_use_id":"tu_m3"}' | bash -c "cd $TD2 && $AFLOCK hook PostToolUse" >/dev/null 2>&1
+
+assert_file_count "3 attestations for 3 tool calls" "$HOME/.aflock/sessions/att-run-2/attestations" 3
+
+rm -rf "$TD2"
+
+# ============================================================
+bold ""
+bold "--- Test Group 3: DSSE Envelope Structure ---"
+
+ATTEST=$(ls "$HOME/.aflock/sessions/att-run-1/attestations/"*.intoto.json 2>/dev/null | head -1)
+if [ -n "$ATTEST" ]; then
+  OUT=$(python3 -c "
+import json, sys
+env = json.load(open('$ATTEST'))
+checks = []
+checks.append('payloadType' if env.get('payloadType') == 'application/vnd.in-toto+json' else 'FAIL:payloadType')
+checks.append('payload' if env.get('payload') else 'FAIL:payload')
+checks.append('signatures' if len(env.get('signatures', [])) > 0 else 'FAIL:signatures')
+sig = env.get('signatures', [{}])[0]
+checks.append('sig' if sig.get('sig') else 'FAIL:sig')
+checks.append('keyid' if sig.get('keyid') else 'FAIL:keyid')
+checks.append('certificate' if sig.get('certificate','').startswith('-----BEGIN') else 'FAIL:cert')
+print(' '.join(checks))
+" 2>&1)
+  assert_contains "DSSE payloadType correct" "$OUT" "payloadType"
+  assert_contains "DSSE payload present" "$OUT" "payload"
+  assert_contains "DSSE signatures present" "$OUT" "signatures"
+  assert_contains "DSSE sig non-empty" "$OUT" " sig"
+  assert_contains "DSSE keyid present" "$OUT" "keyid"
+  assert_contains "DSSE certificate present" "$OUT" "certificate"
+else
+  TOTAL=$((TOTAL + 6))
+  FAIL=$((FAIL + 6))
+  red "  FAIL: No attestation file to validate"
+fi
+
+# ============================================================
+bold ""
+bold "--- Test Group 4: in-toto v1 Statement ---"
+
+if [ -n "$ATTEST" ]; then
+  OUT=$(python3 -c "
+import json, base64, sys
+env = json.load(open('$ATTEST'))
+stmt = json.loads(base64.b64decode(env['payload']))
+checks = []
+checks.append('v1' if stmt.get('_type') == 'https://in-toto.io/Statement/v1' else 'FAIL:type')
+checks.append('action_v01' if stmt.get('predicateType') == 'https://aflock.ai/attestations/action/v0.1' else 'FAIL:predType')
+checks.append('subject' if len(stmt.get('subject',[])) > 0 else 'FAIL:subject')
+checks.append('subject_name' if 'session:att-run-1/action:tu_r1' in stmt.get('subject',[{}])[0].get('name','') else 'FAIL:subjectName')
+pred = stmt.get('predicate', {})
+checks.append('toolName' if pred.get('toolName') == 'Read' else 'FAIL:toolName')
+checks.append('decision' if pred.get('decision') == 'allow' else 'FAIL:decision')
+checks.append('sessionId' if pred.get('sessionId') == 'att-run-1' else 'FAIL:sessionId')
+print(' '.join(checks))
+" 2>&1)
+  assert_contains "Statement type is v1" "$OUT" "v1"
+  assert_contains "Predicate type is action/v0.1" "$OUT" "action_v01"
+  assert_contains "Subject present" "$OUT" "subject "
+  assert_contains "Subject name matches session/action" "$OUT" "subject_name"
+  assert_contains "Predicate toolName is Read" "$OUT" "toolName"
+  assert_contains "Predicate decision is allow" "$OUT" "decision"
+  assert_contains "Predicate sessionId correct" "$OUT" "sessionId"
+else
+  TOTAL=$((TOTAL + 7))
+  FAIL=$((FAIL + 7))
+  red "  FAIL: No attestation file to validate"
+fi
+
+# ============================================================
+bold ""
+bold "--- Test Group 5: Agent Identity in Attestation ---"
+
+if [ -n "$ATTEST" ]; then
+  OUT=$(python3 -c "
+import json, base64, sys
+env = json.load(open('$ATTEST'))
+stmt = json.loads(base64.b64decode(env['payload']))
+ai = stmt.get('predicate', {}).get('agentIdentity', {})
+checks = []
+checks.append('model' if ai.get('model','unknown') != 'unknown' and ai.get('model','') != '' else 'FAIL:model')
+checks.append('identityHash' if len(ai.get('identityHash','')) > 10 else 'FAIL:hash')
+checks.append('binary' if ai.get('binary','') != '' else 'FAIL:binary')
+checks.append('environment' if ai.get('environment','') != '' else 'FAIL:env')
+agentId = stmt.get('predicate', {}).get('agentId', '')
+checks.append('agentId_spiffe' if agentId.startswith('spiffe://') else 'FAIL:agentId')
+print(' '.join(checks))
+" 2>&1)
+  assert_contains "Agent model discovered (not unknown)" "$OUT" "model"
+  assert_contains "Identity hash present" "$OUT" "identityHash"
+  assert_contains "Binary info present" "$OUT" "binary"
+  assert_contains "Environment present" "$OUT" "environment"
+  assert_contains "Agent ID is SPIFFE format" "$OUT" "agentId_spiffe"
+else
+  TOTAL=$((TOTAL + 5))
+  FAIL=$((FAIL + 5))
+  red "  FAIL: No attestation file to validate"
+fi
+
+# ============================================================
+bold ""
+bold "--- Test Group 6: Signing Mode Detection ---"
+
+if [ -n "$ATTEST" ]; then
+  OUT=$(python3 -c "
+import json
+env = json.load(open('$ATTEST'))
+keyid = env['signatures'][0]['keyid']
+if 'ephemeral' in keyid:
+    print('MODE:ephemeral')
+else:
+    print('MODE:spire')
+" 2>&1)
+  # Without SPIRE running, should be ephemeral
+  assert_contains "Signing mode is ephemeral (no SPIRE)" "$OUT" "MODE:ephemeral"
+fi
+
+# ============================================================
+bold ""
+bold "--- Test Group 7: handleStop Finds Attestations ---"
+
+TD7=$(mktemp -d)
+echo '{"version":"1.0","name":"stop-test","tools":{"allow":["Read"]},"files":{"allow":["**/*"]},"requiredAttestations":["Read"]}' > "$TD7/.aflock"
+
+echo '{"cwd":"'"$TD7"'","session_id":"att-run-7"}' | bash -c "cd $TD7 && $AFLOCK hook SessionStart" >/dev/null 2>&1
+echo '{"tool_name":"Read","tool_input":{"file_path":"x.go"},"session_id":"att-run-7","tool_use_id":"tu_s1"}' | bash -c "cd $TD7 && $AFLOCK hook PreToolUse" >/dev/null 2>&1
+echo '{"tool_name":"Read","tool_input":{"file_path":"x.go"},"session_id":"att-run-7","tool_use_id":"tu_s1"}' | bash -c "cd $TD7 && $AFLOCK hook PostToolUse" >/dev/null 2>&1
+
+OUT=$(echo '{"session_id":"att-run-7"}' | bash -c "cd $TD7 && $AFLOCK hook Stop 2>&1")
+assert_not_contains "handleStop finds Read attestation (no missing)" "$OUT" "missing required attestations"
+
+rm -rf "$TD7"
+
+# ============================================================
+bold ""
+bold "--- Test Group 8: No Attestation Without Session ---"
+
+OUT=$(echo '{"tool_name":"Read","tool_input":{"file_path":"x.go"},"session_id":"nonexistent-session-xyz"}' | bash -c "$AFLOCK hook PostToolUse 2>&1")
+TOTAL=$((TOTAL + 1))
+if [ ! -d "$HOME/.aflock/sessions/nonexistent-session-xyz/attestations" ]; then
+  green "  PASS: No attestation dir for nonexistent session"
+  PASS=$((PASS + 1))
+else
+  red "  FAIL: Attestation dir created for nonexistent session"
+  FAIL=$((FAIL + 1))
+fi
+
+# ============================================================
+bold ""
+bold "--- Test Group 9: Unit Tests ---"
+
+OUT=$(cd "$(dirname "$AFLOCK")/.." && go test ./internal/hooks/ -run 'TestPostToolUse_Creates|TestPostToolUse_AttestationHas|TestPostToolUse_NoAttest|TestPostToolUse_AttestationFile|TestInitializeEphemeral' -count=1 2>&1)
+assert_contains "Unit tests pass" "$OUT" "ok"
+assert_not_contains "No unit test failures" "$OUT" "FAIL"
+
+# ============================================================
+# Cleanup
+rm -rf ~/.aflock/sessions/att-run-*
+
+bold ""
+bold "============================================"
+bold "  RESULTS"
+bold "============================================"
+echo ""
+echo "  Total: $TOTAL"
+green "  Passed: $PASS"
+if [ "$FAIL" -gt 0 ]; then
+  red "  Failed: $FAIL"
+else
+  echo "  Failed: 0"
+fi
+echo ""
+if [ "$FAIL" -eq 0 ]; then
+  green "  ALL ATTESTATION TESTS PASSED"
+else
+  red "  SOME TESTS FAILED"
+fi

--- a/internal/attestation/signer.go
+++ b/internal/attestation/signer.go
@@ -6,6 +6,7 @@ import (
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/ed25519"
+	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha256"
@@ -15,10 +16,12 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
+	"math/big"
 	"time"
 
 	"github.com/aflock-ai/rookery/attestation"
 	"github.com/aflock-ai/rookery/attestation/cryptoutil"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 
 	"github.com/aflock-ai/aflock/internal/identity"
 	"github.com/aflock-ai/aflock/pkg/aflock"
@@ -60,6 +63,46 @@ func (s *Signer) Initialize(ctx context.Context) error {
 	}
 
 	s.identity = id
+	return nil
+}
+
+// InitializeEphemeral creates an ephemeral ECDSA signing key for environments
+// where SPIRE is not available. The key is generated fresh and not persisted.
+// This enables attestation signing in hooks mode without requiring SPIRE infrastructure.
+func (s *Signer) InitializeEphemeral(agentIdentityHash string) error {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return fmt.Errorf("generate ephemeral key: %w", err)
+	}
+
+	// Create a self-signed certificate for the ephemeral key
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		return fmt.Errorf("create ephemeral certificate: %w", err)
+	}
+	cert, err := x509.ParseCertificate(certDER)
+	if err != nil {
+		return fmt.Errorf("parse ephemeral certificate: %w", err)
+	}
+
+	// Use agent identity hash as SPIFFE ID path
+	spiffeID, err := spiffeid.FromString(fmt.Sprintf("spiffe://aflock.ai/agent/ephemeral/%s", agentIdentityHash))
+	if err != nil {
+		spiffeID = spiffeid.RequireFromString("spiffe://aflock.ai/agent/ephemeral/unknown")
+	}
+
+	s.identity = &identity.Identity{
+		SPIFFEID:    spiffeID,
+		Certificate: cert,
+		PrivateKey:  key,
+		ExpiresAt:   template.NotAfter,
+	}
 	return nil
 }
 

--- a/internal/hooks/handler.go
+++ b/internal/hooks/handler.go
@@ -535,18 +535,28 @@ func (h *Handler) handleStop(input *aflock.HookInput) error {
 		return output.Write(output.StopAllow())
 	}
 
-	// Check if required attestations are present
+	// Check required attestations — only for tools that were actually used.
+	// Policy constrains what must be attested, it doesn't instruct the agent
+	// to use tools it wasn't asked to use. If the user never used Bash,
+	// don't block Stop for a missing Bash attestation.
 	if len(sessionState.Policy.RequiredAttestations) > 0 {
+		usedTools := make(map[string]bool)
+		for _, action := range sessionState.Actions {
+			if action.Decision == "allow" {
+				usedTools[action.ToolName] = true
+			}
+		}
+
 		attestDir := h.stateManager.AttestationsDir(input.SessionID)
 		var missing []string
 		for _, required := range sessionState.Policy.RequiredAttestations {
-			if !findAttestation(attestDir, required) {
+			if usedTools[required] && !findAttestation(attestDir, required) {
 				missing = append(missing, required)
 			}
 		}
 		if len(missing) > 0 {
 			return output.Write(output.StopBlock(
-				fmt.Sprintf("[aflock] Cannot stop: missing required attestations: %v", missing)))
+				fmt.Sprintf("[aflock] Cannot stop: missing attestations for used tools: %v", missing)))
 		}
 	}
 

--- a/internal/hooks/handler.go
+++ b/internal/hooks/handler.go
@@ -2,6 +2,7 @@
 package hooks
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -11,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aflock-ai/aflock/internal/attestation"
 	"github.com/aflock-ai/aflock/internal/identity"
 	"github.com/aflock-ai/aflock/internal/output"
 	"github.com/aflock-ai/aflock/internal/policy"
@@ -117,6 +119,20 @@ func (h *Handler) handleSessionStart(input *aflock.HookInput) error {
 
 	// Initialize session state
 	sessionState := h.stateManager.Initialize(input.SessionID, pol, policyPath)
+
+	// Save agent identity metadata for reuse in PostToolUse attestations
+	sessionState.AgentIdentityMeta = &aflock.AgentIdentityMeta{
+		Model:        agentIdentity.Model,
+		ModelVersion: agentIdentity.ModelVersion,
+		IdentityHash: agentIdentity.IdentityHash,
+		PolicyDigest: agentIdentity.PolicyDigest,
+		Environment:  func() string { if agentIdentity.Environment != nil { return agentIdentity.Environment.Type }; return "" }(),
+	}
+	if agentIdentity.Binary != nil {
+		sessionState.AgentIdentityMeta.BinaryName = agentIdentity.Binary.Name
+		sessionState.AgentIdentityMeta.BinaryVer = agentIdentity.Binary.Version
+		sessionState.AgentIdentityMeta.BinaryDigest = agentIdentity.Binary.Digest
+	}
 
 	// Check for propagation from a parent session (sublayout delegation).
 	// If found, inherit materials and attenuate limits.
@@ -347,7 +363,120 @@ func (h *Handler) handlePostToolUse(input *aflock.HookInput) error {
 		}
 	}
 
+	// Create and store attestation for this tool call
+	h.createAttestation(sessionState, input)
+
 	return output.WriteEmpty()
+}
+
+// createAttestation creates a signed attestation for a tool call and stores it on disk.
+// Failures are logged as warnings — attestation is evidence, not enforcement.
+// Uses identity metadata saved in session state from SessionStart to avoid
+// re-discovering identity (and the noisy PID-walking warnings) on every tool call.
+func (h *Handler) createAttestation(sessionState *aflock.SessionState, input *aflock.HookInput) {
+	if sessionState == nil || sessionState.Policy == nil {
+		return
+	}
+
+	// Reconstruct agent identity from session state (saved at SessionStart)
+	// instead of re-discovering via PID walking on every PostToolUse call.
+	// If the saved model is "unknown", try re-discovering — SessionStart may
+	// have failed to find the model (e.g., new project with no session files)
+	// but PostToolUse might succeed if Claude session files now exist.
+	var agentIdentity *identity.AgentIdentity
+	if meta := sessionState.AgentIdentityMeta; meta != nil && meta.Model != "" && meta.Model != "unknown" {
+		agentIdentity = &identity.AgentIdentity{
+			Model:        meta.Model,
+			ModelVersion: meta.ModelVersion,
+			IdentityHash: meta.IdentityHash,
+			PolicyDigest: meta.PolicyDigest,
+		}
+		if meta.BinaryName != "" {
+			agentIdentity.Binary = &identity.BinaryIdentity{
+				Name:    meta.BinaryName,
+				Version: meta.BinaryVer,
+				Digest:  meta.BinaryDigest,
+			}
+		}
+		if meta.Environment != "" {
+			agentIdentity.Environment = &identity.EnvironmentIdentity{
+				Type: meta.Environment,
+			}
+		}
+	} else {
+		// Saved identity has unknown model — try fresh discovery
+		agentIdentity, _ = identity.DiscoverAgentIdentity()
+	}
+
+	// Create signer — try SPIRE first, fall back to ephemeral key
+	signer := attestation.NewSigner("")
+	if err := signer.Initialize(context.Background()); err != nil {
+		// SPIRE not available — use ephemeral key
+		identityHash := ""
+		if agentIdentity != nil {
+			identityHash = agentIdentity.IdentityHash
+		}
+		if err := signer.InitializeEphemeral(identityHash); err != nil {
+			fmt.Fprintf(os.Stderr, "[aflock] Warning: attestation signing unavailable: %v\n", err)
+			return
+		}
+	}
+	defer signer.Close()
+
+	// Build action record
+	toolUseID := input.ToolUseID
+	if toolUseID == "" {
+		toolUseID = fmt.Sprintf("%s-%d", input.ToolName, time.Now().UnixNano())
+	}
+
+	record := aflock.ActionRecord{
+		Timestamp: time.Now(),
+		ToolName:  input.ToolName,
+		ToolUseID: toolUseID,
+		ToolInput: input.ToolInput,
+		Decision:  "allow",
+	}
+
+	// Create signed attestation
+	envelope, err := signer.CreateActionAttestation(
+		context.Background(),
+		record,
+		sessionState.SessionID,
+		sessionState.Metrics,
+		agentIdentity,
+	)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[aflock] Warning: attestation creation failed: %v\n", err)
+		return
+	}
+
+	// Store attestation to disk
+	attestDir := h.stateManager.AttestationsDir(sessionState.SessionID)
+	if err := os.MkdirAll(attestDir, 0750); err != nil {
+		fmt.Fprintf(os.Stderr, "[aflock] Warning: create attestation dir: %v\n", err)
+		return
+	}
+
+	ts := time.Now().Format("20060102-150405")
+	prefix := toolUseID
+	if len(prefix) > 8 {
+		prefix = prefix[:8]
+	}
+	filename := fmt.Sprintf("%s-%s.intoto.json", ts, prefix)
+	path := filepath.Join(attestDir, filename)
+
+	data, err := json.MarshalIndent(envelope, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[aflock] Warning: marshal attestation: %v\n", err)
+		return
+	}
+
+	if err := os.WriteFile(path, data, 0640); err != nil {
+		fmt.Fprintf(os.Stderr, "[aflock] Warning: write attestation: %v\n", err)
+		return
+	}
+
+	fmt.Fprintf(os.Stderr, "[aflock] Attestation signed: %s\n", filename)
 }
 
 // handlePermissionRequest auto-approves or denies based on policy.

--- a/internal/hooks/handler.go
+++ b/internal/hooks/handler.go
@@ -126,7 +126,12 @@ func (h *Handler) handleSessionStart(input *aflock.HookInput) error {
 		ModelVersion: agentIdentity.ModelVersion,
 		IdentityHash: agentIdentity.IdentityHash,
 		PolicyDigest: agentIdentity.PolicyDigest,
-		Environment:  func() string { if agentIdentity.Environment != nil { return agentIdentity.Environment.Type }; return "" }(),
+		Environment: func() string {
+			if agentIdentity.Environment != nil {
+				return agentIdentity.Environment.Type
+			}
+			return ""
+		}(),
 	}
 	if agentIdentity.Binary != nil {
 		sessionState.AgentIdentityMeta.BinaryName = agentIdentity.Binary.Name
@@ -421,7 +426,7 @@ func (h *Handler) createAttestation(sessionState *aflock.SessionState, input *af
 			return
 		}
 	}
-	defer signer.Close()
+	defer signer.Close() //nolint:errcheck // best-effort cleanup
 
 	// Build action record
 	toolUseID := input.ToolUseID

--- a/internal/hooks/handler_attestation_test.go
+++ b/internal/hooks/handler_attestation_test.go
@@ -1,0 +1,251 @@
+package hooks
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/aflock-ai/aflock/internal/attestation"
+	"github.com/aflock-ai/aflock/pkg/aflock"
+)
+
+func TestPostToolUse_CreatesAttestation(t *testing.T) {
+	h := newTestHandler(t)
+	pol := &aflock.Policy{
+		Name: "attest-test",
+		Tools: &aflock.ToolsPolicy{
+			Allow: []string{"Read"},
+		},
+	}
+	seedSession(t, h, "session-attest-1", pol)
+
+	input := &aflock.HookInput{
+		SessionID: "session-attest-1",
+		ToolName:  "Read",
+		ToolUseID: "tu_test_123",
+		ToolInput: json.RawMessage(`{"file_path": "src/main.go"}`),
+	}
+
+	captureStdout(t, func() {
+		if err := h.handlePostToolUse(input); err != nil {
+			t.Fatalf("handlePostToolUse: %v", err)
+		}
+	})
+
+	// Check attestation was created
+	attestDir := h.stateManager.AttestationsDir("session-attest-1")
+	entries, err := os.ReadDir(attestDir)
+	if err != nil {
+		t.Fatalf("read attestation dir: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("expected at least one attestation file, got 0")
+	}
+
+	// Verify the attestation file has valid DSSE structure
+	attestPath := filepath.Join(attestDir, entries[0].Name())
+	data, err := os.ReadFile(attestPath)
+	if err != nil {
+		t.Fatalf("read attestation: %v", err)
+	}
+	var envelope attestation.Envelope
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		t.Fatalf("parse envelope: %v", err)
+	}
+	if envelope.PayloadType == "" || envelope.Payload == "" || len(envelope.Signatures) == 0 {
+		t.Error("attestation has invalid DSSE structure")
+	}
+}
+
+func TestPostToolUse_AttestationHasValidContent(t *testing.T) {
+	h := newTestHandler(t)
+	pol := &aflock.Policy{
+		Name: "attest-content-test",
+		Tools: &aflock.ToolsPolicy{
+			Allow: []string{"Bash"},
+		},
+	}
+	seedSession(t, h, "session-attest-2", pol)
+
+	input := &aflock.HookInput{
+		SessionID: "session-attest-2",
+		ToolName:  "Bash",
+		ToolUseID: "tu_bash_456",
+		ToolInput: json.RawMessage(`{"command": "go test ./..."}`),
+	}
+
+	captureStdout(t, func() {
+		if err := h.handlePostToolUse(input); err != nil {
+			t.Fatalf("handlePostToolUse: %v", err)
+		}
+	})
+
+	// Read the attestation file
+	attestDir := h.stateManager.AttestationsDir("session-attest-2")
+	entries, err := os.ReadDir(attestDir)
+	if err != nil || len(entries) == 0 {
+		t.Fatalf("no attestation files found")
+	}
+
+	data, err := os.ReadFile(filepath.Join(attestDir, entries[0].Name()))
+	if err != nil {
+		t.Fatalf("read attestation: %v", err)
+	}
+
+	// Parse envelope
+	var envelope attestation.Envelope
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		t.Fatalf("parse envelope: %v", err)
+	}
+
+	if envelope.PayloadType != "application/vnd.in-toto+json" {
+		t.Errorf("expected payloadType 'application/vnd.in-toto+json', got %q", envelope.PayloadType)
+	}
+	if len(envelope.Signatures) == 0 {
+		t.Error("expected at least one signature")
+	}
+	if envelope.Signatures[0].Sig == "" {
+		t.Error("expected non-empty signature")
+	}
+
+	// Decode and verify payload is valid in-toto v1 statement
+	payloadBytes, err := base64.StdEncoding.DecodeString(envelope.Payload)
+	if err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+
+	var statement attestation.Statement
+	if err := json.Unmarshal(payloadBytes, &statement); err != nil {
+		t.Fatalf("parse statement: %v", err)
+	}
+
+	if statement.Type != "https://in-toto.io/Statement/v1" {
+		t.Errorf("expected statement type v1, got %q", statement.Type)
+	}
+	if statement.PredicateType != "https://aflock.ai/attestations/action/v0.1" {
+		t.Errorf("expected predicate type action/v0.1, got %q", statement.PredicateType)
+	}
+	if len(statement.Subject) == 0 {
+		t.Error("expected at least one subject")
+	}
+	if statement.Subject[0].Name != "session:session-attest-2/action:tu_bash_456" {
+		t.Errorf("unexpected subject name: %s", statement.Subject[0].Name)
+	}
+
+	// Check predicate contains the tool call info
+	predBytes, err := json.Marshal(statement.Predicate)
+	if err != nil {
+		t.Fatalf("marshal predicate: %v", err)
+	}
+	var predicate attestation.ActionPredicate
+	if err := json.Unmarshal(predBytes, &predicate); err != nil {
+		t.Fatalf("parse predicate: %v", err)
+	}
+	if predicate.ToolName != "Bash" {
+		t.Errorf("expected toolName 'Bash', got %q", predicate.ToolName)
+	}
+	if predicate.Decision != "allow" {
+		t.Errorf("expected decision 'allow', got %q", predicate.Decision)
+	}
+	if predicate.SessionID != "session-attest-2" {
+		t.Errorf("expected sessionId 'session-attest-2', got %q", predicate.SessionID)
+	}
+}
+
+func TestPostToolUse_NoAttestationWithoutSession(t *testing.T) {
+	h := newTestHandler(t)
+
+	// PostToolUse without a valid session should not panic
+	input := &aflock.HookInput{
+		SessionID: "nonexistent-session",
+		ToolName:  "Read",
+		ToolInput: json.RawMessage(`{"file_path": "test.go"}`),
+	}
+
+	captureStdout(t, func() {
+		if err := h.handlePostToolUse(input); err != nil {
+			t.Fatalf("handlePostToolUse: %v", err)
+		}
+	})
+
+	// Should not have created any attestation dir
+	attestDir := h.stateManager.AttestationsDir("nonexistent-session")
+	if _, err := os.Stat(attestDir); err == nil {
+		t.Error("expected no attestation dir for nonexistent session")
+	}
+}
+
+func TestPostToolUse_AttestationFileNaming(t *testing.T) {
+	h := newTestHandler(t)
+	pol := &aflock.Policy{
+		Name: "naming-test",
+		Tools: &aflock.ToolsPolicy{
+			Allow: []string{"Read"},
+		},
+	}
+	seedSession(t, h, "session-attest-3", pol)
+
+	input := &aflock.HookInput{
+		SessionID: "session-attest-3",
+		ToolName:  "Read",
+		ToolUseID: "tu_longid_abcdef1234567890",
+		ToolInput: json.RawMessage(`{"file_path": "x.go"}`),
+	}
+
+	captureStdout(t, func() {
+		if err := h.handlePostToolUse(input); err != nil {
+			t.Fatalf("handlePostToolUse: %v", err)
+		}
+	})
+
+	attestDir := h.stateManager.AttestationsDir("session-attest-3")
+	entries, err := os.ReadDir(attestDir)
+	if err != nil || len(entries) == 0 {
+		t.Fatalf("no attestation files found")
+	}
+
+	name := entries[0].Name()
+	// Should be <timestamp>-<first8chars>.intoto.json
+	if filepath.Ext(name) != ".json" {
+		t.Errorf("expected .json extension, got %q", name)
+	}
+	if len(name) < 20 {
+		t.Errorf("filename too short: %q", name)
+	}
+}
+
+func TestInitializeEphemeral(t *testing.T) {
+	signer := attestation.NewSigner("")
+	err := signer.InitializeEphemeral("abc123hash")
+	if err != nil {
+		t.Fatalf("InitializeEphemeral: %v", err)
+	}
+
+	// Should be able to sign
+	stmt := attestation.Statement{
+		Type: "https://in-toto.io/Statement/v1",
+		Subject: []attestation.Subject{
+			{Name: "test", Digest: map[string]string{"sha256": "abc"}},
+		},
+		PredicateType: "https://aflock.ai/attestations/action/v0.1",
+		Predicate:     map[string]string{"test": "value"},
+	}
+
+	envelope, err := signer.Sign(context.Background(), stmt)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+
+	if envelope.PayloadType != "application/vnd.in-toto+json" {
+		t.Errorf("unexpected payloadType: %s", envelope.PayloadType)
+	}
+	if len(envelope.Signatures) == 0 {
+		t.Error("expected signatures")
+	}
+	if envelope.Signatures[0].Certificate == "" {
+		t.Error("expected certificate in signature")
+	}
+}

--- a/internal/hooks/handler_test.go
+++ b/internal/hooks/handler_test.go
@@ -838,6 +838,13 @@ func TestHandleStop_MissingAttestation(t *testing.T) {
 	}
 	seedSession(t, h, "session-missing-attest", pol)
 
+	// Record that the tool was used — Stop only blocks for tools actually used
+	ss, _ := h.stateManager.Load("session-missing-attest")
+	h.stateManager.RecordAction(ss, aflock.ActionRecord{
+		ToolName: "security-review", Decision: "allow",
+	})
+	h.stateManager.Save(ss)
+
 	input := &aflock.HookInput{
 		SessionID: "session-missing-attest",
 	}
@@ -855,11 +862,49 @@ func TestHandleStop_MissingAttestation(t *testing.T) {
 	if out.Decision != "block" {
 		t.Errorf("expected block for missing attestation, got %q", out.Decision)
 	}
-	if !strings.Contains(out.Reason, "missing required attestations") {
-		t.Errorf("expected 'missing required attestations' in reason, got: %s", out.Reason)
+	if !strings.Contains(out.Reason, "missing attestations") {
+		t.Errorf("expected 'missing attestations' in reason, got: %s", out.Reason)
 	}
 	if !strings.Contains(out.Reason, "security-review") {
 		t.Errorf("expected 'security-review' in reason, got: %s", out.Reason)
+	}
+}
+
+func TestHandleStop_UnusedToolNotRequired(t *testing.T) {
+	h := newTestHandler(t)
+	pol := &aflock.Policy{
+		Name:                 "test-unused",
+		RequiredAttestations: []string{"Bash", "Read"},
+	}
+	seedSession(t, h, "session-unused-tool", pol)
+
+	// Only Read was used, Bash was never used
+	ss, _ := h.stateManager.Load("session-unused-tool")
+	h.stateManager.RecordAction(ss, aflock.ActionRecord{
+		ToolName: "Read", Decision: "allow",
+	})
+	h.stateManager.Save(ss)
+
+	// Create Read attestation
+	attestDir := h.stateManager.AttestationsDir("session-unused-tool")
+	os.MkdirAll(attestDir, 0755)
+	os.WriteFile(filepath.Join(attestDir, "Read.json"),
+		[]byte(`{"payload":"eyJ0ZXN0IjoidmFsaWQifQ==","payloadType":"application/vnd.in-toto+json","signatures":[{"keyid":"k","sig":"s"}]}`), 0644)
+
+	input := &aflock.HookInput{SessionID: "session-unused-tool"}
+
+	got := captureStdout(t, func() {
+		if err := h.handleStop(input); err != nil {
+			t.Fatalf("handleStop: %v", err)
+		}
+	})
+
+	var out aflock.HookOutput
+	if err := json.Unmarshal([]byte(got), &out); err != nil {
+		t.Fatalf("parse: %v (raw: %s)", err, got)
+	}
+	if out.Decision == "block" {
+		t.Errorf("expected allow when required tool was never used, got block: %s", out.Reason)
 	}
 }
 
@@ -1035,11 +1080,18 @@ func TestHandleStop_MultipleAttestations_OneMissing(t *testing.T) {
 	}
 	seedSession(t, h, "session-multi", pol)
 
+	// Record all three tools as used
+	ss, _ := h.stateManager.Load("session-multi")
+	h.stateManager.RecordAction(ss, aflock.ActionRecord{ToolName: "build", Decision: "allow"})
+	h.stateManager.RecordAction(ss, aflock.ActionRecord{ToolName: "test", Decision: "allow"})
+	h.stateManager.RecordAction(ss, aflock.ActionRecord{ToolName: "deploy", Decision: "allow"})
+	h.stateManager.Save(ss)
+
 	attestDir := h.stateManager.AttestationsDir("session-multi")
 	os.MkdirAll(attestDir, 0755)
 	os.WriteFile(filepath.Join(attestDir, "build.json"), []byte(`{}`), 0644)
 	os.WriteFile(filepath.Join(attestDir, "test.json"), []byte(`{}`), 0644)
-	// "deploy" is missing
+	// "deploy" was used but attestation is missing — should block
 
 	input := &aflock.HookInput{SessionID: "session-multi"}
 

--- a/pkg/aflock/types.go
+++ b/pkg/aflock/types.go
@@ -444,6 +444,22 @@ type SessionState struct {
 	ParentSessionID string `json:"parent_session_id,omitempty"`
 	// ChildSessionIDs tracks subagent sessions spawned from this session
 	ChildSessionIDs []string `json:"child_session_ids,omitempty"`
+	// AgentIdentityMeta stores identity discovered at SessionStart for reuse in PostToolUse
+	AgentIdentityMeta *AgentIdentityMeta `json:"agent_identity_meta,omitempty"`
+}
+
+// AgentIdentityMeta stores agent identity metadata in session state.
+// This is a serializable subset of identity.AgentIdentity, saved at SessionStart
+// and reused in PostToolUse to avoid re-discovering identity per tool call.
+type AgentIdentityMeta struct {
+	Model        string `json:"model"`
+	ModelVersion string `json:"model_version,omitempty"`
+	BinaryName   string `json:"binary_name,omitempty"`
+	BinaryVer    string `json:"binary_version,omitempty"`
+	BinaryDigest string `json:"binary_digest,omitempty"`
+	Environment  string `json:"environment,omitempty"`
+	PolicyDigest string `json:"policy_digest,omitempty"`
+	IdentityHash string `json:"identity_hash"`
 }
 
 // PropagationRecord is written by a parent session's PreToolUse(Agent) hook


### PR DESCRIPTION
## Summary
Every allowed tool call in hooks mode now produces a DSSE-signed in-toto v1 attestation with the `action/v0.1` predicate type. Signing uses SPIRE X509-SVIDs when available, ephemeral ECDSA P-256 keys as fallback (no infrastructure required). Agent identity metadata saved at SessionStart, reused in PostToolUse to avoid redundant PID-tree walking.


  ### Attestation format

  ```json
  {
    "_type": "https://in-toto.io/Statement/v1",
    "subject": [{"name": "session:<id>/action:<toolUseId>", "digest": {"sha256": "..."}}],
    "predicateType": "https://aflock.ai/attestations/action/v0.1",
    "predicate": {
      "action": "tool_call",
      "toolName": "Read",
      "decision": "allow",
      "agentIdentity": {"model": "claude-opus-4-6", "identityHash": "..."},
      "metrics": {"cumulativeTokensIn": 15000, "turnNumber": 3}
    }
  }
```

  Wrapped in DSSE envelope with signature + certificate. Stored at ~/.aflock/sessions/<id>/attestations/<timestamp>-<toolUseId>.intoto.json.

  Two signing modes

 ```
  Two signing modes

  ┌───────────┬─────────────────────┬───────────────────────────────────────────┐
  │   Mode    │        When         │                  Key ID                   │
  ├───────────┼─────────────────────┼───────────────────────────────────────────┤
  │ SPIRE     │ SPIRE agent running │ spiffe://aflock.ai/agent/claude-*         │
  ├───────────┼─────────────────────┼───────────────────────────────────────────┤
  │ Ephemeral │ No SPIRE (default)  │ spiffe://aflock.ai/agent/ephemeral/<hash> │
  └───────────┴─────────────────────┴───────────────────────────────────────────┘
```

  Both produce identical DSSE envelopes. Ephemeral uses self-signed cert, SPIRE uses CA-chained X509-SVID.

fixes #17
fixes #36
