### PR TITLE
feat(hooks): validate JWT in PreToolUse via persisted public key

### DIFF
--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -16,8 +16,10 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/sha256"
+	"crypto/x509"
 	"encoding/hex"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"time"
 
@@ -248,6 +250,36 @@ func ComputePolicyDigest(pol *aflock.Policy) string {
 // PublicKey returns the issuer's public key (useful for testing/debugging).
 func (ti *TokenIssuer) PublicKey() crypto.PublicKey {
 	return ti.publicKey
+}
+
+// MarshalPublicKey returns the issuer's public key as PEM-encoded PKIX bytes.
+// Used by hooks mode to persist the validation key across PreToolUse
+// subprocesses — the private key dies with the SessionStart process, but the
+// public key on disk lets a separate hook process validate the JWT (issue #48).
+func (ti *TokenIssuer) MarshalPublicKey() ([]byte, error) {
+	der, err := x509.MarshalPKIXPublicKey(ti.publicKey)
+	if err != nil {
+		return nil, fmt.Errorf("marshal public key: %w", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der}), nil
+}
+
+// NewTokenIssuerFromPublicKey reconstructs a validation-only TokenIssuer from
+// PEM-encoded public key bytes produced by MarshalPublicKey. The returned
+// issuer can validate tokens but cannot sign new ones (no private key).
+func NewTokenIssuerFromPublicKey(pemData []byte) (*TokenIssuer, error) {
+	block, _ := pem.Decode(pemData)
+	if block == nil {
+		return nil, fmt.Errorf("no PEM block in public key data")
+	}
+	pub, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse public key: %w", err)
+	}
+	if _, ok := pub.(*ecdsa.PublicKey); !ok {
+		return nil, fmt.Errorf("public key is not ECDSA: %T", pub)
+	}
+	return &TokenIssuer{publicKey: pub}, nil
 }
 
 // KeyID returns the key identifier.

--- a/internal/auth/jwt_test.go
+++ b/internal/auth/jwt_test.go
@@ -287,3 +287,65 @@ func TestNewTokenIssuerFromSigner(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "a1", claims.AgentID)
 }
+
+// TestPublicKeyRoundtrip exercises issue #48: hooks mode persists the JWT
+// public key to disk so a separate PreToolUse subprocess can validate the
+// token. Marshal → Parse must reproduce a working validation-only issuer.
+func TestPublicKeyRoundtrip(t *testing.T) {
+	signer, err := NewTokenIssuer()
+	require.NoError(t, err)
+
+	tokenStr, err := signer.IssueToken("s1", "a1", "h1", nil, time.Hour)
+	require.NoError(t, err)
+
+	pemBytes, err := signer.MarshalPublicKey()
+	require.NoError(t, err)
+	assert.Contains(t, string(pemBytes), "-----BEGIN PUBLIC KEY-----")
+
+	validator, err := NewTokenIssuerFromPublicKey(pemBytes)
+	require.NoError(t, err)
+
+	// The cross-process validator accepts tokens issued by the original signer.
+	claims, err := validator.ValidateToken(tokenStr)
+	require.NoError(t, err)
+	assert.Equal(t, "a1", claims.AgentID)
+}
+
+// TestNewTokenIssuerFromPublicKey_RejectsTamperedPEM guards the parser
+// against malformed inputs that could otherwise turn into nil-pointer
+// surprises during validation.
+func TestNewTokenIssuerFromPublicKey_RejectsTamperedPEM(t *testing.T) {
+	cases := map[string][]byte{
+		"empty":       []byte(""),
+		"not pem":     []byte("not a pem block"),
+		"empty block": []byte("-----BEGIN PUBLIC KEY-----\n-----END PUBLIC KEY-----\n"),
+	}
+	for name, data := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := NewTokenIssuerFromPublicKey(data)
+			assert.Error(t, err)
+		})
+	}
+}
+
+// TestValidatorRejectsForeignToken — a token issued by a different signer
+// must fail validation, even though both keys are valid ECDSA P-256. This
+// is the security claim of the hooks-mode design: an attacker who swaps
+// the persisted pubkey file invalidates the existing token.
+func TestValidatorRejectsForeignToken(t *testing.T) {
+	signerA, err := NewTokenIssuer()
+	require.NoError(t, err)
+	signerB, err := NewTokenIssuer()
+	require.NoError(t, err)
+
+	tokenA, err := signerA.IssueToken("s1", "a1", "h1", nil, time.Hour)
+	require.NoError(t, err)
+
+	pemB, err := signerB.MarshalPublicKey()
+	require.NoError(t, err)
+	validatorB, err := NewTokenIssuerFromPublicKey(pemB)
+	require.NoError(t, err)
+
+	_, err = validatorB.ValidateToken(tokenA)
+	assert.Error(t, err)
+}

--- a/internal/hooks/handler.go
+++ b/internal/hooks/handler.go
@@ -209,6 +209,21 @@ func (h *Handler) handleSessionStart(input *aflock.HookInput) error {
 		} else {
 			sessionState.AuthToken = token
 			fmt.Fprintf(os.Stderr, "[aflock] JWT issued for session %s (ttl=%s)\n", input.SessionID, ttl)
+
+			// Persist the public key alongside the session so PreToolUse — a
+			// separate subprocess that has no in-memory access to the signer —
+			// can validate this token (issue #48). Best-effort: a write failure
+			// downgrades to policy-only enforcement, with a stderr warning.
+			if pubPEM, marshalErr := issuer.MarshalPublicKey(); marshalErr != nil {
+				fmt.Fprintf(os.Stderr, "[aflock] Warning: marshal JWT public key: %v\n", marshalErr)
+			} else {
+				sessionDir := h.stateManager.SessionDir(input.SessionID)
+				if mkErr := os.MkdirAll(sessionDir, 0700); mkErr != nil {
+					fmt.Fprintf(os.Stderr, "[aflock] Warning: create session dir for JWT pubkey: %v\n", mkErr)
+				} else if writeErr := os.WriteFile(filepath.Join(sessionDir, "jwt-pubkey.pem"), pubPEM, 0600); writeErr != nil {
+					fmt.Fprintf(os.Stderr, "[aflock] Warning: write JWT public key: %v\n", writeErr)
+				}
+			}
 		}
 	}
 
@@ -355,6 +370,41 @@ func (h *Handler) handlePreToolUse(input *aflock.HookInput) error {
 	if pol.IsExpired() {
 		return output.Write(output.PreToolUseDeny(fmt.Sprintf("[aflock] BLOCKED: policy '%s' expired at %s", pol.Name, pol.Expires.Format(time.RFC3339))))
 	}
+
+	// Validate the session JWT (#48). The signing key dies with the
+	// SessionStart subprocess, so we reconstruct a validation-only issuer
+	// from the public key persisted next to state.json. If the pubkey file
+	// is missing — pre-existing sessions, or SessionStart failed to write
+	// it — we fall through to policy-only enforcement (preserves backward
+	// compatibility on upgrade). All other failures are deny.
+	if sessionState.AuthToken != "" && input.SessionID != "" {
+		pubKeyPath := filepath.Join(h.stateManager.SessionDir(input.SessionID), "jwt-pubkey.pem")
+		pubPEM, readErr := os.ReadFile(pubKeyPath) //nolint:gosec // G304: path under managed state dir
+		switch {
+		case os.IsNotExist(readErr):
+			// Legacy session — fall through, no JWT enforcement.
+		case readErr != nil:
+			return output.Write(output.PreToolUseDeny(
+				fmt.Sprintf("[aflock] BLOCKED: read JWT public key: %v", readErr)))
+		default:
+			validator, valErr := auth.NewTokenIssuerFromPublicKey(pubPEM)
+			if valErr != nil {
+				return output.Write(output.PreToolUseDeny(
+					fmt.Sprintf("[aflock] BLOCKED: parse JWT public key: %v", valErr)))
+			}
+			claims, valErr := validator.ValidateTokenForSessionAndPolicy(
+				sessionState.AuthToken, input.SessionID, auth.ComputePolicyDigest(pol))
+			if valErr != nil {
+				return output.Write(output.PreToolUseDeny(
+					fmt.Sprintf("[aflock] BLOCKED: JWT validation failed: %v", valErr)))
+			}
+			if !auth.IsToolAllowed(input.ToolName, claims.AllowedTools, claims.DeniedTools) {
+				return output.Write(output.PreToolUseDeny(
+					fmt.Sprintf("[aflock] BLOCKED: tool '%s' not permitted by JWT scope", input.ToolName)))
+			}
+		}
+	}
+
 	// Use cwd as projectRoot when policy path is outside cwd (e.g., AFLOCK_POLICY env var
 	// pointing to a tenant-specific policy in a subdirectory). Otherwise use the policy
 	// file's directory (standard case where .aflock is at project root).

--- a/internal/hooks/handler_jwt_test.go
+++ b/internal/hooks/handler_jwt_test.go
@@ -1,0 +1,182 @@
+package hooks
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aflock-ai/aflock/internal/auth"
+	"github.com/aflock-ai/aflock/pkg/aflock"
+)
+
+// issueTokenForSession issues a session-bound JWT and writes the matching
+// public key to the session directory. Mirrors what handleSessionStart now
+// produces, but lets tests assemble it directly without going through
+// stdin-based hook plumbing.
+func issueTokenForSession(t *testing.T, h *Handler, sessionID string, pol *aflock.Policy) string {
+	t.Helper()
+	issuer, err := auth.NewTokenIssuer()
+	if err != nil {
+		t.Fatalf("issuer: %v", err)
+	}
+	token, err := issuer.IssueToken(sessionID, "a1", "h1", pol, time.Hour)
+	if err != nil {
+		t.Fatalf("issue token: %v", err)
+	}
+	pubPEM, err := issuer.MarshalPublicKey()
+	if err != nil {
+		t.Fatalf("marshal pubkey: %v", err)
+	}
+	dir := h.stateManager.SessionDir(sessionID)
+	if mkErr := os.MkdirAll(dir, 0700); mkErr != nil {
+		t.Fatalf("mkdir: %v", mkErr)
+	}
+	if writeErr := os.WriteFile(filepath.Join(dir, "jwt-pubkey.pem"), pubPEM, 0600); writeErr != nil {
+		t.Fatalf("write pubkey: %v", writeErr)
+	}
+	return token
+}
+
+func decisionFromOutput(t *testing.T, raw string) (aflock.PermissionDecision, string) {
+	t.Helper()
+	var out aflock.HookOutput
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		t.Fatalf("parse output: %v (raw: %s)", err, raw)
+	}
+	if out.HookSpecificOutput == nil {
+		t.Fatalf("expected hookSpecificOutput, got: %s", raw)
+	}
+	return out.HookSpecificOutput.PermissionDecision, out.HookSpecificOutput.PermissionDecisionReason
+}
+
+// TestPreToolUse_JWTValid_AllowedTool — the happy path. A valid JWT whose
+// allowed_tools include the requested tool must allow the call.
+func TestPreToolUse_JWTValid_AllowedTool(t *testing.T) {
+	h := newTestHandler(t)
+	pol := &aflock.Policy{
+		Name:  "jwt-happy",
+		Tools: &aflock.ToolsPolicy{Allow: []string{"Read", "Bash"}},
+	}
+	ss := seedSession(t, h, "session-jwt-happy", pol)
+	ss.AuthToken = issueTokenForSession(t, h, "session-jwt-happy", pol)
+	if err := h.stateManager.Save(ss); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	got := captureStdout(t, func() {
+		_ = h.handlePreToolUse(&aflock.HookInput{
+			SessionID: "session-jwt-happy",
+			ToolName:  "Read",
+			ToolInput: json.RawMessage(`{"file_path":"main.go"}`),
+		})
+	})
+	dec, _ := decisionFromOutput(t, got)
+	if dec != aflock.DecisionAllow {
+		t.Errorf("expected allow, got %v (raw: %s)", dec, got)
+	}
+}
+
+// TestPreToolUse_JWTValid_ToolOutOfScope — the JWT is valid, but the
+// requested tool is not in allowed_tools. The fix must reject this
+// before the policy evaluator runs, which is the *whole point* of #48:
+// the JWT scope is enforced at runtime, not just embedded.
+func TestPreToolUse_JWTValid_ToolOutOfScope(t *testing.T) {
+	h := newTestHandler(t)
+	pol := &aflock.Policy{
+		Name:  "jwt-scope",
+		Tools: &aflock.ToolsPolicy{Allow: []string{"Read"}},
+	}
+	ss := seedSession(t, h, "session-jwt-scope", pol)
+	ss.AuthToken = issueTokenForSession(t, h, "session-jwt-scope", pol)
+	if err := h.stateManager.Save(ss); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	got := captureStdout(t, func() {
+		_ = h.handlePreToolUse(&aflock.HookInput{
+			SessionID: "session-jwt-scope",
+			ToolName:  "Bash", // not in allowed_tools
+			ToolInput: json.RawMessage(`{"command":"ls"}`),
+		})
+	})
+	dec, reason := decisionFromOutput(t, got)
+	if dec != aflock.DecisionDeny {
+		t.Fatalf("expected deny, got %v (raw: %s)", dec, got)
+	}
+	if !strings.Contains(reason, "JWT scope") {
+		t.Errorf("expected JWT scope reason, got: %s", reason)
+	}
+}
+
+// TestPreToolUse_JWTTampered — flipping a single byte in the signature
+// must fail validation. Uses a known invalid character to avoid producing
+// another valid base64url string by accident.
+func TestPreToolUse_JWTTampered(t *testing.T) {
+	h := newTestHandler(t)
+	pol := &aflock.Policy{
+		Name:  "jwt-tamper",
+		Tools: &aflock.ToolsPolicy{Allow: []string{"Read"}},
+	}
+	ss := seedSession(t, h, "session-jwt-tamper", pol)
+	token := issueTokenForSession(t, h, "session-jwt-tamper", pol)
+
+	// Corrupt the signature segment (after the second dot).
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		t.Fatalf("expected 3-part JWT, got %d", len(parts))
+	}
+	parts[2] = parts[2][:len(parts[2])-2] + "AA"
+	ss.AuthToken = strings.Join(parts, ".")
+	if err := h.stateManager.Save(ss); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	got := captureStdout(t, func() {
+		_ = h.handlePreToolUse(&aflock.HookInput{
+			SessionID: "session-jwt-tamper",
+			ToolName:  "Read",
+			ToolInput: json.RawMessage(`{"file_path":"main.go"}`),
+		})
+	})
+	dec, reason := decisionFromOutput(t, got)
+	if dec != aflock.DecisionDeny {
+		t.Fatalf("expected deny on tampered JWT, got %v (raw: %s)", dec, got)
+	}
+	if !strings.Contains(reason, "JWT validation failed") {
+		t.Errorf("expected validation-failed reason, got: %s", reason)
+	}
+}
+
+// TestPreToolUse_JWTPubKeyMissing — backward-compat for upgrades. A
+// session with AuthToken set but no jwt-pubkey.pem on disk (because it
+// was created by an older aflock) must NOT block. We log a warning and
+// fall through to policy-only enforcement.
+func TestPreToolUse_JWTPubKeyMissing(t *testing.T) {
+	h := newTestHandler(t)
+	pol := &aflock.Policy{
+		Name:  "jwt-legacy",
+		Tools: &aflock.ToolsPolicy{Allow: []string{"Read"}},
+	}
+	ss := seedSession(t, h, "session-jwt-legacy", pol)
+	// Set token but DO NOT write jwt-pubkey.pem — the legacy upgrade case.
+	ss.AuthToken = "eyJsZWdhY3kiOiJ0b2tlbiJ9.x.y"
+	if err := h.stateManager.Save(ss); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	got := captureStdout(t, func() {
+		_ = h.handlePreToolUse(&aflock.HookInput{
+			SessionID: "session-jwt-legacy",
+			ToolName:  "Read",
+			ToolInput: json.RawMessage(`{"file_path":"main.go"}`),
+		})
+	})
+	dec, _ := decisionFromOutput(t, got)
+	// Falls through to policy: Read is allowed by policy → allow.
+	if dec != aflock.DecisionAllow {
+		t.Errorf("expected allow (legacy session, policy permits), got %v (raw: %s)", dec, got)
+	}
+}


### PR DESCRIPTION
Hooks mode issued a JWT at SessionStart but never validated it — the ephemeral signing key died with the SessionStart subprocess, so PreToolUse had nothing to verify against.

SessionStart now persists the ECDSA public key to `<session-dir>/jwt-pubkey.pem` (0600). PreToolUse reconstructs a validation-only issuer from it and rejects tampered tokens or out-of-scope tool calls before policy evaluation. Missing pubkey file → graceful fallback for legacy sessions on upgrade.

Closes #48
Closes #39 (duplicate of #48)