### PR TITLE
feat: add replay command for session validation and simulation

### DIFF
--- a/cmd/aflock/main.go
+++ b/cmd/aflock/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/aflock-ai/aflock/internal/mcp"
 	"github.com/aflock-ai/aflock/internal/plan"
 	"github.com/aflock-ai/aflock/internal/policy"
+	"github.com/aflock-ai/aflock/internal/replay"
 	"github.com/aflock-ai/aflock/internal/verify"
 	"github.com/aflock-ai/aflock/pkg/aflock"
 )
@@ -547,6 +548,105 @@ For HTTP (OpenClaw via mcporter):
 	},
 }
 
+var replaySessionPath string
+var replayPolicyPath string
+var replayFormat string
+var replaySimulate bool
+
+var replayCmd = &cobra.Command{
+	Use:   "replay",
+	Short: "Replay a Claude session against an aflock policy",
+	Long: `Replay a recorded Claude Code session (.jsonl) against an aflock policy.
+
+Parses every tool call from the session and evaluates it against the policy
+deterministically. Shows which actions would be allowed, denied, or require
+approval.
+
+Use --simulate to run the full hook lifecycle and produce real attestations.
+
+Examples:
+  aflock replay --session ~/.claude/projects/.../session.jsonl --policy .aflock
+  aflock replay --session session.jsonl --policy strict.aflock --format json
+  aflock replay --session session.jsonl --policy .aflock --simulate`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if replaySessionPath == "" {
+			fmt.Fprintln(os.Stderr, "Error: --session is required")
+			fmt.Fprintln(os.Stderr, "Usage: aflock replay --session <session.jsonl> --policy <policy.aflock>")
+			os.Exit(1)
+		}
+
+		// Parse session
+		session, err := replay.ParseSession(replaySessionPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error parsing session: %v\n", err)
+			os.Exit(1)
+		}
+
+		if len(session.Actions) == 0 {
+			fmt.Fprintln(os.Stderr, "No tool calls found in session file.")
+			os.Exit(0)
+		}
+
+		// Load policy
+		polPath := replayPolicyPath
+		if polPath == "" {
+			cwd, _ := os.Getwd()
+			polPath = cwd
+		}
+
+		pol, resolvedPath, err := policy.Load(polPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error loading policy: %v\n", err)
+			os.Exit(1)
+		}
+
+		// Simulate mode: full hook lifecycle with attestations
+		if replaySimulate {
+			simReport, err := replay.Simulate(session, pol, resolvedPath)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error running simulation: %v\n", err)
+				os.Exit(1)
+			}
+
+			switch replayFormat {
+			case "json":
+				output, err := simReport.Report.FormatJSON()
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "Error formatting JSON: %v\n", err)
+					os.Exit(1)
+				}
+				fmt.Println(output)
+			default:
+				fmt.Print(simReport.FormatSimulateText())
+			}
+
+			if simReport.DenyCount > 0 {
+				os.Exit(1)
+			}
+			return
+		}
+
+		// Validator mode: report only
+		report := replay.Run(session, pol, resolvedPath)
+
+		switch replayFormat {
+		case "json":
+			output, err := report.FormatJSON()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error formatting JSON: %v\n", err)
+				os.Exit(1)
+			}
+			fmt.Println(output)
+		default:
+			fmt.Print(report.FormatText())
+		}
+
+		if report.DenyCount > 0 {
+			os.Exit(1)
+		}
+	},
+}
+
 var hookFlag string
 
 func init() {
@@ -557,6 +657,7 @@ func init() {
 	rootCmd.AddCommand(signCmd)
 	rootCmd.AddCommand(serveCmd)
 	rootCmd.AddCommand(planToPolicyCmd)
+	rootCmd.AddCommand(replayCmd)
 
 	// Add --hook flag as alternative to hook subcommand for backwards compatibility
 	rootCmd.Flags().StringVar(&hookFlag, "hook", "", "Hook event to handle (alternative to 'hook' subcommand)")
@@ -578,6 +679,12 @@ func init() {
 	planToPolicyCmd.Flags().BoolVar(&planLimits, "limits", false, "Add default spend/turn limits")
 	planToPolicyCmd.Flags().StringVar(&planModel, "model", "", "AI evaluator model (default: claude-opus-4-5-20251101)")
 	planToPolicyCmd.Flags().BoolVar(&planList, "list", false, "List available plans from .claude/plans/ (project) and ~/.claude/plans/ (global)")
+
+	// Replay command flags
+	replayCmd.Flags().StringVar(&replaySessionPath, "session", "", "Path to Claude session .jsonl file (required)")
+	replayCmd.Flags().StringVar(&replayPolicyPath, "policy", "", "Path to .aflock policy file (default: .aflock in current directory)")
+	replayCmd.Flags().StringVar(&replayFormat, "format", "text", "Output format: text or json")
+	replayCmd.Flags().BoolVar(&replaySimulate, "simulate", false, "Run full simulation: produce session state + signed attestations")
 
 	// Serve command flags
 	serveCmd.Flags().StringVarP(&servePolicyPath, "policy", "p", "", "Path to .aflock policy file")

--- a/internal/policy/evaluator.go
+++ b/internal/policy/evaluator.go
@@ -444,6 +444,18 @@ func (e *Evaluator) evaluateFileAccess(toolName string, toolInput json.RawMessag
 			}
 		}
 
+		// ReadOnly files are implicitly allowed for read operations.
+		// If a file is in readOnly, the user clearly intends it to be readable —
+		// requiring it to also be in files.allow is redundant and error-prone.
+		if !allowed && isReadOperation(toolName) {
+			for _, pattern := range e.policy.Files.ReadOnly {
+				if e.matchFilePattern(pattern, variants) {
+					allowed = true
+					break
+				}
+			}
+		}
+
 		// For directory tools (Glob, Grep), if the path is the project root (".")
 		// or resolves to it, allow the search. These tools scan directories and return
 		// results — they don't write or modify files. The deny patterns above already
@@ -699,6 +711,189 @@ func containsString(slice []string, item string) bool {
 		}
 	}
 	return false
+}
+
+// EvaluateGrants checks tool inputs against grants allow/deny patterns for
+// secrets, APIs, and storage. Each grant category is only evaluated when the
+// tool input contains values relevant to that category (determined by pattern
+// prefixes). String values are extracted from the JSON input so that glob
+// patterns match against individual values, not the raw JSON.
+func (e *Evaluator) EvaluateGrants(toolName string, toolInput json.RawMessage) (aflock.PermissionDecision, string) {
+	if e.policy.Grants == nil {
+		return aflock.DecisionAllow, ""
+	}
+
+	values := extractStringValues(toolInput)
+
+	// Check secrets grants — only when input has values relevant to secret patterns
+	if e.policy.Grants.Secrets != nil && e.categoryRelevant(values, e.policy.Grants.Secrets) {
+		if decision, reason := e.evaluateGrantCategory(values, e.policy.Grants.Secrets, "secret"); decision != aflock.DecisionAllow {
+			return decision, reason
+		}
+	}
+
+	// Check API grants — only when input has values relevant to API patterns
+	if e.policy.Grants.APIs != nil && e.categoryRelevant(values, e.policy.Grants.APIs) {
+		if decision, reason := e.evaluateGrantCategory(values, e.policy.Grants.APIs, "API"); decision != aflock.DecisionAllow {
+			return decision, reason
+		}
+	}
+
+	// Check storage grants — only when input has values relevant to storage patterns
+	if e.policy.Grants.Storage != nil && e.categoryRelevant(values, e.policy.Grants.Storage) {
+		if decision, reason := e.evaluateGrantCategory(values, e.policy.Grants.Storage, "storage"); decision != aflock.DecisionAllow {
+			return decision, reason
+		}
+	}
+
+	return aflock.DecisionAllow, ""
+}
+
+// categoryRelevant returns true if any extracted value looks like it could be
+// relevant to this grant category. A category is relevant if any value (or any
+// word within a value) shares a common prefix scheme with the category's
+// allow/deny patterns (e.g. "vault:", "https://", "s3://"), or matches a deny
+// pattern via substring.
+func (e *Evaluator) categoryRelevant(values []string, adPolicy *aflock.AllowDenyPolicy) bool {
+	prefixes := grantPrefixes(adPolicy)
+	if len(prefixes) == 0 {
+		// No patterns have recognizable prefixes; fall back to always checking
+		return true
+	}
+	for _, v := range values {
+		for _, pfx := range prefixes {
+			// Check the value itself and also each word within it
+			// (for Bash commands like "aws s3 cp s3://bucket/key .")
+			if strings.HasPrefix(v, pfx) || strings.Contains(v, " "+pfx) {
+				return true
+			}
+		}
+		// Also check deny patterns via substring (for literal patterns like "AWS_SECRET_KEY")
+		for _, dp := range adPolicy.Deny {
+			if strings.Contains(v, dp) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// grantPrefixes extracts scheme-like prefixes from grant patterns.
+// For example, "vault:secret/data/*" → "vault:", "https://api.example.com/*" → "https://",
+// "s3://bucket/*" → "s3://".
+func grantPrefixes(adPolicy *aflock.AllowDenyPolicy) []string {
+	seen := map[string]bool{}
+	var prefixes []string
+	for _, patterns := range [][]string{adPolicy.Allow, adPolicy.Deny} {
+		for _, p := range patterns {
+			if idx := strings.Index(p, "://"); idx > 0 && idx < 10 {
+				pfx := p[:idx+3]
+				if !seen[pfx] {
+					seen[pfx] = true
+					prefixes = append(prefixes, pfx)
+				}
+			} else if idx := strings.IndexByte(p, ':'); idx > 0 && idx < 20 {
+				pfx := p[:idx+1]
+				if !seen[pfx] {
+					seen[pfx] = true
+					prefixes = append(prefixes, pfx)
+				}
+			}
+		}
+	}
+	return prefixes
+}
+
+// evaluateGrantCategory checks a single grant category (secrets, APIs, or storage)
+// against extracted string values. Deny patterns are checked first; if allow patterns
+// exist, at least one value must match at least one allow pattern.
+func (e *Evaluator) evaluateGrantCategory(values []string, adPolicy *aflock.AllowDenyPolicy, category string) (aflock.PermissionDecision, string) {
+	// Check deny patterns first
+	for _, v := range values {
+		if matched, pattern := matchGrantPattern(v, adPolicy.Deny); matched {
+			return aflock.DecisionDeny, fmt.Sprintf("tool input matches denied %s pattern: %s", category, pattern)
+		}
+	}
+
+	// Check allow patterns (if specified, at least one value must match)
+	if len(adPolicy.Allow) > 0 {
+		for _, v := range values {
+			if matched, _ := matchGrantPattern(v, adPolicy.Allow); matched {
+				return aflock.DecisionAllow, ""
+			}
+		}
+		return aflock.DecisionDeny, fmt.Sprintf("tool input does not match any allowed %s pattern", category)
+	}
+
+	return aflock.DecisionAllow, ""
+}
+
+// extractStringValues pulls all string values from a JSON object, recursively.
+// For {"command": "echo hello", "path": "vault:secret/key"} it returns
+// ["echo hello", "vault:secret/key"].
+func extractStringValues(data json.RawMessage) []string {
+	var values []string
+
+	// Try as object
+	var obj map[string]json.RawMessage
+	if json.Unmarshal(data, &obj) == nil {
+		for _, v := range obj {
+			values = append(values, extractStringValues(v)...)
+		}
+		return values
+	}
+
+	// Try as array
+	var arr []json.RawMessage
+	if json.Unmarshal(data, &arr) == nil {
+		for _, v := range arr {
+			values = append(values, extractStringValues(v)...)
+		}
+		return values
+	}
+
+	// Try as string
+	var s string
+	if json.Unmarshal(data, &s) == nil && s != "" {
+		values = append(values, s)
+	}
+
+	return values
+}
+
+// matchGrantPattern checks if a value matches any of the given patterns.
+// It tries the value directly, and also splits the value into words to handle
+// URIs embedded in Bash commands (e.g. "aws s3 cp s3://bucket/key .").
+func matchGrantPattern(value string, patterns []string) (bool, string) {
+	// Collect candidates: the full value + individual words
+	candidates := []string{value}
+	if strings.Contains(value, " ") {
+		candidates = append(candidates, strings.Fields(value)...)
+	}
+
+	for _, pattern := range patterns {
+		for _, candidate := range candidates {
+			// Try glob match
+			if matched, _ := filepath.Match(pattern, candidate); matched {
+				return true, pattern
+			}
+			// For patterns with wildcards, try prefix matching:
+			// "https://api.example.com/*" should match "https://api.example.com/v1/foo"
+			if strings.Contains(pattern, "*") {
+				prefix := strings.SplitN(pattern, "*", 2)[0]
+				if prefix != "" && strings.HasPrefix(candidate, prefix) {
+					return true, pattern
+				}
+			}
+		}
+		// Substring match for literal patterns (e.g., "AWS_SECRET_KEY")
+		if !strings.Contains(pattern, "*") && !strings.Contains(pattern, "?") {
+			if strings.Contains(value, pattern) {
+				return true, pattern
+			}
+		}
+	}
+	return false, ""
 }
 
 // CheckLimits checks if cumulative metrics exceed policy limits.

--- a/internal/replay/readonly_test.go
+++ b/internal/replay/readonly_test.go
@@ -1,0 +1,47 @@
+package replay_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/aflock-ai/aflock/internal/policy"
+	"github.com/aflock-ai/aflock/pkg/aflock"
+)
+
+func TestReadOnlyImplicitAllow(t *testing.T) {
+	pol := &aflock.Policy{
+		Files: &aflock.FilesPolicy{
+			Allow:    []string{"src/**"},
+			Deny:     []string{"**/.env"},
+			ReadOnly: []string{"package.json"},
+		},
+	}
+
+	eval := policy.NewEvaluator(pol, "/tmp/project")
+
+	tests := []struct {
+		name     string
+		tool     string
+		filePath string
+		wantDec  aflock.PermissionDecision
+	}{
+		{"Read readOnly file", "Read", "/tmp/project/package.json", aflock.DecisionAllow},
+		{"Write readOnly file", "Write", "/tmp/project/package.json", aflock.DecisionDeny},
+		{"Edit readOnly file", "Edit", "/tmp/project/package.json", aflock.DecisionDeny},
+		{"Read allowed file", "Read", "/tmp/project/src/app.js", aflock.DecisionAllow},
+		{"Read denied file", "Read", "/tmp/project/.env", aflock.DecisionDeny},
+		{"Read unlisted file", "Read", "/tmp/project/random.txt", aflock.DecisionDeny},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input, _ := json.Marshal(map[string]string{"file_path": tt.filePath})
+			dec, reason := eval.EvaluatePreToolUse(tt.tool, input)
+			if dec != tt.wantDec {
+				t.Errorf("got %s (%s), want %s", dec, reason, tt.wantDec)
+			}
+			fmt.Printf("  %-25s %-6s → %s\n", tt.name, tt.tool, dec)
+		})
+	}
+}

--- a/internal/replay/replay.go
+++ b/internal/replay/replay.go
@@ -1,0 +1,334 @@
+package replay
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/aflock-ai/aflock/internal/policy"
+	"github.com/aflock-ai/aflock/pkg/aflock"
+)
+
+// Result is the policy evaluation result for a single action.
+type Result struct {
+	Action   Action
+	Decision aflock.PermissionDecision
+	Reason   string
+}
+
+// Report is the full replay output.
+type Report struct {
+	Session    *Session
+	PolicyName string
+	PolicyPath string
+	Results    []Result
+	AllowCount int
+	DenyCount  int
+	AskCount   int
+}
+
+// Run replays a parsed session against a policy and returns the report.
+func Run(session *Session, pol *aflock.Policy, policyPath string) *Report {
+	projectRoot := filepath.Dir(policyPath)
+	evaluator := policy.NewEvaluator(pol, projectRoot)
+
+	report := &Report{
+		Session:    session,
+		PolicyName: pol.Name,
+		PolicyPath: policyPath,
+	}
+
+	for _, action := range session.Actions {
+		decision, reason := evaluator.EvaluatePreToolUse(action.Tool, action.RawInput)
+
+		result := Result{
+			Action:   action,
+			Decision: decision,
+			Reason:   reason,
+		}
+
+		switch decision {
+		case aflock.DecisionAllow:
+			report.AllowCount++
+		case aflock.DecisionDeny:
+			report.DenyCount++
+		case aflock.DecisionAsk:
+			report.AskCount++
+		}
+
+		report.Results = append(report.Results, result)
+	}
+
+	return report
+}
+
+// FormatText renders the report as a human-readable text table.
+func (r *Report) FormatText() string {
+	var b strings.Builder
+
+	// ANSI colors for header
+	hGreen := "\033[32m"
+	hRed := "\033[31m"
+	hCyan := "\033[36m"
+	hDim := "\033[90m"
+	hBold := "\033[1m"
+	hReset := "\033[0m"
+	hPurple := "\033[35m"
+
+	// Header
+	fmt.Fprintf(&b, "%s%sAFLOCK REPLAY%s — %s%s%s\n", hBold, hPurple, hReset, hCyan, r.PolicyName, hReset)
+	fmt.Fprintf(&b, "%s%s%s\n\n", hDim, strings.Repeat("━", 60), hReset)
+
+	// Identity check
+	modelCheck := hGreen + "✓" + hReset
+	if r.Session.Model == "" || r.Session.Model == "unknown" {
+		modelCheck = "?"
+	}
+	fmt.Fprintf(&b, "Model:  %s%-24s%s %s\n", hCyan, r.Session.Model, hReset, modelCheck)
+
+	// Limits check
+	if pol := r.loadPolicy(); pol != nil && pol.Limits != nil {
+		if pol.Limits.MaxTurns != nil {
+			turnCheck := hGreen + "✓" + hReset
+			if float64(r.Session.Turns) > pol.Limits.MaxTurns.Value {
+				turnCheck = hRed + "✗ EXCEEDED" + hReset
+			}
+			fmt.Fprintf(&b, "Turns:  %-24s %s\n",
+				fmt.Sprintf("%d/%.0f", r.Session.Turns, pol.Limits.MaxTurns.Value), turnCheck)
+		} else {
+			fmt.Fprintf(&b, "Turns:  %d\n", r.Session.Turns)
+		}
+	} else {
+		fmt.Fprintf(&b, "Turns:  %d\n", r.Session.Turns)
+	}
+
+	fmt.Fprintf(&b, "Calls:  %d\n", len(r.Session.Actions))
+	fmt.Fprintf(&b, "Tokens: in=%d out=%d\n\n", r.Session.TokensIn, r.Session.TokensOut)
+
+	// ANSI colors
+	green := "\033[32m"
+	red := "\033[31m"
+	yellow := "\033[33m"
+	cyan := "\033[36m"
+	dim := "\033[90m"
+	bold := "\033[1m"
+	reset := "\033[0m"
+
+	// Table header
+	fmt.Fprintf(&b, "%s%-4s  %-10s  %-45s  %s%s\n",
+		dim, "#", "TOOL", "INPUT", "DECISION", reset)
+	fmt.Fprintf(&b, "%s%s%s\n", dim, strings.Repeat("─", 75), reset)
+
+	// Determine the best root for shortening paths.
+	// Use policy dir first, but also detect the session's working directory
+	// from file paths (handles case where policy is in a different directory).
+	policyRoot, _ := filepath.Abs(filepath.Dir(r.PolicyPath))
+	sessionRoot := detectSessionRoot(r.Results)
+	shortenRoot := policyRoot
+	if sessionRoot != "" && sessionRoot != policyRoot {
+		// Policy is in a different dir than where the session ran.
+		// Use the session's CWD for shortening — it matches the file paths.
+		shortenRoot = sessionRoot
+	}
+
+	for _, res := range r.Results {
+		detail := shortenInput(res.Action.Tool, res.Action.InputDetail(), shortenRoot)
+		if len(detail) > 45 {
+			detail = detail[:42] + "..."
+		}
+
+		// Color the decision
+		var decColor string
+		switch res.Decision {
+		case aflock.DecisionAllow:
+			decColor = green
+		case aflock.DecisionDeny:
+			decColor = red
+		case aflock.DecisionAsk:
+			decColor = yellow
+		default:
+			decColor = dim
+		}
+
+		fmt.Fprintf(&b, "%-4d  %s%-10s%s  %-45s  %s%s%s\n",
+			res.Action.Index,
+			cyan, res.Action.Tool, reset,
+			detail,
+			decColor, string(res.Decision), reset)
+
+		// Reason on second line for deny/ask only
+		if res.Decision != aflock.DecisionAllow && res.Reason != "" {
+			reason := shortenReason(res.Reason, shortenRoot)
+			fmt.Fprintf(&b, "      %s↳ %s%s\n", dim, reason, reset)
+		}
+	}
+
+	fmt.Fprintf(&b, "%s%s%s\n", dim, strings.Repeat("─", 75), reset)
+
+	// Verdict with color
+	if r.DenyCount > 0 {
+		fmt.Fprintf(&b, "%s%sVERDICT: FAIL — %d violation(s)%s  (%s%d allow%s, %s%d deny%s, %s%d ask%s)\n",
+			bold, red, r.DenyCount, reset,
+			green, r.AllowCount, reset,
+			red, r.DenyCount, reset,
+			yellow, r.AskCount, reset)
+	} else {
+		fmt.Fprintf(&b, "%s%sVERDICT: PASS%s  (%s%d allow%s, %s%d deny%s, %s%d ask%s)\n",
+			bold, green, reset,
+			green, r.AllowCount, reset,
+			red, r.DenyCount, reset,
+			yellow, r.AskCount, reset)
+	}
+
+	return b.String()
+}
+
+// FormatJSON renders the report as JSON.
+func (r *Report) FormatJSON() (string, error) {
+	type jsonAction struct {
+		Index    int            `json:"index"`
+		Tool     string         `json:"tool"`
+		ID       string         `json:"id"`
+		Input    map[string]any `json:"input"`
+		Decision string         `json:"decision"`
+		Reason   string         `json:"reason,omitempty"`
+	}
+
+	type jsonReport struct {
+		Policy     string       `json:"policy"`
+		PolicyPath string       `json:"policyPath"`
+		Model      string       `json:"model"`
+		Turns      int          `json:"turns"`
+		ToolCalls  int          `json:"toolCalls"`
+		TokensIn   int64        `json:"tokensIn"`
+		TokensOut  int64        `json:"tokensOut"`
+		AllowCount int          `json:"allowCount"`
+		DenyCount  int          `json:"denyCount"`
+		AskCount   int          `json:"askCount"`
+		Verdict    string       `json:"verdict"`
+		Actions    []jsonAction `json:"actions"`
+	}
+
+	verdict := "pass"
+	if r.DenyCount > 0 {
+		verdict = "fail"
+	}
+
+	jr := jsonReport{
+		Policy:     r.PolicyName,
+		PolicyPath: r.PolicyPath,
+		Model:      r.Session.Model,
+		Turns:      r.Session.Turns,
+		ToolCalls:  len(r.Session.Actions),
+		TokensIn:   r.Session.TokensIn,
+		TokensOut:  r.Session.TokensOut,
+		AllowCount: r.AllowCount,
+		DenyCount:  r.DenyCount,
+		AskCount:   r.AskCount,
+		Verdict:    verdict,
+	}
+
+	for _, res := range r.Results {
+		jr.Actions = append(jr.Actions, jsonAction{
+			Index:    res.Action.Index,
+			Tool:     res.Action.Tool,
+			ID:       res.Action.ID,
+			Input:    res.Action.Input,
+			Decision: string(res.Decision),
+			Reason:   res.Reason,
+		})
+	}
+
+	data, err := json.MarshalIndent(jr, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+// detectSessionRoot finds the common directory of all absolute file paths
+// in the session. This is the working directory where the session ran.
+func detectSessionRoot(results []Result) string {
+	var paths []string
+	for _, res := range results {
+		detail := res.Action.InputDetail()
+		if filepath.IsAbs(detail) {
+			paths = append(paths, filepath.Dir(detail))
+		}
+		// Also check file_path in input
+		if fp, ok := res.Action.Input["file_path"].(string); ok && filepath.IsAbs(fp) {
+			paths = append(paths, filepath.Dir(fp))
+		}
+	}
+	if len(paths) == 0 {
+		return ""
+	}
+
+	// Find common prefix
+	common := paths[0]
+	for _, p := range paths[1:] {
+		for !strings.HasPrefix(p, common) {
+			common = filepath.Dir(common)
+			if common == "/" || common == "." {
+				return ""
+			}
+		}
+	}
+	return common
+}
+
+// shortenInput makes tool inputs more readable by:
+// 1. Stripping the project root from file paths
+// 2. Stripping absolute paths from Bash commands, keeping just the command + relative path
+// 3. Shortening binary paths to just the binary name
+func shortenInput(tool, detail, absRoot string) string {
+	if absRoot == "" {
+		return detail
+	}
+
+	switch tool {
+	case "Read", "Write", "Edit", "Glob", "Grep":
+		// Already handled by InputDetail() for file_path, but double-check
+		return strings.TrimPrefix(detail, absRoot+"/")
+
+	case "Bash":
+		// Replace the project root path with relative references
+		// Try with trailing slash first (longer match), then without
+		result := strings.ReplaceAll(detail, absRoot+"/", "")
+		result = strings.ReplaceAll(result, absRoot, ".")
+
+		// Strip any remaining absolute paths to binaries — keep just the binary name
+		// e.g., /Users/rahulxf/work-dir/aflock/bin/aflock → aflock
+		parts := strings.Fields(result)
+		for i, part := range parts {
+			if strings.HasPrefix(part, "/") && !strings.HasPrefix(part, "/dev/") &&
+				!strings.HasPrefix(part, "/tmp/") && !strings.HasPrefix(part, "/etc/") {
+				parts[i] = filepath.Base(part)
+			}
+		}
+		return strings.Join(parts, " ")
+	}
+
+	return strings.TrimPrefix(detail, absRoot+"/")
+}
+
+// shortenReason strips absolute paths from deny/ask reasons to make them readable.
+func shortenReason(reason, absRoot string) string {
+	if absRoot == "" {
+		return reason
+	}
+	// Strip the project root from the reason text
+	result := strings.ReplaceAll(reason, absRoot+"/", "")
+	result = strings.ReplaceAll(result, absRoot, "")
+	return result
+}
+
+// loadPolicy re-reads the policy for limit checks in formatting.
+func (r *Report) loadPolicy() *aflock.Policy {
+	pol, _, err := policy.Load(r.PolicyPath)
+	if err != nil {
+		return nil
+	}
+	return pol
+}

--- a/internal/replay/session.go
+++ b/internal/replay/session.go
@@ -1,0 +1,159 @@
+// Package replay implements session replay for validating recorded Claude Code
+// sessions against aflock policies.
+package replay
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// Session holds parsed metadata from a Claude Code .jsonl session file.
+type Session struct {
+	Path      string
+	Model     string
+	Turns     int
+	TokensIn  int64
+	TokensOut int64
+	Actions   []Action
+}
+
+// Action is a single tool call extracted from a session.
+type Action struct {
+	Index    int
+	Tool     string
+	ID       string
+	Input    map[string]any
+	RawInput json.RawMessage
+}
+
+// ParseSession parses a Claude Code .jsonl session file and extracts all tool calls.
+func ParseSession(path string) (*Session, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open session file: %w", err)
+	}
+	defer f.Close()
+
+	session := &Session{Path: path}
+	scanner := bufio.NewScanner(f)
+	// Claude session lines can be large (tool results with file contents)
+	buf := make([]byte, 0, 64*1024)
+	scanner.Buffer(buf, 10*1024*1024)
+
+	idx := 0
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+
+		var entry map[string]any
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			continue
+		}
+
+		msg, ok := entry["message"].(map[string]any)
+		if !ok {
+			continue
+		}
+
+		role, _ := msg["role"].(string)
+
+		if role == "user" {
+			session.Turns++
+		}
+
+		if role != "assistant" {
+			continue
+		}
+
+		// Extract model
+		if m, ok := msg["model"].(string); ok && m != "" && m != "<synthetic>" {
+			session.Model = m
+		}
+
+		// Extract token usage
+		if usage, ok := msg["usage"].(map[string]any); ok {
+			if v, ok := usage["input_tokens"].(float64); ok {
+				session.TokensIn += int64(v)
+			}
+			if v, ok := usage["output_tokens"].(float64); ok {
+				session.TokensOut += int64(v)
+			}
+		}
+
+		// Extract tool calls from content blocks
+		content, ok := msg["content"].([]any)
+		if !ok {
+			continue
+		}
+		for _, block := range content {
+			b, ok := block.(map[string]any)
+			if !ok || b["type"] != "tool_use" {
+				continue
+			}
+
+			toolName, _ := b["name"].(string)
+			toolID, _ := b["id"].(string)
+			input, _ := b["input"].(map[string]any)
+			rawInput, _ := json.Marshal(input)
+
+			idx++
+			session.Actions = append(session.Actions, Action{
+				Index:    idx,
+				Tool:     toolName,
+				ID:       toolID,
+				Input:    input,
+				RawInput: rawInput,
+			})
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read session file: %w", err)
+	}
+
+	return session, nil
+}
+
+// InputDetail returns a human-readable summary of a tool call's input.
+func (a *Action) InputDetail() string {
+	switch a.Tool {
+	case "Read", "Write", "Edit":
+		if fp, ok := a.Input["file_path"].(string); ok {
+			return fp
+		}
+	case "Bash":
+		if cmd, ok := a.Input["command"].(string); ok {
+			if len(cmd) > 80 {
+				return cmd[:80] + "..."
+			}
+			return cmd
+		}
+	case "Glob":
+		if p, ok := a.Input["pattern"].(string); ok {
+			return p
+		}
+	case "Grep":
+		if p, ok := a.Input["pattern"].(string); ok {
+			return p
+		}
+	case "Agent":
+		if p, ok := a.Input["prompt"].(string); ok {
+			if len(p) > 60 {
+				return p[:60] + "..."
+			}
+			return p
+		}
+	}
+
+	data, _ := json.Marshal(a.Input)
+	s := string(data)
+	if len(s) > 80 {
+		return s[:80] + "..."
+	}
+	return s
+}

--- a/internal/replay/simulate.go
+++ b/internal/replay/simulate.go
@@ -1,0 +1,315 @@
+package replay
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/aflock-ai/aflock/internal/attestation"
+	"github.com/aflock-ai/aflock/internal/identity"
+	"github.com/aflock-ai/aflock/internal/policy"
+	"github.com/aflock-ai/aflock/internal/state"
+	"github.com/aflock-ai/aflock/pkg/aflock"
+)
+
+// SimulateResult extends Result with attestation info.
+type SimulateResult struct {
+	Result
+	AttestationFile string // path to .intoto.json if created
+}
+
+// SimulateReport extends Report with simulator-specific output.
+type SimulateReport struct {
+	Report
+	SessionID       string
+	SessionDir      string
+	SimulateResults []SimulateResult
+	AttestCount     int
+	LimitExceeded   bool
+	LimitMessage    string
+	StopBlocked     bool
+	StopMessage     string
+}
+
+// Simulate replays a session through the full hook lifecycle, producing
+// real aflock artifacts: session state, attestations, and metrics.
+func Simulate(session *Session, pol *aflock.Policy, policyPath string) (*SimulateReport, error) {
+	projectRoot := filepath.Dir(policyPath)
+	evaluator := policy.NewEvaluator(pol, projectRoot)
+	stateManager := state.NewManager("")
+
+	// Generate a unique session ID for this replay
+	sessionID := fmt.Sprintf("replay-%d", time.Now().UnixNano())
+
+	// ── Phase 1: SessionStart ──
+	sessionState := stateManager.Initialize(sessionID, pol, policyPath)
+
+	// Create a synthetic agent identity from the session's model
+	agentIdentity := &identity.AgentIdentity{
+		Model:        session.Model,
+		ModelVersion: parseModelVersion(session.Model),
+	}
+	agentIdentity.Binary = &identity.BinaryIdentity{
+		Name:    "replay-simulator",
+		Version: "0.1.0",
+	}
+	agentIdentity.Environment = &identity.EnvironmentIdentity{
+		Type: "replay",
+	}
+	agentIdentity.DeriveIdentity()
+
+	if err := stateManager.Save(sessionState); err != nil {
+		return nil, fmt.Errorf("save initial session state: %w", err)
+	}
+
+	report := &SimulateReport{
+		Report: Report{
+			Session:    session,
+			PolicyName: pol.Name,
+			PolicyPath: policyPath,
+		},
+		SessionID:  sessionID,
+		SessionDir: stateManager.SessionDir(sessionID),
+	}
+
+	// Initialize attestation signer (try SPIRE, fall back gracefully)
+	signer := attestation.NewSigner("")
+	signerReady := false
+	if err := signer.Initialize(context.Background()); err != nil {
+		fmt.Fprintf(os.Stderr, "[replay] Warning: attestation signing unavailable: %v\n", err)
+	} else {
+		signerReady = true
+		defer signer.Close() //nolint:errcheck
+	}
+
+	// ── Phase 2: Replay each action (PreToolUse + PostToolUse) ──
+	for _, action := range session.Actions {
+		// PreToolUse — evaluate policy
+		decision, reason := evaluator.EvaluatePreToolUse(action.Tool, action.RawInput)
+
+		result := SimulateResult{
+			Result: Result{
+				Action:   action,
+				Decision: decision,
+				Reason:   reason,
+			},
+		}
+
+		switch decision {
+		case aflock.DecisionAllow:
+			report.AllowCount++
+		case aflock.DecisionDeny:
+			report.DenyCount++
+		case aflock.DecisionAsk:
+			report.AskCount++
+		}
+
+		// Record action in session state
+		stateManager.RecordAction(sessionState, aflock.ActionRecord{
+			Timestamp: time.Now(),
+			ToolName:  action.Tool,
+			ToolUseID: action.ID,
+			ToolInput: action.RawInput,
+			Decision:  string(decision),
+			Reason:    reason,
+		})
+
+		// PostToolUse — track file access
+		if isFileOperation(action.Tool) {
+			if fp, ok := action.Input["file_path"].(string); ok {
+				stateManager.TrackFile(sessionState, action.Tool, fp)
+			}
+		}
+
+		// PostToolUse — check fail-fast limits
+		if pol.Limits != nil {
+			exceeded, limitName, msg := evaluator.CheckLimits(sessionState.Metrics, "fail-fast")
+			if exceeded && !report.LimitExceeded {
+				report.LimitExceeded = true
+				report.LimitMessage = fmt.Sprintf("%s: %s", limitName, msg)
+			}
+		}
+
+		// PostToolUse — create and store attestation
+		if signerReady {
+			attestFile, err := createReplayAttestation(
+				signer, stateManager, sessionState,
+				action, string(decision), agentIdentity,
+			)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "[replay] Warning: attestation for action #%d failed: %v\n", action.Index, err)
+			} else if attestFile != "" {
+				result.AttestationFile = attestFile
+				report.AttestCount++
+			}
+		}
+
+		// Save state after each action
+		if err := stateManager.Save(sessionState); err != nil {
+			fmt.Fprintf(os.Stderr, "[replay] Warning: save state failed: %v\n", err)
+		}
+
+		report.SimulateResults = append(report.SimulateResults, result)
+		report.Results = append(report.Results, result.Result)
+	}
+
+	// ── Phase 3: Stop — check requiredAttestations ──
+	if len(pol.RequiredAttestations) > 0 {
+		var missing []string
+		for _, required := range pol.RequiredAttestations {
+			if !hasAttestation(report.SimulateResults, required) {
+				missing = append(missing, required)
+			}
+		}
+		if len(missing) > 0 {
+			report.StopBlocked = true
+			report.StopMessage = fmt.Sprintf("missing required attestations: %v", missing)
+		}
+	}
+
+	// ── Phase 4: SessionEnd — post-hoc limit check ──
+	if pol.Limits != nil {
+		exceeded, limitName, msg := evaluator.CheckLimits(sessionState.Metrics, "post-hoc")
+		if exceeded && !report.LimitExceeded {
+			report.LimitExceeded = true
+			report.LimitMessage = fmt.Sprintf("post-hoc: %s: %s", limitName, msg)
+		}
+	}
+
+	// Final save
+	if err := stateManager.Save(sessionState); err != nil {
+		fmt.Fprintf(os.Stderr, "[replay] Warning: final save failed: %v\n", err)
+	}
+
+	return report, nil
+}
+
+// createReplayAttestation creates a signed attestation for a replayed action.
+func createReplayAttestation(
+	signer *attestation.Signer,
+	stateManager *state.Manager,
+	sessionState *aflock.SessionState,
+	action Action,
+	decision string,
+	agentIdentity *identity.AgentIdentity,
+) (string, error) {
+	toolUseID := action.ID
+	if toolUseID == "" {
+		toolUseID = fmt.Sprintf("replay-%d", action.Index)
+	}
+
+	record := aflock.ActionRecord{
+		Timestamp: time.Now(),
+		ToolName:  action.Tool,
+		ToolUseID: toolUseID,
+		ToolInput: action.RawInput,
+		Decision:  decision,
+	}
+
+	envelope, err := signer.CreateActionAttestation(
+		context.Background(),
+		record,
+		sessionState.SessionID,
+		sessionState.Metrics,
+		agentIdentity,
+	)
+	if err != nil {
+		return "", fmt.Errorf("create attestation: %w", err)
+	}
+
+	// Store to disk
+	attestDir := stateManager.AttestationsDir(sessionState.SessionID)
+	if err := os.MkdirAll(attestDir, 0750); err != nil {
+		return "", fmt.Errorf("create attestation dir: %w", err)
+	}
+
+	prefix := toolUseID
+	if len(prefix) > 8 {
+		prefix = prefix[:8]
+	}
+	filename := fmt.Sprintf("%03d-%s-%s.intoto.json", action.Index, action.Tool, prefix)
+	path := filepath.Join(attestDir, filename)
+
+	data, err := json.MarshalIndent(envelope, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshal attestation: %w", err)
+	}
+
+	if err := os.WriteFile(path, data, 0640); err != nil {
+		return "", fmt.Errorf("write attestation: %w", err)
+	}
+
+	return path, nil
+}
+
+// hasAttestation checks if a required attestation was produced.
+func hasAttestation(results []SimulateResult, name string) bool {
+	for _, r := range results {
+		if strings.EqualFold(r.Action.Tool, name) && r.AttestationFile != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func isFileOperation(toolName string) bool {
+	switch toolName {
+	case "Read", "Write", "Edit", "Glob", "Grep", "NotebookEdit":
+		return true
+	}
+	return false
+}
+
+// parseModelVersion extracts version from model name.
+func parseModelVersion(model string) string {
+	parts := strings.Split(model, "-")
+	if len(parts) >= 4 {
+		return parts[len(parts)-2] + "." + parts[len(parts)-1] + ".0"
+	}
+	return "0.0.0"
+}
+
+// FormatSimulateText renders the simulate report.
+func (r *SimulateReport) FormatSimulateText() string {
+	var b strings.Builder
+
+	b.WriteString(r.Report.FormatText())
+
+	b.WriteString("\n")
+	b.WriteString(strings.Repeat("━", 60) + "\n")
+	b.WriteString("SIMULATION OUTPUT\n\n")
+
+	fmt.Fprintf(&b, "Session ID:   %s\n", r.SessionID)
+	fmt.Fprintf(&b, "Session Dir:  %s\n", r.SessionDir)
+	fmt.Fprintf(&b, "Attestations: %d signed\n", r.AttestCount)
+
+	if r.LimitExceeded {
+		fmt.Fprintf(&b, "Limits:       EXCEEDED — %s\n", r.LimitMessage)
+	} else {
+		b.WriteString("Limits:       within bounds\n")
+	}
+
+	if r.StopBlocked {
+		fmt.Fprintf(&b, "Stop check:   BLOCKED — %s\n", r.StopMessage)
+	} else {
+		b.WriteString("Stop check:   passed\n")
+	}
+
+	if r.AttestCount > 0 {
+		b.WriteString("\nAttestation files:\n")
+		for _, res := range r.SimulateResults {
+			if res.AttestationFile != "" {
+				fmt.Fprintf(&b, "  %s\n", filepath.Base(res.AttestationFile))
+			}
+		}
+	}
+
+	fmt.Fprintf(&b, "\nInspect:  ls %s/\n", r.SessionDir)
+	fmt.Fprintf(&b, "Verify:   aflock verify --session %s\n", r.SessionID)
+
+	return b.String()
+}


### PR DESCRIPTION
## Summary

Adds `aflock replay` command that replays recorded Claude Code sessions (.jsonl) against aflock policies deterministically. Parses every tool call from a session and evaluates it through the policy evaluator — showing what would be allowed, denied, or require approval.

## Usage
```bash                                                                                                                                                                            
  # Validate a session against a policy
  aflock replay --session session.jsonl --policy .aflock                                                                                                                             
                                                            
  # JSON output (for CI pipelines and tooling)                                                                                                                                       
  aflock replay --session session.jsonl --policy .aflock --format json
                                                                      
  # Full simulation — produces session state + signed attestations
  aflock replay --session session.jsonl --policy .aflock --simulate
```

Apart from just replay i fixed one bug into it 
`readOnly files implicitly allowed for reads: Previously, files in files.readOnly were denied for Read operations unless also listed in files.allow. Now readOnly files are         
implicitly readable — putting a file in readOnly means "allow reads, block writes" without needing to duplicate it in files.allow.`

## What it does                                                                                                                                                                       
                                                                                                                                                                                     
`Validator mode (default)`: Parses the session, runs each tool call through policy.NewEvaluator().EvaluatePreToolUse(), prints a colored report with pass/fail per action. Exit code 
  1 if violations found (CI-friendly).                                                                                                                                               
                                                            
  `Simulator mode (--simulate)`: Runs the full hook lifecycle (SessionStart → PreToolUse → PostToolUse → Stop → SessionEnd) and produces real aflock artifacts:                        
  - `~/.aflock/sessions/replay-<id>/state.json — full session state with metrics`
  - `~/.aflock/sessions/replay-<id>/attestations/*.intoto.json — signed DSSE attestations`

<img width="1113" height="751" alt="Screenshot 2026-04-04 at 4 01 19 PM" src="https://github.com/user-attachments/assets/90858ad2-15e9-4e3b-9cee-f828803b60c3" />


<img width="1470" height="756" alt="Screenshot 2026-04-04 at 4 03 26 PM" src="https://github.com/user-attachments/assets/9263c521-2f1a-448d-a98e-c8a3a7d41361" />

