### PR TITLE
fix(attestation): drop trailing @ in agentIdentity.binary when version empty

### DIFF
--- a/internal/attestation/signer.go
+++ b/internal/attestation/signer.go
@@ -240,7 +240,16 @@ func (s *Signer) CreateActionAttestation(
 			IdentityHash: agentIdentity.IdentityHash,
 		}
 		if agentIdentity.Binary != nil {
-			predicate.AgentIdentity.Binary = fmt.Sprintf("%s@%s", agentIdentity.Binary.Name, agentIdentity.Binary.Version)
+			// Version is intentionally empty on the kernel-attested path
+			// (peerBinaryIdentity leaves it unset because the digest is the
+			// authoritative version identifier). Only emit "@<version>" when
+			// we actually have one — otherwise the predicate would carry a
+			// dangling "@" suffix like "socat1@".
+			binary := agentIdentity.Binary.Name
+			if agentIdentity.Binary.Version != "" {
+				binary = agentIdentity.Binary.Name + "@" + agentIdentity.Binary.Version
+			}
+			predicate.AgentIdentity.Binary = binary
 			predicate.AgentIdentity.BinaryHash = agentIdentity.Binary.Digest
 		}
 		if agentIdentity.Environment != nil {

--- a/internal/attestation/signer.go
+++ b/internal/attestation/signer.go
@@ -240,14 +240,16 @@ func (s *Signer) CreateActionAttestation(
 			IdentityHash: agentIdentity.IdentityHash,
 		}
 		if agentIdentity.Binary != nil {
-			// Version is intentionally empty on the kernel-attested path
-			// (peerBinaryIdentity leaves it unset because the digest is the
-			// authoritative version identifier). Only emit "@<version>" when
-			// we actually have one — otherwise the predicate would carry a
-			// dangling "@" suffix like "socat1@".
+			// Format as "<name>@<version>", but only when both halves
+			// exist. Two edge cases the predicate must not produce:
+			//   - kernel-attested peer-cred path leaves Version empty
+			//     (digest is the authoritative version), so we'd otherwise
+			//     emit "socat1@" with a dangling @
+			//   - if Name resolution failed but Version was defaulted, we'd
+			//     otherwise emit a leading "@0.0.0"
 			binary := agentIdentity.Binary.Name
-			if agentIdentity.Binary.Version != "" {
-				binary = agentIdentity.Binary.Name + "@" + agentIdentity.Binary.Version
+			if binary != "" && agentIdentity.Binary.Version != "" {
+				binary = binary + "@" + agentIdentity.Binary.Version
 			}
 			predicate.AgentIdentity.Binary = binary
 			predicate.AgentIdentity.BinaryHash = agentIdentity.Binary.Digest

--- a/internal/attestation/signer_test.go
+++ b/internal/attestation/signer_test.go
@@ -956,6 +956,69 @@ func TestCreateActionAttestation_NoIdentity(t *testing.T) {
 	}
 }
 
+// TestCreateActionAttestation_BinaryWithEmptyVersion regression-tests the
+// kernel-attested peer-cred path: when the BinaryIdentity has a Name but no
+// Version (peerBinaryIdentity intentionally leaves Version empty because the
+// Digest is the authoritative version), the predicate's binary string must
+// NOT carry a dangling "@" suffix. Closes #92.
+func TestCreateActionAttestation_BinaryWithEmptyVersion(t *testing.T) {
+	signer, _, _ := newSignerWithIdentity(t)
+
+	record := aflock.ActionRecord{
+		Timestamp: time.Now(),
+		ToolName:  "Read",
+		ToolUseID: "tu_kernel_attested",
+		Decision:  "allow",
+	}
+
+	// Mirrors what peerBinaryIdentity returns for a kernel-attested peer
+	// on macOS: a real basename + digest, no version string.
+	agentID := &identity.AgentIdentity{
+		Model:        "claude-opus-4-7",
+		ModelVersion: "4.7.0",
+		Binary: &identity.BinaryIdentity{
+			Name:    "socat1",
+			Version: "",
+			Path:    "/opt/homebrew/Cellar/socat/1.8.1.0/bin/socat1",
+			Digest:  "aba6184a9a8390e048193234b027fcbf134bd5306d90c8dd429fdc214b5b40f7",
+		},
+		IdentityHash: "abcdef1234567890",
+	}
+
+	env, err := signer.CreateActionAttestation(
+		context.Background(),
+		record,
+		"session-kernel",
+		nil,
+		agentID,
+	)
+	if err != nil {
+		t.Fatalf("CreateActionAttestation: %v", err)
+	}
+
+	payloadBytes, _ := base64.StdEncoding.DecodeString(env.Payload)
+	var stmt Statement
+	if err := json.Unmarshal(payloadBytes, &stmt); err != nil {
+		t.Fatalf("unmarshal statement: %v", err)
+	}
+	predicateJSON, _ := json.Marshal(stmt.Predicate)
+	var pred ActionPredicate
+	if err := json.Unmarshal(predicateJSON, &pred); err != nil {
+		t.Fatalf("unmarshal predicate: %v", err)
+	}
+
+	if pred.AgentIdentity == nil {
+		t.Fatal("agentIdentity should not be nil")
+	}
+	if pred.AgentIdentity.Binary != "socat1" {
+		t.Errorf("binary = %q, want %q (no trailing @ when Version is empty)",
+			pred.AgentIdentity.Binary, "socat1")
+	}
+	if pred.AgentIdentity.BinaryHash == "" {
+		t.Error("binaryHash should still be populated even with empty Version")
+	}
+}
+
 func TestCreateActionAttestation_AgentIdentityWithoutBinary(t *testing.T) {
 	signer, _, _ := newSignerWithIdentity(t)
 

--- a/internal/attestation/signer_test.go
+++ b/internal/attestation/signer_test.go
@@ -1019,6 +1019,58 @@ func TestCreateActionAttestation_BinaryWithEmptyVersion(t *testing.T) {
 	}
 }
 
+// TestCreateActionAttestation_BinaryWithEmptyName guards the symmetric
+// edge case Copilot flagged on PR #93: if Name is empty but Version is
+// somehow set (e.g. discovery returns "0.0.0" default without resolving
+// a path), the predicate must NOT emit a leading "@0.0.0" — it should
+// stay empty. Closes the empty-name half of the @ formatting fix.
+func TestCreateActionAttestation_BinaryWithEmptyName(t *testing.T) {
+	signer, _, _ := newSignerWithIdentity(t)
+
+	record := aflock.ActionRecord{
+		Timestamp: time.Now(),
+		ToolName:  "Read",
+		ToolUseID: "tu_empty_name",
+		Decision:  "allow",
+	}
+
+	agentID := &identity.AgentIdentity{
+		Model: "claude-opus-4-7",
+		Binary: &identity.BinaryIdentity{
+			Name:    "",
+			Version: "0.0.0",
+			Digest:  "sha256:placeholder",
+		},
+		IdentityHash: "abcdef1234567890",
+	}
+
+	env, err := signer.CreateActionAttestation(
+		context.Background(), record, "session-empty-name", nil, agentID,
+	)
+	if err != nil {
+		t.Fatalf("CreateActionAttestation: %v", err)
+	}
+
+	payloadBytes, _ := base64.StdEncoding.DecodeString(env.Payload)
+	var stmt Statement
+	if err := json.Unmarshal(payloadBytes, &stmt); err != nil {
+		t.Fatalf("unmarshal statement: %v", err)
+	}
+	predicateJSON, _ := json.Marshal(stmt.Predicate)
+	var pred ActionPredicate
+	if err := json.Unmarshal(predicateJSON, &pred); err != nil {
+		t.Fatalf("unmarshal predicate: %v", err)
+	}
+
+	if pred.AgentIdentity == nil {
+		t.Fatal("agentIdentity should not be nil")
+	}
+	if pred.AgentIdentity.Binary != "" {
+		t.Errorf("binary = %q, want empty (no leading @ when Name is missing)",
+			pred.AgentIdentity.Binary)
+	}
+}
+
 func TestCreateActionAttestation_AgentIdentityWithoutBinary(t *testing.T) {
 	signer, _, _ := newSignerWithIdentity(t)
 


### PR DESCRIPTION
Closes #92.

Attestation predicate emitted "name@" with a trailing @ when `Binary.Version` was empty (the kernel-attested peer-cred path leaves Version empty intentionally — Digest is the authoritative version). Now mirrors the conditional already in `internal/identity/agent.go`.

```
run-mcp-spire (main) $ TMP_SOCK=$(mktemp -u)
run-mcp-spire (main) $ socat UNIX-LISTEN:"$TMP_SOCK" /dev/null &
[1] 18290
run-mcp-spire (main) $ SOCAT_PID=$!
run-mcp-spire (main) $ sleep 1
run-mcp-spire (main) $ /usr/sbin/lsof -p $SOCAT_PID -Fn | head -25
p18290
fcwd
n/Users/rahulxf/work-dir/aflock-example/peer-cred-pr88/workspace/run-mcp-spire
ftxt
n/opt/homebrew/Cellar/socat/1.8.1.0/bin/socat1
ftxt
n/opt/homebrew/Cellar/openssl@3/3.6.0/lib/libssl.3.dylib
ftxt
n/usr/lib/dyld
ftxt
n/opt/homebrew/Cellar/openssl@3/3.6.0/lib/libcrypto.3.dylib
f0
n/dev/ttys004
f1
n/dev/ttys004
f2
n/dev/ttys004
f3
n->0x17d7056f3df9db4c
f4
n->0xd027271815ff2af0
f5
n/var/folders/4h/5y3zgd4915j20mq_xjbv3bvc0000gn/T/tmp.UtGJceaYft
```

<img width="1426" height="501" alt="Screenshot 2026-05-06 at 12 43 27 AM" src="https://github.com/user-attachments/assets/ffa33b14-57a0-4047-9adc-db1333ff4924" />

```js
  Before PR #93 (today):                                                                                                                                                             
  "agentIdentity": {                                                                                           
    "binary": "socat1@",          ← name + "@" + empty version = trailing dangling @                                                                                                 
    "binaryHash": "aba6184a..."                                                                                                                                                    
  }                                                                                                                                                                                  
                                                                                                  
  After PR #93 merges:                                                                                                                                                               
  "agentIdentity": {                                                                              
    "binary": "socat1",            ← just the name, no @
    "binaryHash": "aba6184a..."                         
  }                                          

```
