### PR TITLE
fix(mcp): reuse SPIRE SVID key for JWT signing

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -3,6 +3,9 @@ package mcp
 
 import (
 	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -44,6 +47,7 @@ type Server struct {
 	// entirely to satisfy golangci-lint's unused check.)
 	signer         *attestation.Signer
 	signingEnabled bool
+	signingMode    string     // "spire", "fulcio", "ephemeral", or "" — set by initSigning, read by initAuth (#71)
 	attestDir      string     // Directory for storing step attestations by git tree hash
 	sessionMu      sync.Mutex // Protects session state access for dataFlow tracking
 
@@ -549,6 +553,7 @@ func (s *Server) initSigning() {
 
 	if err := s.signer.Initialize(ctx); err == nil {
 		s.signingEnabled = true
+		s.signingMode = "spire"
 		fmt.Fprintf(os.Stderr, "[aflock] Attestation signing: SPIRE\n")
 		// Note: trusted-model enforcement happens in the policy evaluator via
 		// identity.allowedModels at SessionStart (issue #67 review). We no
@@ -559,25 +564,41 @@ func (s *Server) initSigning() {
 
 	if err := s.signer.InitializeFulcio(ctx); err == nil {
 		s.signingEnabled = true
+		s.signingMode = "fulcio"
 		fmt.Fprintf(os.Stderr, "[aflock] Attestation signing: Fulcio (keyless)\n")
 		return
 	}
 
 	if err := s.signer.InitializeEphemeral(identityHash); err == nil {
 		s.signingEnabled = true
+		s.signingMode = "ephemeral"
 		fmt.Fprintf(os.Stderr, "[aflock] Attestation signing: ephemeral key\n")
 		return
 	}
 
 	s.signingEnabled = false
+	s.signingMode = ""
 	fmt.Fprintf(os.Stderr, "[aflock] Warning: attestation signing unavailable (SPIRE, Fulcio, and ephemeral all failed)\n")
 }
 
-// initAuth initializes the JWT token issuer. If SPIRE is available and provides
-// a signing key, it is used; otherwise an ephemeral ECDSA P-256 key is generated.
+// initAuth initializes the JWT token issuer. When SPIRE is the active
+// signing source, the SVID's ECDSA P-256 key is reused so the JWT shares
+// the agent's SPIFFE identity (paper §3.2, issue #71). Fulcio is skipped
+// because its cert TTL (~10 min) is shorter than typical JWT TTLs. The
+// ephemeral attestation key is process-scoped just like a fresh JWT key,
+// so a separate ephemeral key is fine there.
 func (s *Server) initAuth() error {
-	// For now, always use ephemeral key. When SPIRE integration provides a
-	// crypto.Signer, use auth.NewTokenIssuerFromSigner instead.
+	if s.signingMode == "spire" && s.signer != nil {
+		if id, _ := s.signer.GetSigningIdentity(); id != nil {
+			if priv, ok := id.PrivateKey.(crypto.Signer); ok {
+				if ecPub, ok := priv.Public().(*ecdsa.PublicKey); ok && ecPub.Curve == elliptic.P256() {
+					s.tokenIssuer = auth.NewTokenIssuerFromSigner(priv, id.SPIFFEID.String())
+					return nil
+				}
+				fmt.Fprintf(os.Stderr, "[aflock] JWT: SPIRE SVID is not ECDSA P-256, falling back to ephemeral JWT key\n")
+			}
+		}
+	}
 	issuer, err := auth.NewTokenIssuer()
 	if err != nil {
 		return fmt.Errorf("create token issuer: %w", err)

--- a/internal/mcp/server_initauth_test.go
+++ b/internal/mcp/server_initauth_test.go
@@ -1,0 +1,97 @@
+package mcp
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/aflock-ai/aflock/internal/attestation"
+)
+
+// TestInitAuth_ReusesSPIRESigner exercises issue #71: when SPIRE is the
+// active signing source, the JWT signer must reuse the SPIRE SVID key
+// instead of generating a fresh ephemeral key. We construct a Signer via
+// InitializeEphemeral (which produces a real ECDSA P-256 identity) and
+// then force signingMode="spire" to drive the reuse path.
+func TestInitAuth_ReusesSPIRESigner(t *testing.T) {
+	s := newTestServer(t)
+	s.signer = attestation.NewSigner("")
+	if err := s.signer.InitializeEphemeral("test-identity-hash"); err != nil {
+		t.Fatalf("init signer: %v", err)
+	}
+	s.signingMode = "spire"
+
+	if err := s.initAuth(); err != nil {
+		t.Fatalf("initAuth: %v", err)
+	}
+
+	id, _ := s.signer.GetSigningIdentity()
+	if id == nil {
+		t.Fatal("signer returned nil identity")
+	}
+	wantKID := id.SPIFFEID.String()
+	if got := s.tokenIssuer.KeyID(); got != wantKID {
+		t.Errorf("kid = %q, want SPIFFE ID %q (JWT did not adopt SPIRE key)", got, wantKID)
+	}
+	if s.tokenIssuer.PublicKey() == nil {
+		t.Error("tokenIssuer.PublicKey() is nil")
+	}
+}
+
+// TestInitAuth_EphemeralModeDoesNotReuse confirms that when attestation
+// signing fell back to ephemeral, the JWT issuer also gets its own
+// ephemeral key (current behavior preserved — no key sharing).
+func TestInitAuth_EphemeralModeDoesNotReuse(t *testing.T) {
+	s := newTestServer(t)
+	s.signer = attestation.NewSigner("")
+	if err := s.signer.InitializeEphemeral("test-identity-hash"); err != nil {
+		t.Fatalf("init signer: %v", err)
+	}
+	s.signingMode = "ephemeral"
+
+	if err := s.initAuth(); err != nil {
+		t.Fatalf("initAuth: %v", err)
+	}
+
+	if got := s.tokenIssuer.KeyID(); got != "ephemeral-ecdsa-p256" {
+		t.Errorf("kid = %q, want %q (ephemeral mode must use fresh JWT key)", got, "ephemeral-ecdsa-p256")
+	}
+}
+
+// TestInitAuth_FulcioModeDoesNotReuse confirms Fulcio is skipped: its
+// cert TTL (~10 min) is shorter than typical JWT TTLs, so the JWT keeps
+// its own ephemeral key.
+func TestInitAuth_FulcioModeDoesNotReuse(t *testing.T) {
+	s := newTestServer(t)
+	s.signer = attestation.NewSigner("")
+	if err := s.signer.InitializeEphemeral("test-identity-hash"); err != nil {
+		t.Fatalf("init signer: %v", err)
+	}
+	s.signingMode = "fulcio"
+
+	if err := s.initAuth(); err != nil {
+		t.Fatalf("initAuth: %v", err)
+	}
+
+	if got := s.tokenIssuer.KeyID(); got != "ephemeral-ecdsa-p256" {
+		t.Errorf("kid = %q, want %q (fulcio mode must keep ephemeral JWT key)", got, "ephemeral-ecdsa-p256")
+	}
+}
+
+// TestInitAuth_NoSignerFallsBackToEphemeral confirms the no-signer path
+// (signingMode unset, signer nil) still produces a working ephemeral
+// issuer — preserves backward compatibility for callers that don't run
+// initSigning at all (tests, edge cases).
+func TestInitAuth_NoSignerFallsBackToEphemeral(t *testing.T) {
+	s := newTestServer(t)
+
+	if err := s.initAuth(); err != nil {
+		t.Fatalf("initAuth: %v", err)
+	}
+
+	if s.tokenIssuer == nil {
+		t.Fatal("tokenIssuer is nil")
+	}
+	if got := s.tokenIssuer.KeyID(); !strings.HasPrefix(got, "ephemeral") {
+		t.Errorf("kid = %q, want ephemeral-prefixed", got)
+	}
+}


### PR DESCRIPTION
`initAuth` always created a fresh ephemeral key, so the JWT signing identity diverged from the SPIRE-backed attestation identity (paper §3.2 says they should be the same).

Now reuses the SVID's ECDSA P-256 key as the JWT signer when `signingMode == "spire"`, so JWT `kid` = SPIFFE ID. Fulcio is skipped (cert TTL too short). Ephemeral path unchanged.

Closes #71