### PR TITLE
feat(attestation): bind JWT claims to action attestation predicate

### DIFF
--- a/internal/attestation/jwt_binding_test.go
+++ b/internal/attestation/jwt_binding_test.go
@@ -1,0 +1,134 @@
+package attestation
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/aflock-ai/aflock/pkg/aflock"
+)
+
+// TestActionAttestation_NoJWTBinding — backward-compat path. Existing
+// callers that omit the JWT binding still produce an attestation with no
+// jwtBinding field in the predicate.
+func TestActionAttestation_NoJWTBinding(t *testing.T) {
+	signer := NewSigner("")
+	if err := signer.InitializeEphemeral("hash-1"); err != nil {
+		t.Fatalf("init signer: %v", err)
+	}
+	defer signer.Close() //nolint:errcheck
+
+	rec := aflock.ActionRecord{
+		Timestamp: time.Now(),
+		ToolName:  "Read",
+		ToolUseID: "tu-1",
+		Decision:  "allow",
+	}
+	env, err := signer.CreateActionAttestation(context.Background(), rec, "session-no-jwt", nil, nil)
+	if err != nil {
+		t.Fatalf("CreateActionAttestation: %v", err)
+	}
+
+	pred := decodePredicate(t, env)
+	if pred.JWTBinding != nil {
+		t.Errorf("expected no jwtBinding when binding arg omitted, got %+v", pred.JWTBinding)
+	}
+}
+
+// TestActionAttestation_WithJWTBinding — issue #40 happy path. The
+// supplied binding must round-trip into the predicate verbatim so a
+// downstream verifier can prove the action was authorized by a token
+// with the listed scope.
+func TestActionAttestation_WithJWTBinding(t *testing.T) {
+	signer := NewSigner("")
+	if err := signer.InitializeEphemeral("hash-2"); err != nil {
+		t.Fatalf("init signer: %v", err)
+	}
+	defer signer.Close() //nolint:errcheck
+
+	binding := &JWTBinding{
+		SessionID:    "session-abc",
+		JTI:          "jti-1",
+		KeyID:        "spiffe://aflock.local/agent/aflock",
+		PolicyDigest: "deadbeef",
+		TokenSHA256:  "feedface",
+		AllowedTools: []string{"Read", "Bash"},
+		DeniedTools:  []string{"WebFetch"},
+	}
+	rec := aflock.ActionRecord{
+		Timestamp: time.Now(),
+		ToolName:  "Bash",
+		ToolUseID: "tu-2",
+		Decision:  "allow",
+	}
+	env, err := signer.CreateActionAttestation(context.Background(), rec, "session-abc", nil, nil, binding)
+	if err != nil {
+		t.Fatalf("CreateActionAttestation: %v", err)
+	}
+
+	pred := decodePredicate(t, env)
+	if pred.JWTBinding == nil {
+		t.Fatal("expected jwtBinding in predicate, got nil")
+	}
+	if pred.JWTBinding.JTI != "jti-1" {
+		t.Errorf("jti = %q, want %q", pred.JWTBinding.JTI, "jti-1")
+	}
+	if pred.JWTBinding.KeyID != binding.KeyID {
+		t.Errorf("kid = %q, want %q", pred.JWTBinding.KeyID, binding.KeyID)
+	}
+	if pred.JWTBinding.TokenSHA256 != "feedface" {
+		t.Errorf("tokenSha256 = %q, want %q", pred.JWTBinding.TokenSHA256, "feedface")
+	}
+	if len(pred.JWTBinding.AllowedTools) != 2 || pred.JWTBinding.AllowedTools[0] != "Read" {
+		t.Errorf("allowedTools mismatch: %v", pred.JWTBinding.AllowedTools)
+	}
+	if len(pred.JWTBinding.DeniedTools) != 1 || pred.JWTBinding.DeniedTools[0] != "WebFetch" {
+		t.Errorf("deniedTools mismatch: %v", pred.JWTBinding.DeniedTools)
+	}
+}
+
+// TestCreateActionAttestation_TooManyBindingsPanics guards the variadic
+// abuse case. The "0 or 1" semantics is enforced via panic so a future
+// caller doesn't silently get the first binding while ignoring others.
+func TestCreateActionAttestation_TooManyBindingsPanics(t *testing.T) {
+	signer := NewSigner("")
+	if err := signer.InitializeEphemeral("hash-3"); err != nil {
+		t.Fatalf("init signer: %v", err)
+	}
+	defer signer.Close() //nolint:errcheck
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic when supplying multiple bindings")
+		}
+	}()
+	a := &JWTBinding{SessionID: "a"}
+	b := &JWTBinding{SessionID: "b"}
+	_, _ = signer.CreateActionAttestation(
+		context.Background(),
+		aflock.ActionRecord{ToolName: "X"},
+		"s",
+		nil,
+		nil,
+		a, b,
+	)
+}
+
+// decodePredicate base64-decodes the DSSE payload and parses it as an
+// ActionPredicate so tests can assert on the embedded fields.
+func decodePredicate(t *testing.T, env *Envelope) *ActionPredicate {
+	t.Helper()
+	payload, err := base64.StdEncoding.DecodeString(env.Payload)
+	if err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	var stmt struct {
+		Predicate ActionPredicate `json:"predicate"`
+	}
+	if err := json.Unmarshal(payload, &stmt); err != nil {
+		t.Fatalf("unmarshal statement: %v", err)
+	}
+	return &stmt.Predicate
+}

--- a/internal/attestation/signer.go
+++ b/internal/attestation/signer.go
@@ -165,6 +165,22 @@ type ActionPredicate struct {
 	AgentID       string                 `json:"agentId,omitempty"`
 	AgentIdentity *TransitiveIdentity    `json:"agentIdentity,omitempty"`
 	Metrics       *MetricsPredicate      `json:"metrics,omitempty"`
+	JWTBinding    *JWTBinding            `json:"jwtBinding,omitempty"`
+}
+
+// JWTBinding records the authorization context that permitted this action,
+// closing the issue #40 gap where JWT claims were not embedded in the
+// resulting attestation. A reviewer can prove the action was signed only
+// because the agent presented a token with the listed scope, and can
+// cross-reference the token digest with their own audit log.
+type JWTBinding struct {
+	SessionID    string   `json:"sessionId"`
+	JTI          string   `json:"jti"`
+	KeyID        string   `json:"kid,omitempty"`
+	PolicyDigest string   `json:"policyDigest,omitempty"`
+	TokenSHA256  string   `json:"tokenSha256"` // hex digest, NOT the token
+	AllowedTools []string `json:"allowedTools,omitempty"`
+	DeniedTools  []string `json:"deniedTools,omitempty"`
 }
 
 // TransitiveIdentity represents the full transitive agent identity.
@@ -202,13 +218,29 @@ type Signature struct {
 }
 
 // CreateActionAttestation creates an attestation for an action.
+//
+// jwtBindings is a 0-or-1 variadic so legacy callers (replay, tests, hook
+// paths that did not present a token) compile unchanged. When a binding is
+// supplied, it is embedded in the predicate so verifiers can confirm the
+// action was signed only because a JWT with the listed scope was
+// presented (issue #40). Passing more than one binding is a programming
+// error and panics.
 func (s *Signer) CreateActionAttestation(
 	ctx context.Context,
 	record aflock.ActionRecord,
 	sessionID string,
 	metrics *aflock.SessionMetrics,
 	agentIdentity *identity.AgentIdentity,
+	jwtBindings ...*JWTBinding,
 ) (*Envelope, error) {
+	if len(jwtBindings) > 1 {
+		panic("CreateActionAttestation: at most one JWTBinding allowed")
+	}
+	var jwtBinding *JWTBinding
+	if len(jwtBindings) == 1 {
+		jwtBinding = jwtBindings[0]
+	}
+
 	// Parse tool input (best-effort, ignore errors)
 	var toolInput map[string]interface{}
 	if record.ToolInput != nil {
@@ -217,14 +249,15 @@ func (s *Signer) CreateActionAttestation(
 
 	// Build predicate
 	predicate := ActionPredicate{
-		Action:    "tool_call",
-		SessionID: sessionID,
-		ToolName:  record.ToolName,
-		ToolUseID: record.ToolUseID,
-		ToolInput: toolInput,
-		Decision:  record.Decision,
-		Reason:    record.Reason,
-		Timestamp: record.Timestamp,
+		Action:     "tool_call",
+		SessionID:  sessionID,
+		ToolName:   record.ToolName,
+		ToolUseID:  record.ToolUseID,
+		ToolInput:  toolInput,
+		Decision:   record.Decision,
+		Reason:     record.Reason,
+		Timestamp:  record.Timestamp,
+		JWTBinding: jwtBinding,
 	}
 
 	if s.identity != nil {

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -16,8 +16,10 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/sha256"
+	"crypto/x509"
 	"encoding/hex"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"time"
 
@@ -248,6 +250,36 @@ func ComputePolicyDigest(pol *aflock.Policy) string {
 // PublicKey returns the issuer's public key (useful for testing/debugging).
 func (ti *TokenIssuer) PublicKey() crypto.PublicKey {
 	return ti.publicKey
+}
+
+// MarshalPublicKey returns the issuer's public key as PEM-encoded PKIX bytes.
+// Used by hooks mode to persist the validation key across PreToolUse
+// subprocesses — the private key dies with the SessionStart process, but the
+// public key on disk lets a separate hook process validate the JWT (issue #48).
+func (ti *TokenIssuer) MarshalPublicKey() ([]byte, error) {
+	der, err := x509.MarshalPKIXPublicKey(ti.publicKey)
+	if err != nil {
+		return nil, fmt.Errorf("marshal public key: %w", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der}), nil
+}
+
+// NewTokenIssuerFromPublicKey reconstructs a validation-only TokenIssuer from
+// PEM-encoded public key bytes produced by MarshalPublicKey. The returned
+// issuer can validate tokens but cannot sign new ones (no private key).
+func NewTokenIssuerFromPublicKey(pemData []byte) (*TokenIssuer, error) {
+	block, _ := pem.Decode(pemData)
+	if block == nil {
+		return nil, fmt.Errorf("no PEM block in public key data")
+	}
+	pub, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse public key: %w", err)
+	}
+	if _, ok := pub.(*ecdsa.PublicKey); !ok {
+		return nil, fmt.Errorf("public key is not ECDSA: %T", pub)
+	}
+	return &TokenIssuer{publicKey: pub}, nil
 }
 
 // KeyID returns the key identifier.

--- a/internal/auth/jwt_test.go
+++ b/internal/auth/jwt_test.go
@@ -287,3 +287,65 @@ func TestNewTokenIssuerFromSigner(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "a1", claims.AgentID)
 }
+
+// TestPublicKeyRoundtrip exercises issue #48: hooks mode persists the JWT
+// public key to disk so a separate PreToolUse subprocess can validate the
+// token. Marshal → Parse must reproduce a working validation-only issuer.
+func TestPublicKeyRoundtrip(t *testing.T) {
+	signer, err := NewTokenIssuer()
+	require.NoError(t, err)
+
+	tokenStr, err := signer.IssueToken("s1", "a1", "h1", nil, time.Hour)
+	require.NoError(t, err)
+
+	pemBytes, err := signer.MarshalPublicKey()
+	require.NoError(t, err)
+	assert.Contains(t, string(pemBytes), "-----BEGIN PUBLIC KEY-----")
+
+	validator, err := NewTokenIssuerFromPublicKey(pemBytes)
+	require.NoError(t, err)
+
+	// The cross-process validator accepts tokens issued by the original signer.
+	claims, err := validator.ValidateToken(tokenStr)
+	require.NoError(t, err)
+	assert.Equal(t, "a1", claims.AgentID)
+}
+
+// TestNewTokenIssuerFromPublicKey_RejectsTamperedPEM guards the parser
+// against malformed inputs that could otherwise turn into nil-pointer
+// surprises during validation.
+func TestNewTokenIssuerFromPublicKey_RejectsTamperedPEM(t *testing.T) {
+	cases := map[string][]byte{
+		"empty":       []byte(""),
+		"not pem":     []byte("not a pem block"),
+		"empty block": []byte("-----BEGIN PUBLIC KEY-----\n-----END PUBLIC KEY-----\n"),
+	}
+	for name, data := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := NewTokenIssuerFromPublicKey(data)
+			assert.Error(t, err)
+		})
+	}
+}
+
+// TestValidatorRejectsForeignToken — a token issued by a different signer
+// must fail validation, even though both keys are valid ECDSA P-256. This
+// is the security claim of the hooks-mode design: an attacker who swaps
+// the persisted pubkey file invalidates the existing token.
+func TestValidatorRejectsForeignToken(t *testing.T) {
+	signerA, err := NewTokenIssuer()
+	require.NoError(t, err)
+	signerB, err := NewTokenIssuer()
+	require.NoError(t, err)
+
+	tokenA, err := signerA.IssueToken("s1", "a1", "h1", nil, time.Hour)
+	require.NoError(t, err)
+
+	pemB, err := signerB.MarshalPublicKey()
+	require.NoError(t, err)
+	validatorB, err := NewTokenIssuerFromPublicKey(pemB)
+	require.NoError(t, err)
+
+	_, err = validatorB.ValidateToken(tokenA)
+	assert.Error(t, err)
+}

--- a/internal/hooks/handler.go
+++ b/internal/hooks/handler.go
@@ -3,8 +3,10 @@ package hooks
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
 	"errors"
@@ -634,6 +636,13 @@ func (h *Handler) createAttestation(sessionState *aflock.SessionState, input *af
 		Decision:  "allow",
 	}
 
+	// Build the JWT binding for the attestation predicate (#40). PreToolUse
+	// already validated the token (#48); we re-validate here so the binding
+	// reflects ground truth at signing time, not state captured upstream.
+	// Failure to validate skips the binding but still produces an attestation
+	// — consistent with "attestation is evidence, not enforcement."
+	jwtBinding := h.buildJWTBindingForSession(sessionState)
+
 	// Create signed attestation
 	envelope, err := signer.CreateActionAttestation(
 		context.Background(),
@@ -641,6 +650,7 @@ func (h *Handler) createAttestation(sessionState *aflock.SessionState, input *af
 		sessionState.SessionID,
 		sessionState.Metrics,
 		agentIdentity,
+		jwtBinding,
 	)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "[aflock] Warning: attestation creation failed: %v\n", err)
@@ -677,6 +687,46 @@ func (h *Handler) createAttestation(sessionState *aflock.SessionState, input *af
 	}
 
 	fmt.Fprintf(os.Stderr, "[aflock] Attestation signed: %s\n", filename)
+}
+
+// buildJWTBindingForSession constructs an attestation predicate binding
+// from the session's stored JWT, validated against the public key
+// persisted at SessionStart (#48). Returns nil on any failure — missing
+// pubkey, missing token, or validation error — so the attestation is
+// still produced. Validation failures are logged but do not block.
+func (h *Handler) buildJWTBindingForSession(sessionState *aflock.SessionState) *attestation.JWTBinding {
+	if sessionState == nil || sessionState.AuthToken == "" || sessionState.SessionID == "" {
+		return nil
+	}
+	pubKeyPath := filepath.Join(h.stateManager.SessionDir(sessionState.SessionID), "jwt-pubkey.pem")
+	pubPEM, err := os.ReadFile(pubKeyPath) //nolint:gosec // G304: managed state dir
+	if err != nil {
+		return nil // legacy session or absent pubkey — skip binding silently
+	}
+	validator, err := auth.NewTokenIssuerFromPublicKey(pubPEM)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[aflock] Warning: parse JWT public key for binding: %v\n", err)
+		return nil
+	}
+	currentDigest := ""
+	if sessionState.Policy != nil {
+		currentDigest = auth.ComputePolicyDigest(sessionState.Policy)
+	}
+	claims, err := validator.ValidateTokenForSessionAndPolicy(
+		sessionState.AuthToken, sessionState.SessionID, currentDigest)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[aflock] Warning: JWT failed validation at signing time: %v\n", err)
+		return nil
+	}
+	digest := sha256.Sum256([]byte(sessionState.AuthToken))
+	return &attestation.JWTBinding{
+		SessionID:    sessionState.SessionID,
+		JTI:          claims.ID,
+		PolicyDigest: claims.PolicyDigest,
+		TokenSHA256:  hex.EncodeToString(digest[:]),
+		AllowedTools: claims.AllowedTools,
+		DeniedTools:  claims.DeniedTools,
+	}
 }
 
 // handlePermissionRequest auto-approves or denies based on policy.

--- a/internal/hooks/handler.go
+++ b/internal/hooks/handler.go
@@ -209,6 +209,21 @@ func (h *Handler) handleSessionStart(input *aflock.HookInput) error {
 		} else {
 			sessionState.AuthToken = token
 			fmt.Fprintf(os.Stderr, "[aflock] JWT issued for session %s (ttl=%s)\n", input.SessionID, ttl)
+
+			// Persist the public key alongside the session so PreToolUse — a
+			// separate subprocess that has no in-memory access to the signer —
+			// can validate this token (issue #48). Best-effort: a write failure
+			// downgrades to policy-only enforcement, with a stderr warning.
+			if pubPEM, marshalErr := issuer.MarshalPublicKey(); marshalErr != nil {
+				fmt.Fprintf(os.Stderr, "[aflock] Warning: marshal JWT public key: %v\n", marshalErr)
+			} else {
+				sessionDir := h.stateManager.SessionDir(input.SessionID)
+				if mkErr := os.MkdirAll(sessionDir, 0700); mkErr != nil {
+					fmt.Fprintf(os.Stderr, "[aflock] Warning: create session dir for JWT pubkey: %v\n", mkErr)
+				} else if writeErr := os.WriteFile(filepath.Join(sessionDir, "jwt-pubkey.pem"), pubPEM, 0600); writeErr != nil {
+					fmt.Fprintf(os.Stderr, "[aflock] Warning: write JWT public key: %v\n", writeErr)
+				}
+			}
 		}
 	}
 
@@ -355,6 +370,41 @@ func (h *Handler) handlePreToolUse(input *aflock.HookInput) error {
 	if pol.IsExpired() {
 		return output.Write(output.PreToolUseDeny(fmt.Sprintf("[aflock] BLOCKED: policy '%s' expired at %s", pol.Name, pol.Expires.Format(time.RFC3339))))
 	}
+
+	// Validate the session JWT (#48). The signing key dies with the
+	// SessionStart subprocess, so we reconstruct a validation-only issuer
+	// from the public key persisted next to state.json. If the pubkey file
+	// is missing — pre-existing sessions, or SessionStart failed to write
+	// it — we fall through to policy-only enforcement (preserves backward
+	// compatibility on upgrade). All other failures are deny.
+	if sessionState.AuthToken != "" && input.SessionID != "" {
+		pubKeyPath := filepath.Join(h.stateManager.SessionDir(input.SessionID), "jwt-pubkey.pem")
+		pubPEM, readErr := os.ReadFile(pubKeyPath) //nolint:gosec // G304: path under managed state dir
+		switch {
+		case os.IsNotExist(readErr):
+			// Legacy session — fall through, no JWT enforcement.
+		case readErr != nil:
+			return output.Write(output.PreToolUseDeny(
+				fmt.Sprintf("[aflock] BLOCKED: read JWT public key: %v", readErr)))
+		default:
+			validator, valErr := auth.NewTokenIssuerFromPublicKey(pubPEM)
+			if valErr != nil {
+				return output.Write(output.PreToolUseDeny(
+					fmt.Sprintf("[aflock] BLOCKED: parse JWT public key: %v", valErr)))
+			}
+			claims, valErr := validator.ValidateTokenForSessionAndPolicy(
+				sessionState.AuthToken, input.SessionID, auth.ComputePolicyDigest(pol))
+			if valErr != nil {
+				return output.Write(output.PreToolUseDeny(
+					fmt.Sprintf("[aflock] BLOCKED: JWT validation failed: %v", valErr)))
+			}
+			if !auth.IsToolAllowed(input.ToolName, claims.AllowedTools, claims.DeniedTools) {
+				return output.Write(output.PreToolUseDeny(
+					fmt.Sprintf("[aflock] BLOCKED: tool '%s' not permitted by JWT scope", input.ToolName)))
+			}
+		}
+	}
+
 	// Use cwd as projectRoot when policy path is outside cwd (e.g., AFLOCK_POLICY env var
 	// pointing to a tenant-specific policy in a subdirectory). Otherwise use the policy
 	// file's directory (standard case where .aflock is at project root).

--- a/internal/hooks/handler_attestation_jwt_test.go
+++ b/internal/hooks/handler_attestation_jwt_test.go
@@ -1,0 +1,131 @@
+package hooks
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/aflock-ai/aflock/internal/auth"
+	"github.com/aflock-ai/aflock/pkg/aflock"
+)
+
+// TestBuildJWTBindingForSession_Happy — when a valid token + matching
+// pubkey are persisted, the binding reflects the token's claims.
+func TestBuildJWTBindingForSession_Happy(t *testing.T) {
+	h := newTestHandler(t)
+	pol := &aflock.Policy{
+		Name:  "binding-happy",
+		Tools: &aflock.ToolsPolicy{Allow: []string{"Read"}, Deny: []string{"WebFetch"}},
+	}
+	ss := seedSession(t, h, "session-binding-happy", pol)
+
+	issuer, err := auth.NewTokenIssuer()
+	if err != nil {
+		t.Fatalf("issuer: %v", err)
+	}
+	token, err := issuer.IssueToken("session-binding-happy", "agent-1", "h1", pol, time.Hour)
+	if err != nil {
+		t.Fatalf("issue: %v", err)
+	}
+	pubPEM, err := issuer.MarshalPublicKey()
+	if err != nil {
+		t.Fatalf("marshal pubkey: %v", err)
+	}
+	dir := h.stateManager.SessionDir("session-binding-happy")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "jwt-pubkey.pem"), pubPEM, 0600); err != nil {
+		t.Fatalf("write pubkey: %v", err)
+	}
+	ss.AuthToken = token
+
+	binding := h.buildJWTBindingForSession(ss)
+	if binding == nil {
+		t.Fatal("expected binding, got nil")
+	}
+	if binding.SessionID != "session-binding-happy" {
+		t.Errorf("sessionID = %q", binding.SessionID)
+	}
+	if binding.JTI != "session-binding-happy" {
+		t.Errorf("jti = %q (claims.ID is set to sessionID)", binding.JTI)
+	}
+	want := sha256.Sum256([]byte(token))
+	if binding.TokenSHA256 != hex.EncodeToString(want[:]) {
+		t.Errorf("tokenSha256 mismatch")
+	}
+	if !contains(binding.AllowedTools, "Read") {
+		t.Errorf("AllowedTools missing 'Read': %v", binding.AllowedTools)
+	}
+	if !contains(binding.DeniedTools, "WebFetch") {
+		t.Errorf("DeniedTools missing 'WebFetch': %v", binding.DeniedTools)
+	}
+}
+
+// TestBuildJWTBindingForSession_NoToken — sessions without an AuthToken
+// (legacy or token-issuance failed) get a nil binding, NOT a panic.
+func TestBuildJWTBindingForSession_NoToken(t *testing.T) {
+	h := newTestHandler(t)
+	ss := seedSession(t, h, "session-no-token", &aflock.Policy{Name: "x"})
+	if got := h.buildJWTBindingForSession(ss); got != nil {
+		t.Errorf("expected nil binding when AuthToken is empty, got %+v", got)
+	}
+}
+
+// TestBuildJWTBindingForSession_PubkeyMissing — token present but no
+// jwt-pubkey.pem on disk (legacy session pre-#48). Returns nil silently
+// — same graceful-fallback policy as the PreToolUse path.
+func TestBuildJWTBindingForSession_PubkeyMissing(t *testing.T) {
+	h := newTestHandler(t)
+	ss := seedSession(t, h, "session-no-pubkey", &aflock.Policy{Name: "x"})
+	ss.AuthToken = "eyJhbGciOiJFUzI1NiJ9.eyJqdGkiOiJ4In0.sig"
+	if got := h.buildJWTBindingForSession(ss); got != nil {
+		t.Errorf("expected nil binding when pubkey missing, got %+v", got)
+	}
+}
+
+// TestBuildJWTBindingForSession_ForeignToken — the persisted pubkey
+// belongs to a different signer than the one that issued the stored
+// token. Validation must fail and the binding must be nil — preventing
+// an attacker from swapping the pubkey to bind a forged token.
+func TestBuildJWTBindingForSession_ForeignToken(t *testing.T) {
+	h := newTestHandler(t)
+	pol := &aflock.Policy{Name: "binding-foreign", Tools: &aflock.ToolsPolicy{Allow: []string{"Read"}}}
+	ss := seedSession(t, h, "session-foreign", pol)
+
+	signerA, _ := auth.NewTokenIssuer()
+	signerB, _ := auth.NewTokenIssuer()
+
+	tokenA, err := signerA.IssueToken("session-foreign", "agent-A", "hA", pol, time.Hour)
+	if err != nil {
+		t.Fatalf("issue: %v", err)
+	}
+	pemB, err := signerB.MarshalPublicKey()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	dir := h.stateManager.SessionDir("session-foreign")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "jwt-pubkey.pem"), pemB, 0600); err != nil {
+		t.Fatalf("write pubkey: %v", err)
+	}
+	ss.AuthToken = tokenA
+
+	if got := h.buildJWTBindingForSession(ss); got != nil {
+		t.Errorf("expected nil binding when token doesn't match pubkey, got %+v", got)
+	}
+}
+
+func contains(s []string, want string) bool {
+	for _, v := range s {
+		if v == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/hooks/handler_jwt_test.go
+++ b/internal/hooks/handler_jwt_test.go
@@ -1,0 +1,182 @@
+package hooks
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aflock-ai/aflock/internal/auth"
+	"github.com/aflock-ai/aflock/pkg/aflock"
+)
+
+// issueTokenForSession issues a session-bound JWT and writes the matching
+// public key to the session directory. Mirrors what handleSessionStart now
+// produces, but lets tests assemble it directly without going through
+// stdin-based hook plumbing.
+func issueTokenForSession(t *testing.T, h *Handler, sessionID string, pol *aflock.Policy) string {
+	t.Helper()
+	issuer, err := auth.NewTokenIssuer()
+	if err != nil {
+		t.Fatalf("issuer: %v", err)
+	}
+	token, err := issuer.IssueToken(sessionID, "a1", "h1", pol, time.Hour)
+	if err != nil {
+		t.Fatalf("issue token: %v", err)
+	}
+	pubPEM, err := issuer.MarshalPublicKey()
+	if err != nil {
+		t.Fatalf("marshal pubkey: %v", err)
+	}
+	dir := h.stateManager.SessionDir(sessionID)
+	if mkErr := os.MkdirAll(dir, 0700); mkErr != nil {
+		t.Fatalf("mkdir: %v", mkErr)
+	}
+	if writeErr := os.WriteFile(filepath.Join(dir, "jwt-pubkey.pem"), pubPEM, 0600); writeErr != nil {
+		t.Fatalf("write pubkey: %v", writeErr)
+	}
+	return token
+}
+
+func decisionFromOutput(t *testing.T, raw string) (aflock.PermissionDecision, string) {
+	t.Helper()
+	var out aflock.HookOutput
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		t.Fatalf("parse output: %v (raw: %s)", err, raw)
+	}
+	if out.HookSpecificOutput == nil {
+		t.Fatalf("expected hookSpecificOutput, got: %s", raw)
+	}
+	return out.HookSpecificOutput.PermissionDecision, out.HookSpecificOutput.PermissionDecisionReason
+}
+
+// TestPreToolUse_JWTValid_AllowedTool — the happy path. A valid JWT whose
+// allowed_tools include the requested tool must allow the call.
+func TestPreToolUse_JWTValid_AllowedTool(t *testing.T) {
+	h := newTestHandler(t)
+	pol := &aflock.Policy{
+		Name:  "jwt-happy",
+		Tools: &aflock.ToolsPolicy{Allow: []string{"Read", "Bash"}},
+	}
+	ss := seedSession(t, h, "session-jwt-happy", pol)
+	ss.AuthToken = issueTokenForSession(t, h, "session-jwt-happy", pol)
+	if err := h.stateManager.Save(ss); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	got := captureStdout(t, func() {
+		_ = h.handlePreToolUse(&aflock.HookInput{
+			SessionID: "session-jwt-happy",
+			ToolName:  "Read",
+			ToolInput: json.RawMessage(`{"file_path":"main.go"}`),
+		})
+	})
+	dec, _ := decisionFromOutput(t, got)
+	if dec != aflock.DecisionAllow {
+		t.Errorf("expected allow, got %v (raw: %s)", dec, got)
+	}
+}
+
+// TestPreToolUse_JWTValid_ToolOutOfScope — the JWT is valid, but the
+// requested tool is not in allowed_tools. The fix must reject this
+// before the policy evaluator runs, which is the *whole point* of #48:
+// the JWT scope is enforced at runtime, not just embedded.
+func TestPreToolUse_JWTValid_ToolOutOfScope(t *testing.T) {
+	h := newTestHandler(t)
+	pol := &aflock.Policy{
+		Name:  "jwt-scope",
+		Tools: &aflock.ToolsPolicy{Allow: []string{"Read"}},
+	}
+	ss := seedSession(t, h, "session-jwt-scope", pol)
+	ss.AuthToken = issueTokenForSession(t, h, "session-jwt-scope", pol)
+	if err := h.stateManager.Save(ss); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	got := captureStdout(t, func() {
+		_ = h.handlePreToolUse(&aflock.HookInput{
+			SessionID: "session-jwt-scope",
+			ToolName:  "Bash", // not in allowed_tools
+			ToolInput: json.RawMessage(`{"command":"ls"}`),
+		})
+	})
+	dec, reason := decisionFromOutput(t, got)
+	if dec != aflock.DecisionDeny {
+		t.Fatalf("expected deny, got %v (raw: %s)", dec, got)
+	}
+	if !strings.Contains(reason, "JWT scope") {
+		t.Errorf("expected JWT scope reason, got: %s", reason)
+	}
+}
+
+// TestPreToolUse_JWTTampered — flipping a single byte in the signature
+// must fail validation. Uses a known invalid character to avoid producing
+// another valid base64url string by accident.
+func TestPreToolUse_JWTTampered(t *testing.T) {
+	h := newTestHandler(t)
+	pol := &aflock.Policy{
+		Name:  "jwt-tamper",
+		Tools: &aflock.ToolsPolicy{Allow: []string{"Read"}},
+	}
+	ss := seedSession(t, h, "session-jwt-tamper", pol)
+	token := issueTokenForSession(t, h, "session-jwt-tamper", pol)
+
+	// Corrupt the signature segment (after the second dot).
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		t.Fatalf("expected 3-part JWT, got %d", len(parts))
+	}
+	parts[2] = parts[2][:len(parts[2])-2] + "AA"
+	ss.AuthToken = strings.Join(parts, ".")
+	if err := h.stateManager.Save(ss); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	got := captureStdout(t, func() {
+		_ = h.handlePreToolUse(&aflock.HookInput{
+			SessionID: "session-jwt-tamper",
+			ToolName:  "Read",
+			ToolInput: json.RawMessage(`{"file_path":"main.go"}`),
+		})
+	})
+	dec, reason := decisionFromOutput(t, got)
+	if dec != aflock.DecisionDeny {
+		t.Fatalf("expected deny on tampered JWT, got %v (raw: %s)", dec, got)
+	}
+	if !strings.Contains(reason, "JWT validation failed") {
+		t.Errorf("expected validation-failed reason, got: %s", reason)
+	}
+}
+
+// TestPreToolUse_JWTPubKeyMissing — backward-compat for upgrades. A
+// session with AuthToken set but no jwt-pubkey.pem on disk (because it
+// was created by an older aflock) must NOT block. We log a warning and
+// fall through to policy-only enforcement.
+func TestPreToolUse_JWTPubKeyMissing(t *testing.T) {
+	h := newTestHandler(t)
+	pol := &aflock.Policy{
+		Name:  "jwt-legacy",
+		Tools: &aflock.ToolsPolicy{Allow: []string{"Read"}},
+	}
+	ss := seedSession(t, h, "session-jwt-legacy", pol)
+	// Set token but DO NOT write jwt-pubkey.pem — the legacy upgrade case.
+	ss.AuthToken = "eyJsZWdhY3kiOiJ0b2tlbiJ9.x.y"
+	if err := h.stateManager.Save(ss); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	got := captureStdout(t, func() {
+		_ = h.handlePreToolUse(&aflock.HookInput{
+			SessionID: "session-jwt-legacy",
+			ToolName:  "Read",
+			ToolInput: json.RawMessage(`{"file_path":"main.go"}`),
+		})
+	})
+	dec, _ := decisionFromOutput(t, got)
+	// Falls through to policy: Read is allowed by policy → allow.
+	if dec != aflock.DecisionAllow {
+		t.Errorf("expected allow (legacy session, policy permits), got %v (raw: %s)", dec, got)
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -709,7 +709,12 @@ func (s *Server) validateJWT(request mcp.CallToolRequest) (*auth.AflockClaims, e
 }
 
 // signAndStoreAttestation creates a signed attestation for an action and stores it to disk.
-func (s *Server) signAndStoreAttestation(ctx context.Context, record aflock.ActionRecord) error {
+//
+// jwtBinding may be nil — for graceful-adoption calls that arrived before
+// any get_token, or for paths where no JWT was presented. When non-nil it
+// is embedded in the predicate so verifiers can prove the action was
+// signed only under the listed token scope (issue #40).
+func (s *Server) signAndStoreAttestation(ctx context.Context, record aflock.ActionRecord, jwtBinding *attestation.JWTBinding) error {
 	if !s.signingEnabled {
 		return fmt.Errorf("attestation signing unavailable (SPIRE, Fulcio, and ephemeral all failed)")
 	}
@@ -722,13 +727,40 @@ func (s *Server) signAndStoreAttestation(ctx context.Context, record aflock.Acti
 	}
 
 	// Create and sign attestation
-	envelope, err := s.signer.CreateActionAttestation(ctx, record, s.sessionID, metrics, s.agentIdentity)
+	envelope, err := s.signer.CreateActionAttestation(ctx, record, s.sessionID, metrics, s.agentIdentity, jwtBinding)
 	if err != nil {
 		return fmt.Errorf("create attestation: %w", err)
 	}
 
 	// Store to disk
 	return s.storeAttestation(envelope, record.ToolUseID)
+}
+
+// buildJWTBinding constructs an attestation predicate binding from the
+// validated claims and the token presented on the wire. Returns nil if
+// either is missing — the attestation is still produced, just without
+// JWT context, marking it as a graceful-adoption call (issue #40).
+func (s *Server) buildJWTBinding(request mcp.CallToolRequest, claims *auth.AflockClaims) *attestation.JWTBinding {
+	if claims == nil {
+		return nil
+	}
+	tokenStr, _ := request.GetArguments()["_token"].(string)
+	if tokenStr == "" {
+		return nil
+	}
+	digest := sha256.Sum256([]byte(tokenStr))
+	binding := &attestation.JWTBinding{
+		SessionID:    s.sessionID,
+		JTI:          claims.ID,
+		PolicyDigest: claims.PolicyDigest,
+		TokenSHA256:  hex.EncodeToString(digest[:]),
+		AllowedTools: claims.AllowedTools,
+		DeniedTools:  claims.DeniedTools,
+	}
+	if s.tokenIssuer != nil {
+		binding.KeyID = s.tokenIssuer.KeyID()
+	}
+	return binding
 }
 
 // storeAttestation writes an attestation envelope to the session's attestations directory.
@@ -822,11 +854,14 @@ func (s *Server) handleCheckTool(ctx context.Context, request mcp.CallToolReques
 // handleBash executes a command with policy enforcement.
 func (s *Server) handleBash(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) { //nolint:gocognit,gocyclo,funlen // bash handler requires complex policy + execution logic
 	// JWT authorization check
-	if claims, err := s.validateJWT(request); err != nil {
+	claims, err := s.validateJWT(request)
+	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("Authorization denied: %v", err)), nil
-	} else if claims != nil && !auth.IsToolAllowed("Bash", claims.AllowedTools, claims.DeniedTools) {
+	}
+	if claims != nil && !auth.IsToolAllowed("Bash", claims.AllowedTools, claims.DeniedTools) {
 		return mcp.NewToolResultError("Authorization denied: tool 'Bash' not permitted by token scope"), nil
 	}
+	jwtBinding := s.buildJWTBinding(request, claims)
 
 	command := request.GetString("command", "")
 	timeoutSec := request.GetFloat("timeout", 30)
@@ -870,7 +905,7 @@ func (s *Server) handleBash(ctx context.Context, request mcp.CallToolRequest) (*
 				Reason:    policyReason,
 			}
 			s.recordAction("Bash", "deny", policyReason)
-			if err := s.signAndStoreAttestation(ctx, record); err != nil {
+			if err := s.signAndStoreAttestation(ctx, record, jwtBinding); err != nil {
 				fmt.Fprintf(os.Stderr, "[aflock] Warning: failed to sign attestation: %v\n", err)
 			}
 			return mcp.NewToolResultError(fmt.Sprintf("Policy denied: %s", policyReason)), nil
@@ -886,7 +921,7 @@ func (s *Server) handleBash(ctx context.Context, request mcp.CallToolRequest) (*
 				Decision:  string(aflock.DecisionAsk),
 				Reason:    policyReason,
 			}
-			if err := s.signAndStoreAttestation(ctx, record); err != nil {
+			if err := s.signAndStoreAttestation(ctx, record, jwtBinding); err != nil {
 				fmt.Fprintf(os.Stderr, "[aflock] Warning: failed to sign attestation: %v\n", err)
 			}
 			return mcp.NewToolResultError(fmt.Sprintf("Policy requires approval: %s", policyReason)), nil
@@ -928,7 +963,7 @@ func (s *Server) handleBash(ctx context.Context, request mcp.CallToolRequest) (*
 				Reason:    flowReason,
 			}
 			s.recordAction("Bash", "deny", flowReason)
-			if err := s.signAndStoreAttestation(ctx, record); err != nil {
+			if err := s.signAndStoreAttestation(ctx, record, jwtBinding); err != nil {
 				fmt.Fprintf(os.Stderr, "[aflock] Warning: failed to sign attestation: %v\n", err)
 			}
 			fmt.Fprintf(os.Stderr, "[aflock] BLOCKED data exfiltration: %s\n", flowReason)
@@ -946,11 +981,11 @@ func (s *Server) handleBash(ctx context.Context, request mcp.CallToolRequest) (*
 	}
 
 	// Standard execution without attestation
-	return s.executeCommand(ctx, command, workdir, timeoutSec, toolUseID, inputJSON)
+	return s.executeCommand(ctx, command, workdir, timeoutSec, toolUseID, inputJSON, jwtBinding)
 }
 
 // executeCommand executes a command without attestation.
-func (s *Server) executeCommand(ctx context.Context, command, workdir string, timeoutSec float64, toolUseID string, inputJSON []byte) (*mcp.CallToolResult, error) {
+func (s *Server) executeCommand(ctx context.Context, command, workdir string, timeoutSec float64, toolUseID string, inputJSON []byte, jwtBinding *attestation.JWTBinding) (*mcp.CallToolResult, error) {
 	execCtx, cancel := context.WithTimeout(ctx, time.Duration(timeoutSec)*time.Second)
 	defer cancel()
 
@@ -973,7 +1008,7 @@ func (s *Server) executeCommand(ctx context.Context, command, workdir string, ti
 	s.recordAction("Bash", "allow", "")
 
 	// Sign and store attestation
-	if signErr := s.signAndStoreAttestation(ctx, record); signErr != nil {
+	if signErr := s.signAndStoreAttestation(ctx, record, jwtBinding); signErr != nil {
 		fmt.Fprintf(os.Stderr, "[aflock] Warning: failed to sign attestation: %v\n", signErr)
 	}
 
@@ -1070,11 +1105,14 @@ func (s *Server) storeStepAttestation(envelope any, treeHash, step string) error
 // handleReadFile reads a file with policy enforcement.
 func (s *Server) handleReadFile(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	// JWT authorization check
-	if claims, err := s.validateJWT(request); err != nil {
+	claims, err := s.validateJWT(request)
+	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("Authorization denied: %v", err)), nil
-	} else if claims != nil && !auth.IsToolAllowed("Read", claims.AllowedTools, claims.DeniedTools) {
+	}
+	if claims != nil && !auth.IsToolAllowed("Read", claims.AllowedTools, claims.DeniedTools) {
 		return mcp.NewToolResultError("Authorization denied: tool 'Read' not permitted by token scope"), nil
 	}
+	jwtBinding := s.buildJWTBinding(request, claims)
 
 	filePath := request.GetString("path", "")
 
@@ -1103,7 +1141,7 @@ func (s *Server) handleReadFile(ctx context.Context, request mcp.CallToolRequest
 				Reason:    reason,
 			}
 			s.recordAction("Read", "deny", reason)
-			if err := s.signAndStoreAttestation(ctx, record); err != nil {
+			if err := s.signAndStoreAttestation(ctx, record, jwtBinding); err != nil {
 				fmt.Fprintf(os.Stderr, "[aflock] Warning: failed to sign attestation: %v\n", err)
 			}
 			return mcp.NewToolResultError(fmt.Sprintf("Policy denied: %s", reason)), nil
@@ -1152,7 +1190,7 @@ func (s *Server) handleReadFile(ctx context.Context, request mcp.CallToolRequest
 	s.trackFile("Read", filePath)
 
 	// Sign and store attestation
-	if err := s.signAndStoreAttestation(ctx, record); err != nil {
+	if err := s.signAndStoreAttestation(ctx, record, jwtBinding); err != nil {
 		fmt.Fprintf(os.Stderr, "[aflock] Warning: failed to sign attestation: %v\n", err)
 	}
 
@@ -1162,11 +1200,14 @@ func (s *Server) handleReadFile(ctx context.Context, request mcp.CallToolRequest
 // handleWriteFile writes content to a file with policy enforcement.
 func (s *Server) handleWriteFile(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) { //nolint:gocognit,funlen // file write handler has complex policy + attestation logic
 	// JWT authorization check
-	if claims, err := s.validateJWT(request); err != nil {
+	claims, err := s.validateJWT(request)
+	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("Authorization denied: %v", err)), nil
-	} else if claims != nil && !auth.IsToolAllowed("Write", claims.AllowedTools, claims.DeniedTools) {
+	}
+	if claims != nil && !auth.IsToolAllowed("Write", claims.AllowedTools, claims.DeniedTools) {
 		return mcp.NewToolResultError("Authorization denied: tool 'Write' not permitted by token scope"), nil
 	}
+	jwtBinding := s.buildJWTBinding(request, claims)
 
 	filePath := request.GetString("path", "")
 	content := request.GetString("content", "")
@@ -1196,7 +1237,7 @@ func (s *Server) handleWriteFile(ctx context.Context, request mcp.CallToolReques
 				Reason:    reason,
 			}
 			s.recordAction("Write", "deny", reason)
-			if err := s.signAndStoreAttestation(ctx, record); err != nil {
+			if err := s.signAndStoreAttestation(ctx, record, jwtBinding); err != nil {
 				fmt.Fprintf(os.Stderr, "[aflock] Warning: failed to sign attestation: %v\n", err)
 			}
 			return mcp.NewToolResultError(fmt.Sprintf("Policy denied: %s", reason)), nil
@@ -1231,7 +1272,7 @@ func (s *Server) handleWriteFile(ctx context.Context, request mcp.CallToolReques
 				Reason:    flowReason,
 			}
 			s.recordAction("Write", "deny", flowReason)
-			if err := s.signAndStoreAttestation(ctx, record); err != nil {
+			if err := s.signAndStoreAttestation(ctx, record, jwtBinding); err != nil {
 				fmt.Fprintf(os.Stderr, "[aflock] Warning: failed to sign attestation: %v\n", err)
 			}
 			fmt.Fprintf(os.Stderr, "[aflock] BLOCKED data exfiltration: %s\n", flowReason)
@@ -1258,7 +1299,7 @@ func (s *Server) handleWriteFile(ctx context.Context, request mcp.CallToolReques
 	s.trackFile("Write", filePath)
 
 	// Sign and store attestation
-	if err := s.signAndStoreAttestation(ctx, record); err != nil {
+	if err := s.signAndStoreAttestation(ctx, record, jwtBinding); err != nil {
 		fmt.Fprintf(os.Stderr, "[aflock] Warning: failed to sign attestation: %v\n", err)
 	}
 

--- a/internal/mcp/server_jwt_binding_test.go
+++ b/internal/mcp/server_jwt_binding_test.go
@@ -1,0 +1,87 @@
+package mcp
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+	"time"
+
+	"github.com/aflock-ai/aflock/internal/auth"
+	"github.com/aflock-ai/aflock/pkg/aflock"
+)
+
+// TestBuildJWTBinding_NoClaims — graceful adoption: pre-token tool calls
+// produce no binding, so the attestation has no JWT context.
+func TestBuildJWTBinding_NoClaims(t *testing.T) {
+	s := newTestServer(t)
+	got := s.buildJWTBinding(callRequest(map[string]any{"_token": "x"}), nil)
+	if got != nil {
+		t.Errorf("expected nil binding when claims is nil, got %+v", got)
+	}
+}
+
+// TestBuildJWTBinding_NoTokenInRequest — claims came from somewhere
+// (test fixture), but the request didn't carry _token. We can't compute
+// a token digest without the token itself, so we return nil.
+func TestBuildJWTBinding_NoTokenInRequest(t *testing.T) {
+	s := newTestServer(t)
+	got := s.buildJWTBinding(callRequest(nil), &auth.AflockClaims{})
+	if got != nil {
+		t.Errorf("expected nil binding when _token absent, got %+v", got)
+	}
+}
+
+// TestBuildJWTBinding_Happy — claims and token present: the binding
+// reflects the claims and the token digest matches sha256(token). This
+// is the per-call audit trail entry that the verifier matches against
+// its issuance log to prove "this action used that token."
+func TestBuildJWTBinding_Happy(t *testing.T) {
+	s := newTestServerWithPolicy(t, &aflock.Policy{
+		Name:    "happy-binding",
+		Tools:   &aflock.ToolsPolicy{Allow: []string{"Bash"}, Deny: []string{"WebFetch"}},
+	})
+	issuer, err := auth.NewTokenIssuer()
+	if err != nil {
+		t.Fatalf("issuer: %v", err)
+	}
+	s.tokenIssuer = issuer
+
+	token, err := issuer.IssueToken(s.sessionID, "agent-1", "h-1", s.policy, time.Hour)
+	if err != nil {
+		t.Fatalf("issue: %v", err)
+	}
+	claims, err := issuer.ValidateTokenForSessionAndPolicy(token, s.sessionID, s.computePolicyDigest())
+	if err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+
+	binding := s.buildJWTBinding(callRequest(map[string]any{"_token": token}), claims)
+	if binding == nil {
+		t.Fatal("expected binding")
+	}
+	if binding.SessionID != s.sessionID {
+		t.Errorf("sessionID = %q, want %q", binding.SessionID, s.sessionID)
+	}
+	want := sha256.Sum256([]byte(token))
+	if binding.TokenSHA256 != hex.EncodeToString(want[:]) {
+		t.Errorf("tokenSha256 mismatch")
+	}
+	if binding.KeyID != issuer.KeyID() {
+		t.Errorf("kid = %q, want %q", binding.KeyID, issuer.KeyID())
+	}
+	if binding.PolicyDigest != claims.PolicyDigest {
+		t.Errorf("policyDigest mismatch")
+	}
+	if !sliceContains(binding.AllowedTools, "Bash") || !sliceContains(binding.DeniedTools, "WebFetch") {
+		t.Errorf("scope mismatch: allowed=%v denied=%v", binding.AllowedTools, binding.DeniedTools)
+	}
+}
+
+func sliceContains(s []string, want string) bool {
+	for _, v := range s {
+		if v == want {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Action attestations gain a `jwtBinding` field (sessionID, jti, kid, policy digest, token sha256, allowed/denied tools) so verifiers can prove the signed action was authorized by a token with the listed scope.

Wired through MCP (`signAndStoreAttestation` + `buildJWTBinding` helper) and hooks (`createAttestation` re-validates the token via the pubkey persisted by #48). Replay and tests use the variadic-nil path.

Out of scope: Phase 2 of #40 (separate signer process) — split to a follow-up issue.

Stacked on #103 — base will become `dev` once that merges.

Closes #40 (Phase 1)