### PR TITLE
fix(hooks): pin signer pubkey to close Stop-gate forgery

### DIFF
--- a/internal/attestation/signer.go
+++ b/internal/attestation/signer.go
@@ -121,11 +121,12 @@ func (s *Signer) GetSigningIdentity() (*identity.Identity, string) {
 }
 
 // InitializeFromPersistedKey reconstructs an ephemeral signing identity from
-// a PEM-encoded ECDSA P-256 private key previously written by
-// PersistEphemeralKey. Used by PostToolUse subprocesses to reuse the
-// session-scoped key established at SessionStart (issue #68) rather than
-// minting a fresh key per attestation — which made attestations from one
-// session unverifiable against any pinned key.
+// a PEM-encoded ECDSA P-256 private key previously written via
+// MarshalEphemeralKey (the hook writes it to <session-dir>/signer-key.pem at
+// SessionStart). Used by PostToolUse subprocesses to reuse the session-scoped
+// key rather than minting a fresh one per attestation — which made
+// attestations from one session unverifiable against any pinned key
+// (issue #68).
 func (s *Signer) InitializeFromPersistedKey(keyPEM []byte, agentIdentityHash string) error {
 	block, _ := pem.Decode(keyPEM)
 	if block == nil {

--- a/internal/attestation/signer.go
+++ b/internal/attestation/signer.go
@@ -13,6 +13,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/binary"
+	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
@@ -117,6 +118,117 @@ func (s *Signer) InitializeEphemeral(agentIdentityHash string) error {
 // GetSigningIdentity returns the identity to use for signing.
 func (s *Signer) GetSigningIdentity() (*identity.Identity, string) {
 	return s.identity, ""
+}
+
+// InitializeFromPersistedKey reconstructs an ephemeral signing identity from
+// a PEM-encoded ECDSA P-256 private key previously written by
+// PersistEphemeralKey. Used by PostToolUse subprocesses to reuse the
+// session-scoped key established at SessionStart (issue #68) rather than
+// minting a fresh key per attestation — which made attestations from one
+// session unverifiable against any pinned key.
+func (s *Signer) InitializeFromPersistedKey(keyPEM []byte, agentIdentityHash string) error {
+	block, _ := pem.Decode(keyPEM)
+	if block == nil {
+		return fmt.Errorf("decode signer key PEM: no PEM block found")
+	}
+	key, err := x509.ParseECPrivateKey(block.Bytes)
+	if err != nil {
+		return fmt.Errorf("parse persisted EC private key: %w", err)
+	}
+
+	serialMax := new(big.Int).Lsh(big.NewInt(1), 128)
+	serial, err := rand.Int(rand.Reader, serialMax)
+	if err != nil {
+		return fmt.Errorf("generate certificate serial: %w", err)
+	}
+	template := &x509.Certificate{
+		SerialNumber: serial,
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		return fmt.Errorf("create ephemeral certificate: %w", err)
+	}
+	cert, err := x509.ParseCertificate(certDER)
+	if err != nil {
+		return fmt.Errorf("parse ephemeral certificate: %w", err)
+	}
+
+	spiffeID, err := spiffeid.FromString(fmt.Sprintf("spiffe://aflock.ai/agent/ephemeral/%s", agentIdentityHash))
+	if err != nil {
+		spiffeID = spiffeid.RequireFromString("spiffe://aflock.ai/agent/ephemeral/unknown")
+	}
+
+	s.identity = &identity.Identity{
+		SPIFFEID:    spiffeID,
+		Certificate: cert,
+		PrivateKey:  key,
+		ExpiresAt:   template.NotAfter,
+	}
+	return nil
+}
+
+// MarshalEphemeralKey returns the PEM-encoded SEC1 representation of the
+// ephemeral private key, for persistence at SessionStart. Errors if the
+// signer is not in ephemeral mode (SPIRE/Fulcio private keys are not
+// exportable through this path).
+func (s *Signer) MarshalEphemeralKey() ([]byte, error) {
+	if s.identity == nil || s.identity.PrivateKey == nil {
+		return nil, fmt.Errorf("no signing identity available")
+	}
+	key, ok := s.identity.PrivateKey.(*ecdsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("ephemeral key export only supported for ECDSA keys (got %T)", s.identity.PrivateKey)
+	}
+	der, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return nil, fmt.Errorf("marshal EC private key: %w", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: der}), nil
+}
+
+// MarshalSigningPublicKey returns the PEM-encoded PKIX representation of the
+// signer's public key plus the hex SHA-256 of the SPKI bytes. Used by the
+// Stop gate as the pin (issue #68): the gate refuses any attestation whose
+// signing cert's SPKI hash does not match this fingerprint.
+func (s *Signer) MarshalSigningPublicKey() (pubPEM []byte, spkiFingerprint string, err error) {
+	if s.identity == nil {
+		return nil, "", fmt.Errorf("no signing identity available")
+	}
+	var pubKey crypto.PublicKey
+	switch {
+	case s.identity.Certificate != nil:
+		pubKey = s.identity.Certificate.PublicKey
+	case s.identity.PrivateKey != nil:
+		signer, ok := s.identity.PrivateKey.(crypto.Signer)
+		if !ok {
+			return nil, "", fmt.Errorf("private key does not implement crypto.Signer (got %T)", s.identity.PrivateKey)
+		}
+		pubKey = signer.Public()
+	default:
+		return nil, "", fmt.Errorf("no public key material available")
+	}
+	spkiDER, err := x509.MarshalPKIXPublicKey(pubKey)
+	if err != nil {
+		return nil, "", fmt.Errorf("marshal PKIX public key: %w", err)
+	}
+	sum := sha256.Sum256(spkiDER)
+	return pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: spkiDER}), hex.EncodeToString(sum[:]), nil
+}
+
+// SPKIFingerprint computes the hex-encoded SHA-256 of a public key's PKIX
+// SubjectPublicKeyInfo encoding. Exported so the Stop gate can compute
+// fingerprints of envelope-embedded certs and compare them to the pin
+// recorded in session state.
+func SPKIFingerprint(pub crypto.PublicKey) (string, error) {
+	spkiDER, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		return "", fmt.Errorf("marshal PKIX public key: %w", err)
+	}
+	sum := sha256.Sum256(spkiDER)
+	return hex.EncodeToString(sum[:]), nil
 }
 
 // Close releases resources and securely wipes ephemeral key material from

--- a/internal/hooks/handler.go
+++ b/internal/hooks/handler.go
@@ -3,6 +3,7 @@ package hooks
 
 import (
 	"context"
+	"crypto"
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
@@ -229,6 +230,13 @@ func (h *Handler) handleSessionStart(input *aflock.HookInput) error {
 		}
 	}
 
+	// Establish the per-session attestation signing key and pin its pubkey
+	// fingerprint to session state (issue #68). Subsequent PostToolUse
+	// invocations reuse this key instead of minting one per attestation, and
+	// the Stop gate verifies attestations against the pinned pubkey rather
+	// than the envelope-embedded cert.
+	h.establishSessionSigner(sessionState, agentIdentity)
+
 	if err := h.stateManager.Save(sessionState); err != nil {
 		output.ExitWithWarning(fmt.Sprintf("Failed to save session state: %v", err))
 		return nil
@@ -237,6 +245,77 @@ func (h *Handler) handleSessionStart(input *aflock.HookInput) error {
 	// Build context to inject
 	context := h.buildPolicyContext(pol, agentIdentity)
 	return output.Write(output.SessionStartContext(context))
+}
+
+// establishSessionSigner initializes the per-session attestation signer and
+// persists material that PostToolUse and the Stop gate need:
+//
+//   - signer-pubkey.pem (0600) — pubkey used by the Stop gate for verification
+//   - signer-key.pem (0600) — ephemeral private key; only written when running
+//     without SPIRE / Fulcio so PostToolUse subprocesses can reload it. SPIRE
+//     and Fulcio re-fetch their identities directly, so the private key is
+//     never written to disk in those modes.
+//
+// Failures here are non-fatal: SessionStart still completes, but
+// SignerPubKeyFingerprint stays empty and the Stop gate will deny any
+// required-attestation check (fail-closed, issue #68).
+func (h *Handler) establishSessionSigner(sessionState *aflock.SessionState, agentIdentity *identity.AgentIdentity) {
+	if sessionState == nil || sessionState.SessionID == "" {
+		return
+	}
+
+	signer := attestation.NewSigner("")
+	defer signer.Close() //nolint:errcheck // best-effort cleanup
+
+	mode := ""
+	if err := signer.Initialize(context.Background()); err == nil {
+		mode = "spire"
+	} else if fulcioErr := signer.InitializeFulcio(context.Background()); fulcioErr == nil {
+		mode = "fulcio"
+	} else {
+		identityHash := ""
+		if agentIdentity != nil {
+			identityHash = agentIdentity.IdentityHash
+		}
+		if err := signer.InitializeEphemeral(identityHash); err != nil {
+			fmt.Fprintf(os.Stderr, "[aflock] Warning: signer init failed at SessionStart: %v\n", err)
+			return
+		}
+		mode = "ephemeral"
+	}
+
+	pubPEM, fingerprint, err := signer.MarshalSigningPublicKey()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[aflock] Warning: marshal signer pubkey: %v\n", err)
+		return
+	}
+
+	sessionDir := h.stateManager.SessionDir(sessionState.SessionID)
+	if mkErr := os.MkdirAll(sessionDir, 0700); mkErr != nil {
+		fmt.Fprintf(os.Stderr, "[aflock] Warning: create session dir for signer pubkey: %v\n", mkErr)
+		return
+	}
+	if writeErr := os.WriteFile(filepath.Join(sessionDir, "signer-pubkey.pem"), pubPEM, 0600); writeErr != nil {
+		fmt.Fprintf(os.Stderr, "[aflock] Warning: write signer pubkey: %v\n", writeErr)
+		return
+	}
+
+	if mode == "ephemeral" {
+		keyPEM, keyErr := signer.MarshalEphemeralKey()
+		if keyErr != nil {
+			fmt.Fprintf(os.Stderr, "[aflock] Warning: marshal ephemeral signer key: %v\n", keyErr)
+			return
+		}
+		// The persisted private key is the durable session signing material —
+		// 0600 keeps it owner-only; broader permissions defeat the pin entirely.
+		if writeErr := os.WriteFile(filepath.Join(sessionDir, "signer-key.pem"), keyPEM, 0600); writeErr != nil {
+			fmt.Fprintf(os.Stderr, "[aflock] Warning: write ephemeral signer key: %v\n", writeErr)
+			return
+		}
+	}
+
+	sessionState.SignerPubKeyFingerprint = fingerprint
+	sessionState.SigningMode = mode
 }
 
 // buildPolicyContext creates context string describing the active policy.
@@ -604,20 +683,47 @@ func (h *Handler) createAttestation(sessionState *aflock.SessionState, input *af
 		}
 	}
 
-	// Create signer — try SPIRE first, then Fulcio keyless, fall back to ephemeral key
+	// Create signer. In ephemeral mode reuse the per-session key established at
+	// SessionStart (issue #68); otherwise re-fetch from SPIRE / Fulcio.
 	signer := attestation.NewSigner("")
-	if err := signer.Initialize(context.Background()); err != nil {
-		// SPIRE not available — try Fulcio keyless (CI/CD environments with OIDC)
-		if fulcioErr := signer.InitializeFulcio(context.Background()); fulcioErr != nil {
-			// Fulcio not available — use ephemeral key
+	signerInitialized := false
+	switch sessionState.SigningMode {
+	case "spire":
+		if err := signer.Initialize(context.Background()); err == nil {
+			signerInitialized = true
+		}
+	case "fulcio":
+		if err := signer.InitializeFulcio(context.Background()); err == nil {
+			signerInitialized = true
+		}
+	case "ephemeral", "":
+		keyPath := filepath.Join(h.stateManager.SessionDir(sessionState.SessionID), "signer-key.pem")
+		keyPEM, readErr := os.ReadFile(keyPath) //nolint:gosec // G304: keyPath is under SessionDir
+		if readErr == nil {
 			identityHash := ""
 			if agentIdentity != nil {
 				identityHash = agentIdentity.IdentityHash
 			}
-			if err := signer.InitializeEphemeral(identityHash); err != nil {
-				fmt.Fprintf(os.Stderr, "[aflock] Warning: attestation signing unavailable: %v\n", err)
-				return
+			if err := signer.InitializeFromPersistedKey(keyPEM, identityHash); err == nil {
+				signerInitialized = true
+			} else {
+				fmt.Fprintf(os.Stderr, "[aflock] Warning: load persisted signer key: %v\n", err)
 			}
+		}
+	}
+	if !signerInitialized {
+		// Last-resort fallback: pre-pinning sessions, or a SessionStart that
+		// failed to persist a key. Mint a fresh ephemeral key — the Stop gate
+		// will not be able to pin this key, so required-attestation enforcement
+		// will fail closed for the session, but PostToolUse still produces an
+		// attestation record on disk for forensic value.
+		identityHash := ""
+		if agentIdentity != nil {
+			identityHash = agentIdentity.IdentityHash
+		}
+		if err := signer.InitializeEphemeral(identityHash); err != nil {
+			fmt.Fprintf(os.Stderr, "[aflock] Warning: attestation signing unavailable: %v\n", err)
+			return
 		}
 	}
 	defer signer.Close() //nolint:errcheck // best-effort cleanup
@@ -812,6 +918,25 @@ func (h *Handler) missingRequiredAttestations(sessionID string, sessionState *af
 		usedToolUseIDs[action.ToolName] = append(usedToolUseIDs[action.ToolName], action.ToolUseID)
 	}
 
+	// Load the per-session signing pubkey pin established at SessionStart.
+	// Without this pin we cannot tell "real attestation" from "attacker-dropped
+	// envelope signed with the attacker's own key" (issue #68). Fail-closed:
+	// if the pin is missing or doesn't match what's recorded in state, every
+	// required attestation reports as missing.
+	pin, pinErr := h.loadSessionSignerPin(sessionID, sessionState)
+	if pinErr != nil {
+		fmt.Fprintf(os.Stderr, "[aflock] Cannot verify required attestations: %v\n", pinErr)
+		var missing []string
+		for tool := range usedToolUseIDs {
+			for _, required := range sessionState.Policy.RequiredAttestations {
+				if tool == required {
+					missing = append(missing, required)
+				}
+			}
+		}
+		return missing
+	}
+
 	attestDir := h.stateManager.AttestationsDir(sessionID)
 	var missing []string
 	for _, required := range sessionState.Policy.RequiredAttestations {
@@ -819,11 +944,52 @@ func (h *Handler) missingRequiredAttestations(sessionID string, sessionState *af
 		if !used {
 			continue // tool wasn't used → no attestation needed
 		}
-		if !findVerifiedAttestation(attestDir, sessionID, required, toolUseIDs) {
+		if !findVerifiedAttestation(attestDir, sessionID, required, toolUseIDs, pin) {
 			missing = append(missing, required)
 		}
 	}
 	return missing
+}
+
+// sessionSignerPin captures the trust anchor for required-attestation
+// verification within a session: the pinned public key and the expected SPKI
+// fingerprint recorded in state.json at SessionStart. Stop / SubagentStop
+// refuse any envelope whose embedded cert does not present this exact key.
+type sessionSignerPin struct {
+	pub         crypto.PublicKey
+	fingerprint string
+}
+
+// loadSessionSignerPin reads <session-dir>/signer-pubkey.pem and verifies the
+// SPKI fingerprint matches what was recorded in session state at
+// SessionStart. Any mismatch — missing file, missing recorded fingerprint,
+// fingerprint divergence — is treated as a tampered or pre-pinning session
+// and yields an error so the caller fails closed.
+func (h *Handler) loadSessionSignerPin(sessionID string, sessionState *aflock.SessionState) (*sessionSignerPin, error) {
+	if sessionState == nil || sessionState.SignerPubKeyFingerprint == "" {
+		return nil, fmt.Errorf("session %s has no pinned signer fingerprint — restart the session to re-establish the pin", sessionID)
+	}
+	pubPath := filepath.Join(h.stateManager.SessionDir(sessionID), "signer-pubkey.pem")
+	pubPEM, err := os.ReadFile(pubPath) //nolint:gosec // G304: path under SessionDir
+	if err != nil {
+		return nil, fmt.Errorf("read pinned signer pubkey for session %s: %w", sessionID, err)
+	}
+	block, _ := pem.Decode(pubPEM)
+	if block == nil {
+		return nil, fmt.Errorf("decode pinned signer pubkey for session %s: no PEM block", sessionID)
+	}
+	pub, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse pinned signer pubkey for session %s: %w", sessionID, err)
+	}
+	fp, err := attestation.SPKIFingerprint(pub)
+	if err != nil {
+		return nil, fmt.Errorf("fingerprint pinned signer pubkey for session %s: %w", sessionID, err)
+	}
+	if fp != sessionState.SignerPubKeyFingerprint {
+		return nil, fmt.Errorf("signer pin fingerprint mismatch for session %s (signer-pubkey.pem or state.json was tampered with)", sessionID)
+	}
+	return &sessionSignerPin{pub: pub, fingerprint: fp}, nil
 }
 
 // handleStop checks if required attestations are complete.
@@ -977,14 +1143,15 @@ func (h *Handler) handlePreCompact(_ *aflock.HookInput) error {
 //  3. Payload binds to THIS session (sessionID) and THIS tool (toolName)
 //  4. Payload's toolUseID appears in the session's recorded "allow" actions
 //
-// The embedded cert is trusted by virtue of "whoever signed this had the
-// private key at the time" — which is exactly what keeps a file-drop
-// attacker without key access from forging evidence. Chain validation to an
-// external root (SPIRE/Fulcio) is a stronger mode reserved for the
-// `aflock verify` command; at runtime we use the lighter self-attested
-// signature check because the signing key that produced these files is the
-// hook process's own key, and we want to reject files NOT signed by it.
-func findVerifiedAttestation(dir, sessionID, toolName string, allowedToolUseIDs []string) bool {
+// The trust anchor is the per-session signing pubkey pinned at SessionStart
+// (issue #68). Envelopes whose embedded cert's SPKI does not match the pin
+// are rejected outright — closes the "drop a self-signed forgery in the
+// attestations dir" attack. Chain validation against an external root
+// (SPIRE/Fulcio) remains the stronger mode used by `aflock verify`.
+func findVerifiedAttestation(dir, sessionID, toolName string, allowedToolUseIDs []string, pin *sessionSignerPin) bool {
+	if pin == nil {
+		return false
+	}
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return false
@@ -1001,7 +1168,7 @@ func findVerifiedAttestation(dir, sessionID, toolName string, allowedToolUseIDs 
 		if !validateAttestationIntegrity(p) {
 			continue
 		}
-		if cryptographicallyVerifyAttestation(p, sessionID, toolName, allowed) {
+		if cryptographicallyVerifyAttestation(p, sessionID, toolName, allowed, pin) {
 			return true
 		}
 	}
@@ -1009,9 +1176,13 @@ func findVerifiedAttestation(dir, sessionID, toolName string, allowedToolUseIDs 
 }
 
 // cryptographicallyVerifyAttestation does the heavy lifting for
-// findVerifiedAttestation. Returns true only when the signature verifies and
-// the payload binds to the expected session and tool use.
-func cryptographicallyVerifyAttestation(path, sessionID, toolName string, allowedToolUseIDs map[string]bool) bool {
+// findVerifiedAttestation. Returns true only when the envelope was signed by
+// the per-session pinned key (issue #68) AND the payload binds to the
+// expected session and tool use.
+func cryptographicallyVerifyAttestation(path, sessionID, toolName string, allowedToolUseIDs map[string]bool, pin *sessionSignerPin) bool {
+	if pin == nil {
+		return false
+	}
 	data, err := os.ReadFile(path) //nolint:gosec // G304: path from AttestationsDir
 	if err != nil {
 		return false
@@ -1021,28 +1192,15 @@ func cryptographicallyVerifyAttestation(path, sessionID, toolName string, allowe
 		return false
 	}
 
-	// Extract each signature's embedded leaf cert and treat them as the
-	// trusted set for this file. VerifyEnvelope handles PAE + Ed25519 /
-	// ECDSA / RSA selection and tries both spec + legacy PAE encodings.
-	var leafCerts []*x509.Certificate
-	for _, sig := range envelope.Signatures {
-		if sig.Certificate == "" {
-			continue
-		}
-		block, _ := pem.Decode([]byte(sig.Certificate))
-		if block == nil {
-			continue
-		}
-		cert, err := x509.ParseCertificate(block.Bytes)
-		if err != nil {
-			continue
-		}
-		leafCerts = append(leafCerts, cert)
-	}
-	if len(leafCerts) == 0 {
+	// Only accept envelopes whose embedded cert encodes the pinned pubkey.
+	// Without this gate the verifier trusts whatever key the envelope ships
+	// with, which is exactly the issue #68 forgery path (any attacker with
+	// write access to the attestations dir generates their own keypair).
+	pinnedCerts := envelopeCertsMatchingPin(&envelope, pin)
+	if len(pinnedCerts) == 0 {
 		return false
 	}
-	if err := attestation.VerifyEnvelope(&envelope, leafCerts); err != nil {
+	if err := attestation.VerifyEnvelope(&envelope, pinnedCerts); err != nil {
 		return false
 	}
 
@@ -1082,6 +1240,37 @@ func cryptographicallyVerifyAttestation(path, sessionID, toolName string, allowe
 		}
 	}
 	return true
+}
+
+// envelopeCertsMatchingPin returns the subset of certificates embedded in the
+// envelope whose SPKI hash matches the pinned fingerprint. Used by the Stop
+// gate to confine VerifyEnvelope's trusted-cert set to the session's pinned
+// key (issue #68) — without this filter VerifyEnvelope would trust whichever
+// key the envelope shipped with, which is the vulnerability we're closing.
+func envelopeCertsMatchingPin(envelope *attestation.Envelope, pin *sessionSignerPin) []*x509.Certificate {
+	if pin == nil {
+		return nil
+	}
+	var matched []*x509.Certificate
+	for _, sig := range envelope.Signatures {
+		if sig.Certificate == "" {
+			continue
+		}
+		block, _ := pem.Decode([]byte(sig.Certificate))
+		if block == nil {
+			continue
+		}
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			continue
+		}
+		fp, err := attestation.SPKIFingerprint(cert.PublicKey)
+		if err != nil || fp != pin.fingerprint {
+			continue
+		}
+		matched = append(matched, cert)
+	}
+	return matched
 }
 
 // findAttestation checks if a structurally valid attestation file exists for the given name.

--- a/internal/hooks/handler.go
+++ b/internal/hooks/handler.go
@@ -251,10 +251,17 @@ func (h *Handler) handleSessionStart(input *aflock.HookInput) error {
 // persists material that PostToolUse and the Stop gate need:
 //
 //   - signer-pubkey.pem (0600) — pubkey used by the Stop gate for verification
-//   - signer-key.pem (0600) — ephemeral private key; only written when running
-//     without SPIRE / Fulcio so PostToolUse subprocesses can reload it. SPIRE
-//     and Fulcio re-fetch their identities directly, so the private key is
-//     never written to disk in those modes.
+//   - signer-key.pem (0600) — ephemeral private key reloaded by PostToolUse
+//     subprocesses so every attestation in the session is signed by the same
+//     pinned key
+//
+// Hooks mode is intentionally ephemeral-only. SPIRE and Fulcio are not
+// selected here because (a) Fulcio mints a fresh cert per InitializeFulcio
+// call, so its pubkey wouldn't match the SessionStart pin and the Stop gate
+// would reject every attestation, and (b) hooks-mode SPIRE/Fulcio doesn't
+// give real key separation anyway — the key lives in the same trust domain
+// as the agent (issue #62). MCP-mode still uses the SPIRE → Fulcio →
+// ephemeral fallback because that path has its own verification pipeline.
 //
 // Failures here are non-fatal: SessionStart still completes, but
 // SignerPubKeyFingerprint stays empty and the Stop gate will deny any
@@ -267,26 +274,23 @@ func (h *Handler) establishSessionSigner(sessionState *aflock.SessionState, agen
 	signer := attestation.NewSigner("")
 	defer signer.Close() //nolint:errcheck // best-effort cleanup
 
-	mode := ""
-	if err := signer.Initialize(context.Background()); err == nil {
-		mode = "spire"
-	} else if fulcioErr := signer.InitializeFulcio(context.Background()); fulcioErr == nil {
-		mode = "fulcio"
-	} else {
-		identityHash := ""
-		if agentIdentity != nil {
-			identityHash = agentIdentity.IdentityHash
-		}
-		if err := signer.InitializeEphemeral(identityHash); err != nil {
-			fmt.Fprintf(os.Stderr, "[aflock] Warning: signer init failed at SessionStart: %v\n", err)
-			return
-		}
-		mode = "ephemeral"
+	identityHash := ""
+	if agentIdentity != nil {
+		identityHash = agentIdentity.IdentityHash
+	}
+	if err := signer.InitializeEphemeral(identityHash); err != nil {
+		fmt.Fprintf(os.Stderr, "[aflock] Warning: signer init failed at SessionStart: %v\n", err)
+		return
 	}
 
 	pubPEM, fingerprint, err := signer.MarshalSigningPublicKey()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "[aflock] Warning: marshal signer pubkey: %v\n", err)
+		return
+	}
+	keyPEM, keyErr := signer.MarshalEphemeralKey()
+	if keyErr != nil {
+		fmt.Fprintf(os.Stderr, "[aflock] Warning: marshal ephemeral signer key: %v\n", keyErr)
 		return
 	}
 
@@ -299,23 +303,15 @@ func (h *Handler) establishSessionSigner(sessionState *aflock.SessionState, agen
 		fmt.Fprintf(os.Stderr, "[aflock] Warning: write signer pubkey: %v\n", writeErr)
 		return
 	}
-
-	if mode == "ephemeral" {
-		keyPEM, keyErr := signer.MarshalEphemeralKey()
-		if keyErr != nil {
-			fmt.Fprintf(os.Stderr, "[aflock] Warning: marshal ephemeral signer key: %v\n", keyErr)
-			return
-		}
-		// The persisted private key is the durable session signing material —
-		// 0600 keeps it owner-only; broader permissions defeat the pin entirely.
-		if writeErr := os.WriteFile(filepath.Join(sessionDir, "signer-key.pem"), keyPEM, 0600); writeErr != nil {
-			fmt.Fprintf(os.Stderr, "[aflock] Warning: write ephemeral signer key: %v\n", writeErr)
-			return
-		}
+	// The persisted private key is the durable session signing material —
+	// 0600 keeps it owner-only; broader permissions defeat the pin entirely.
+	if writeErr := os.WriteFile(filepath.Join(sessionDir, "signer-key.pem"), keyPEM, 0600); writeErr != nil {
+		fmt.Fprintf(os.Stderr, "[aflock] Warning: write ephemeral signer key: %v\n", writeErr)
+		return
 	}
 
 	sessionState.SignerPubKeyFingerprint = fingerprint
-	sessionState.SigningMode = mode
+	sessionState.SigningMode = "ephemeral"
 }
 
 // buildPolicyContext creates context string describing the active policy.
@@ -683,32 +679,21 @@ func (h *Handler) createAttestation(sessionState *aflock.SessionState, input *af
 		}
 	}
 
-	// Create signer. In ephemeral mode reuse the per-session key established at
-	// SessionStart (issue #68); otherwise re-fetch from SPIRE / Fulcio.
+	// Create signer. Hooks mode always uses the per-session ephemeral key
+	// established at SessionStart (issue #68) — no SPIRE/Fulcio branches here
+	// because those mint fresh keys per call and would fail the SPKI pin.
 	signer := attestation.NewSigner("")
 	signerInitialized := false
-	switch sessionState.SigningMode {
-	case "spire":
-		if err := signer.Initialize(context.Background()); err == nil {
-			signerInitialized = true
+	keyPath := filepath.Join(h.stateManager.SessionDir(sessionState.SessionID), "signer-key.pem")
+	if keyPEM, readErr := os.ReadFile(keyPath); readErr == nil { //nolint:gosec // G304: keyPath is under SessionDir
+		identityHash := ""
+		if agentIdentity != nil {
+			identityHash = agentIdentity.IdentityHash
 		}
-	case "fulcio":
-		if err := signer.InitializeFulcio(context.Background()); err == nil {
+		if err := signer.InitializeFromPersistedKey(keyPEM, identityHash); err == nil {
 			signerInitialized = true
-		}
-	case "ephemeral", "":
-		keyPath := filepath.Join(h.stateManager.SessionDir(sessionState.SessionID), "signer-key.pem")
-		keyPEM, readErr := os.ReadFile(keyPath) //nolint:gosec // G304: keyPath is under SessionDir
-		if readErr == nil {
-			identityHash := ""
-			if agentIdentity != nil {
-				identityHash = agentIdentity.IdentityHash
-			}
-			if err := signer.InitializeFromPersistedKey(keyPEM, identityHash); err == nil {
-				signerInitialized = true
-			} else {
-				fmt.Fprintf(os.Stderr, "[aflock] Warning: load persisted signer key: %v\n", err)
-			}
+		} else {
+			fmt.Fprintf(os.Stderr, "[aflock] Warning: load persisted signer key: %v\n", err)
 		}
 	}
 	if !signerInitialized {

--- a/internal/hooks/handler_forgery_test.go
+++ b/internal/hooks/handler_forgery_test.go
@@ -21,11 +21,23 @@ import (
 // (hooks-mode signing key lives in the agent's trust domain).
 
 // Helper: produce a valid signed attestation using the ephemeral signer so
-// the test is independent of SPIRE/Fulcio availability.
-func newSignedAttestation(t *testing.T, sessionID, toolName, toolUseID, decision string) *attestation.Envelope {
+// the test is independent of SPIRE/Fulcio availability. Pass a non-empty
+// handler if the attestation needs to be signed with a session's pinned
+// key (issue #68) — pass nil to use a fresh ephemeral key, which is what
+// cross-session-replay and foreign-key-forgery tests want.
+func newSignedAttestationForSession(t *testing.T, h *Handler, sessionID, toolName, toolUseID, decision string) *attestation.Envelope {
 	t.Helper()
 	signer := attestation.NewSigner("")
-	if err := signer.InitializeEphemeral("test-identity"); err != nil {
+	if h != nil {
+		keyPath := filepath.Join(h.stateManager.SessionDir(sessionID), "signer-key.pem")
+		keyPEM, err := os.ReadFile(keyPath)
+		if err != nil {
+			t.Fatalf("read pinned signer key: %v", err)
+		}
+		if err := signer.InitializeFromPersistedKey(keyPEM, "test-identity"); err != nil {
+			t.Fatalf("InitializeFromPersistedKey: %v", err)
+		}
+	} else if err := signer.InitializeEphemeral("test-identity"); err != nil {
 		t.Fatalf("InitializeEphemeral: %v", err)
 	}
 	t.Cleanup(func() { _ = signer.Close() })
@@ -130,8 +142,9 @@ func TestHandleStop_RejectsStructurallyValidButCryptoInvalid(t *testing.T) {
 		t.Fatalf("save: %v", err)
 	}
 
-	// Build a real envelope, then corrupt the signature so crypto check fails.
-	env := newSignedAttestation(t, "session-forged-crypto", "Bash", "tu-crypto-1", "allow")
+	// Build a real envelope (signed by the session's pinned key), then corrupt
+	// the signature so the crypto check fails after the SPKI pin matches.
+	env := newSignedAttestationForSession(t, h, "session-forged-crypto", "Bash", "tu-crypto-1", "allow")
 	// Replace sig bytes with junk (still base64-valid, different length).
 	env.Signatures[0].Sig = base64.StdEncoding.EncodeToString([]byte("wrong-signature-bytes"))
 
@@ -178,8 +191,9 @@ func TestHandleStop_RejectsCrossSessionReplay(t *testing.T) {
 		t.Fatalf("save: %v", err)
 	}
 
-	// Produce a valid attestation signed under session A and drop it in B's dir.
-	envA := newSignedAttestation(t, "session-A-different", "Bash", "tu-A", "allow")
+	// Produce a valid attestation signed under session A (different key, not
+	// B's pin) and drop it in B's dir.
+	envA := newSignedAttestationForSession(t, nil, "session-A-different", "Bash", "tu-A", "allow")
 	attestDirB := h.stateManager.AttestationsDir("session-B")
 	writeEnvelope(t, filepath.Join(attestDirB, "Bash.intoto.json"), envA)
 
@@ -216,7 +230,7 @@ func TestHandleStop_AcceptsLegitimateAttestation(t *testing.T) {
 		t.Fatalf("save: %v", err)
 	}
 
-	env := newSignedAttestation(t, "session-legit", "Bash", "tu-legit", "allow")
+	env := newSignedAttestationForSession(t, h, "session-legit", "Bash", "tu-legit", "allow")
 	attestDir := h.stateManager.AttestationsDir("session-legit")
 	writeEnvelope(t, filepath.Join(attestDir, "Bash.intoto.json"), env)
 
@@ -233,6 +247,138 @@ func TestHandleStop_AcceptsLegitimateAttestation(t *testing.T) {
 	}
 	if out.Decision == "block" {
 		t.Errorf("legitimate attestation must satisfy Stop gate, got block: %s", out.Reason)
+	}
+}
+
+// TestHandleStop_RejectsForeignKeyForgery reproduces the issue #68 attack:
+// an attacker who can only write into the attestations dir generates their
+// own keypair + self-signed cert, signs a DSSE envelope binding to the
+// session's recorded toolUseID, embeds the self-signed cert, and drops the
+// file. The Stop gate must reject because the cert's SPKI does not match
+// the pin established at SessionStart.
+func TestHandleStop_RejectsForeignKeyForgery(t *testing.T) {
+	h := newTestHandler(t)
+	pol := &aflock.Policy{
+		Name:                 "issue-68",
+		Tools:                &aflock.ToolsPolicy{Allow: []string{"Bash"}},
+		RequiredAttestations: []string{"Bash"},
+	}
+	ss := seedSession(t, h, "session-issue-68", pol)
+	ss.Actions = append(ss.Actions, aflock.ActionRecord{
+		Timestamp: time.Now(), ToolName: "Bash", ToolUseID: "tu-victim", Decision: "allow",
+	})
+	if err := h.stateManager.Save(ss); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	// Attacker mints their own signer and produces a fully-valid envelope
+	// bound to the victim session/tool/toolUseID. Same shape as the
+	// reproduction sketch in the issue.
+	forgedEnv := newSignedAttestationForSession(t, nil, "session-issue-68", "Bash", "tu-victim", "allow")
+	attestDir := h.stateManager.AttestationsDir("session-issue-68")
+	writeEnvelope(t, filepath.Join(attestDir, "Bash.intoto.json"), forgedEnv)
+
+	input := &aflock.HookInput{SessionID: "session-issue-68"}
+	got := captureStdout(t, func() {
+		if err := h.handleStop(input); err != nil {
+			t.Fatalf("handleStop: %v", err)
+		}
+	})
+
+	var out aflock.HookOutput
+	if err := json.Unmarshal([]byte(got), &out); err != nil {
+		t.Fatalf("parse: %v (raw: %s)", err, got)
+	}
+	if out.Decision != "block" {
+		t.Errorf("foreign-key forgery must NOT satisfy Stop gate, got decision=%q reason=%q", out.Decision, out.Reason)
+	}
+}
+
+// TestHandleStop_FailsClosedOnMissingPin guards the "delete the pin and
+// drop a forgery" extension of the issue #68 attack: if signer-pubkey.pem or
+// the recorded fingerprint is missing, the gate must deny rather than fall
+// back to today's "trust whatever cert ships in the envelope" behavior.
+func TestHandleStop_FailsClosedOnMissingPin(t *testing.T) {
+	h := newTestHandler(t)
+	pol := &aflock.Policy{
+		Name:                 "pin-missing",
+		Tools:                &aflock.ToolsPolicy{Allow: []string{"Bash"}},
+		RequiredAttestations: []string{"Bash"},
+	}
+	ss := seedSession(t, h, "session-no-pin", pol)
+	ss.Actions = append(ss.Actions, aflock.ActionRecord{
+		Timestamp: time.Now(), ToolName: "Bash", ToolUseID: "tu-x", Decision: "allow",
+	})
+	// Wipe the pin: simulate a session created before pinning or a
+	// state.json deliberately stripped of its fingerprint.
+	ss.SignerPubKeyFingerprint = ""
+	ss.SigningMode = ""
+	if err := h.stateManager.Save(ss); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if err := os.Remove(filepath.Join(h.stateManager.SessionDir("session-no-pin"), "signer-pubkey.pem")); err != nil {
+		t.Fatalf("remove pubkey: %v", err)
+	}
+
+	// Even a "valid" envelope (signed by a fresh ephemeral key) must NOT
+	// satisfy the gate when the pin is gone.
+	env := newSignedAttestationForSession(t, nil, "session-no-pin", "Bash", "tu-x", "allow")
+	writeEnvelope(t, filepath.Join(h.stateManager.AttestationsDir("session-no-pin"), "Bash.intoto.json"), env)
+
+	input := &aflock.HookInput{SessionID: "session-no-pin"}
+	got := captureStdout(t, func() {
+		if err := h.handleStop(input); err != nil {
+			t.Fatalf("handleStop: %v", err)
+		}
+	})
+
+	var out aflock.HookOutput
+	if err := json.Unmarshal([]byte(got), &out); err != nil {
+		t.Fatalf("parse: %v (raw: %s)", err, got)
+	}
+	if out.Decision != "block" {
+		t.Errorf("missing pin must fail closed, got decision=%q", out.Decision)
+	}
+}
+
+// TestHandleStop_FailsClosedOnTamperedFingerprint guards against an attacker
+// who can modify state.json: changing the recorded fingerprint to something
+// they control must be detected (the on-disk pubkey's actual SPKI hash
+// won't match the tampered field).
+func TestHandleStop_FailsClosedOnTamperedFingerprint(t *testing.T) {
+	h := newTestHandler(t)
+	pol := &aflock.Policy{
+		Name:                 "pin-tampered",
+		Tools:                &aflock.ToolsPolicy{Allow: []string{"Bash"}},
+		RequiredAttestations: []string{"Bash"},
+	}
+	ss := seedSession(t, h, "session-tampered", pol)
+	ss.Actions = append(ss.Actions, aflock.ActionRecord{
+		Timestamp: time.Now(), ToolName: "Bash", ToolUseID: "tu-y", Decision: "allow",
+	})
+	// Overwrite the recorded fingerprint with a value that does not match
+	// the persisted signer-pubkey.pem.
+	ss.SignerPubKeyFingerprint = strings.Repeat("0", 64)
+	if err := h.stateManager.Save(ss); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	env := newSignedAttestationForSession(t, h, "session-tampered", "Bash", "tu-y", "allow")
+	writeEnvelope(t, filepath.Join(h.stateManager.AttestationsDir("session-tampered"), "Bash.intoto.json"), env)
+
+	input := &aflock.HookInput{SessionID: "session-tampered"}
+	got := captureStdout(t, func() {
+		if err := h.handleStop(input); err != nil {
+			t.Fatalf("handleStop: %v", err)
+		}
+	})
+
+	var out aflock.HookOutput
+	if err := json.Unmarshal([]byte(got), &out); err != nil {
+		t.Fatalf("parse: %v (raw: %s)", err, got)
+	}
+	if out.Decision != "block" {
+		t.Errorf("tampered fingerprint must fail closed, got decision=%q", out.Decision)
 	}
 }
 

--- a/internal/hooks/handler_test.go
+++ b/internal/hooks/handler_test.go
@@ -23,10 +23,13 @@ func newTestHandler(t *testing.T) *Handler {
 	return h
 }
 
-// seedSession initializes a session with the given policy and returns the session state.
+// seedSession initializes a session with the given policy and returns the
+// session state. It also establishes the per-session signing pin (issue #68)
+// the same way SessionStart does, so Stop-gate tests see realistic state.
 func seedSession(t *testing.T, h *Handler, sessionID string, pol *aflock.Policy) *aflock.SessionState {
 	t.Helper()
 	ss := h.stateManager.Initialize(sessionID, pol, "/fake/policy.aflock")
+	h.establishSessionSigner(ss, nil)
 	if err := h.stateManager.Save(ss); err != nil {
 		t.Fatalf("seed session: %v", err)
 	}

--- a/pkg/aflock/types.go
+++ b/pkg/aflock/types.go
@@ -487,9 +487,12 @@ type SessionState struct {
 	// the pinned one (issue #68). Empty for legacy sessions established
 	// before pinning was introduced.
 	SignerPubKeyFingerprint string `json:"signer_pubkey_fingerprint,omitempty"`
-	// SigningMode records how the session's signing key was established:
-	// "ephemeral", "spire", "fulcio". Determines how the Stop gate verifies
-	// attestations.
+	// SigningMode records how the session's signing key was established.
+	// Hooks mode always sets this to "ephemeral" today (see
+	// establishSessionSigner in internal/hooks/handler.go for why SPIRE/Fulcio
+	// aren't selected in hooks). The field is kept on the wire so future
+	// chain-validation work for SPIRE/Fulcio (#62) can branch Stop-gate
+	// behavior without a state-shape migration.
 	SigningMode string `json:"signing_mode,omitempty"`
 }
 

--- a/pkg/aflock/types.go
+++ b/pkg/aflock/types.go
@@ -481,6 +481,16 @@ type SessionState struct {
 	// AuthToken is the JWT issued at SessionStart for request-level authorization.
 	// Scoped to the session, agent identity, and policy grants.
 	AuthToken string `json:"auth_token,omitempty"`
+	// SignerPubKeyFingerprint is the hex-encoded SHA-256 of the SPKI for the
+	// per-session attestation signing pubkey persisted at SessionStart. The
+	// Stop gate uses this to reject attestations signed by any key other than
+	// the pinned one (issue #68). Empty for legacy sessions established
+	// before pinning was introduced.
+	SignerPubKeyFingerprint string `json:"signer_pubkey_fingerprint,omitempty"`
+	// SigningMode records how the session's signing key was established:
+	// "ephemeral", "spire", "fulcio". Determines how the Stop gate verifies
+	// attestations.
+	SigningMode string `json:"signing_mode,omitempty"`
 }
 
 // AgentIdentityMeta stores agent identity metadata in session state.


### PR DESCRIPTION
## Summary
Closes #68. The Stop gate trusted certs embedded in the attestation envelope itself — any file-drop attacker with their own keypair could forge a valid-looking attestation. Now we pin the per-session signer pubkey at SessionStart and reject any envelope whose cert SPKI doesn't match.

## Details
- SessionStart writes `signer-pubkey.pem` + SPKI fingerprint in `state.json`; ephemeral mode also persists `signer-key.pem` so PostToolUse reuses one key per session.
- `cryptographicallyVerifyAttestation` now filters envelope certs by SPKI match against the pin before calling `VerifyEnvelope`.
- Fail-closed on missing pin, tampered fingerprint, or pre-pinning sessions — restart the session to re-establish.
- Tests cover the issue's reproduction (foreign-key forgery), missing-pin, and tampered-fingerprint paths.
- SPIRE/Fulcio chain validation at the Stop gate left as follow-up under #62.