### PR TITLE
fix(mcp): refuse fail-fast / warn post-hoc on limits MCP cannot enforce

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -198,6 +198,12 @@ func (s *Server) Serve(policyPath string) error {
 		}
 	}
 
+	// Refuse to start if the policy carries limits the MCP transport
+	// cannot enforce. Closes the silent-bypass UX trap (#94).
+	if err := validateMCPLimits(s.policy); err != nil {
+		return err
+	}
+
 	// Identity discovery + policy-digest binding per paper §3.1.
 	s.initAgentIdentity()
 
@@ -224,6 +230,63 @@ func (s *Server) Serve(policyPath string) error {
 
 	// Serve on stdio
 	return server.ServeStdio(s.mcpServer)
+}
+
+// validateMCPLimits guards against silently bypassed policy limits on
+// the MCP transport. The MCP protocol does not carry the agent's token
+// usage (Claude does not include it in tool/call results) or any
+// turn-boundary signal, so the metrics those limits depend on stay at
+// zero on MCP-only deployments. See issue #94.
+//
+// Behavior:
+//   - fail-fast enforcement on any of the affected limits returns an
+//     error; the server refuses to start because honoring the contract
+//     is impossible.
+//   - post-hoc enforcement logs a loud warning; verify will silently
+//     pass on these limits, but startup continues.
+//   - maxToolCalls and maxWallTimeSeconds are unaffected (those
+//     counters work on the MCP path).
+func validateMCPLimits(p *aflock.Policy) error {
+	if p == nil || p.Limits == nil {
+		return nil
+	}
+	bypassed := []struct {
+		name  string
+		limit *aflock.Limit
+	}{
+		{"maxSpendUSD", p.Limits.MaxSpendUSD},
+		{"maxTokensIn", p.Limits.MaxTokensIn},
+		{"maxTokensOut", p.Limits.MaxTokensOut},
+		{"maxTurns", p.Limits.MaxTurns},
+	}
+	var failFast []string
+	for _, e := range bypassed {
+		if e.limit == nil {
+			continue
+		}
+		// Treat empty enforcement as fail-fast — that matches the
+		// number-shorthand path in pkg/aflock/types.go's UnmarshalJSON.
+		switch e.limit.Enforcement {
+		case "post-hoc":
+			fmt.Fprintf(os.Stderr,
+				"[aflock] WARNING: policy limit %q is set to post-hoc enforcement,\n"+
+					"          but the MCP transport cannot observe token usage or\n"+
+					"          turn boundaries. The counter will stay at 0 and verify\n"+
+					"          will silently pass this limit. See issue #94.\n",
+				e.name)
+		default:
+			failFast = append(failFast, e.name)
+		}
+	}
+	if len(failFast) > 0 {
+		return fmt.Errorf(
+			"refusing to start: policy uses fail-fast enforcement on %v, but the "+
+				"MCP transport cannot observe the metrics required to enforce these "+
+				"limits (issue #94). Change enforcement to post-hoc, remove the "+
+				"limits, or run a hooks deployment instead",
+			failFast)
+	}
+	return nil
 }
 
 // projectRoot returns the directory containing the policy file.
@@ -254,6 +317,12 @@ func (s *Server) ServeHTTP(policyPath string, port int) error {
 			s.policy = pol
 			s.policyPath = path
 		}
+	}
+
+	// Refuse to start if the policy carries limits the MCP transport
+	// cannot enforce. Closes the silent-bypass UX trap (#94).
+	if err := validateMCPLimits(s.policy); err != nil {
+		return err
 	}
 
 	// Identity discovery + policy-digest binding per paper §3.1. Mirrors

--- a/internal/mcp/server_limits_test.go
+++ b/internal/mcp/server_limits_test.go
@@ -1,0 +1,124 @@
+package mcp
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/aflock-ai/aflock/pkg/aflock"
+)
+
+func TestValidateMCPLimits_NilPolicy(t *testing.T) {
+	if err := validateMCPLimits(nil); err != nil {
+		t.Errorf("nil policy should pass, got %v", err)
+	}
+}
+
+func TestValidateMCPLimits_NoLimits(t *testing.T) {
+	p := &aflock.Policy{Name: "no-limits"}
+	if err := validateMCPLimits(p); err != nil {
+		t.Errorf("policy without limits should pass, got %v", err)
+	}
+}
+
+func TestValidateMCPLimits_FailFast_Refuses(t *testing.T) {
+	cases := []struct {
+		name   string
+		policy *aflock.Policy
+	}{
+		{
+			name: "explicit fail-fast on maxSpendUSD",
+			policy: &aflock.Policy{Limits: &aflock.LimitsPolicy{
+				MaxSpendUSD: &aflock.Limit{Value: 5, Enforcement: "fail-fast"},
+			}},
+		},
+		{
+			name: "empty enforcement on maxTurns (treated as fail-fast)",
+			policy: &aflock.Policy{Limits: &aflock.LimitsPolicy{
+				MaxTurns: &aflock.Limit{Value: 50, Enforcement: ""},
+			}},
+		},
+		{
+			name: "fail-fast on maxTokensIn",
+			policy: &aflock.Policy{Limits: &aflock.LimitsPolicy{
+				MaxTokensIn: &aflock.Limit{Value: 1000, Enforcement: "fail-fast"},
+			}},
+		},
+		{
+			name: "fail-fast on maxTokensOut",
+			policy: &aflock.Policy{Limits: &aflock.LimitsPolicy{
+				MaxTokensOut: &aflock.Limit{Value: 1000, Enforcement: "fail-fast"},
+			}},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := validateMCPLimits(c.policy)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), "fail-fast") {
+				t.Errorf("error should mention fail-fast, got %q", err.Error())
+			}
+			if !strings.Contains(err.Error(), "#94") {
+				t.Errorf("error should reference issue #94, got %q", err.Error())
+			}
+		})
+	}
+}
+
+func TestValidateMCPLimits_PostHoc_Allows(t *testing.T) {
+	p := &aflock.Policy{Limits: &aflock.LimitsPolicy{
+		MaxSpendUSD: &aflock.Limit{Value: 5, Enforcement: "post-hoc"},
+		MaxTurns:    &aflock.Limit{Value: 50, Enforcement: "post-hoc"},
+	}}
+	if err := validateMCPLimits(p); err != nil {
+		t.Errorf("post-hoc should be allowed, got %v", err)
+	}
+}
+
+func TestValidateMCPLimits_SupportedLimits_Allows(t *testing.T) {
+	// MaxToolCalls and MaxWallTimeSeconds increment correctly on the
+	// MCP path; they must not trigger the bypass guard.
+	p := &aflock.Policy{Limits: &aflock.LimitsPolicy{
+		MaxToolCalls:       &aflock.Limit{Value: 100, Enforcement: "fail-fast"},
+		MaxWallTimeSeconds: &aflock.Limit{Value: 600, Enforcement: "fail-fast"},
+	}}
+	if err := validateMCPLimits(p); err != nil {
+		t.Errorf("supported limits should be allowed, got %v", err)
+	}
+}
+
+func TestValidateMCPLimits_MultipleFailFast_Aggregated(t *testing.T) {
+	p := &aflock.Policy{Limits: &aflock.LimitsPolicy{
+		MaxSpendUSD: &aflock.Limit{Value: 5, Enforcement: "fail-fast"},
+		MaxTurns:    &aflock.Limit{Value: 50, Enforcement: "fail-fast"},
+	}}
+	err := validateMCPLimits(p)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "maxSpendUSD") {
+		t.Errorf("error should list maxSpendUSD, got %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "maxTurns") {
+		t.Errorf("error should list maxTurns, got %q", err.Error())
+	}
+}
+
+func TestValidateMCPLimits_MixedEnforcement(t *testing.T) {
+	// One fail-fast (refuse) plus one post-hoc (warn) — error wins.
+	p := &aflock.Policy{Limits: &aflock.LimitsPolicy{
+		MaxSpendUSD: &aflock.Limit{Value: 5, Enforcement: "fail-fast"},
+		MaxTurns:    &aflock.Limit{Value: 50, Enforcement: "post-hoc"},
+	}}
+	err := validateMCPLimits(p)
+	if err == nil {
+		t.Fatal("expected error from fail-fast, got nil")
+	}
+	if !strings.Contains(err.Error(), "maxSpendUSD") {
+		t.Errorf("error should mention fail-fast limit, got %q", err.Error())
+	}
+	if strings.Contains(err.Error(), "maxTurns") {
+		t.Errorf("post-hoc limit should not appear in error, got %q", err.Error())
+	}
+}


### PR DESCRIPTION
Closes #94.

MCP transport cannot observe token usage or turn boundaries (Claude does not include them in tool/call results), so `maxSpendUSD` / `maxTokensIn` / `maxTokensOut` / `maxTurns` were silently bypassed. Now refuses fail-fast on these (impossible to honor) and warns on post-hoc (verify will see zero metrics). `maxToolCalls` and `maxWallTimeSeconds` are unaffected.
