### PR TITLE
fix(mcp): gate HTTP get_token on bootstrap secret

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -6,7 +6,9 @@ import (
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
+	"crypto/rand"
 	"crypto/sha256"
+	"crypto/subtle"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -66,6 +68,22 @@ type Server struct {
 	// AFLOCK_REQUIRE_TOKEN=1 env var. Closes the unauthenticated bootstrap
 	// window (issue #59 / M10). Default false for backward compatibility.
 	requireToken bool
+
+	// transportMode records which Serve* method was invoked: "stdio", "unix",
+	// or "http". get_token's bootstrap-secret gate (issue #42) is scoped to
+	// "http" because stdio inherits process-tree isolation and unix has
+	// SO_PEERCRED + UID-match at accept time — both already prove same-UID
+	// without an extra secret. Empty until a Serve* method runs.
+	transportMode string
+
+	// httpBootstrapSecret is the random secret a caller must present (via the
+	// _bootstrap arg) to get_token in HTTP transport mode (issue #42). It's
+	// generated when ServeHTTP starts, written to a 0600 file under the
+	// session dir so only the same-UID caller can read it, and cleared from
+	// memory + disk once consumed (one-time use).
+	httpBootstrapSecret      string
+	httpBootstrapSecretPath  string
+	httpBootstrapSecretMu    sync.Mutex
 }
 
 // NewServer creates a new aflock MCP server.
@@ -186,6 +204,7 @@ func (s *Server) registerTools() {
 
 // Serve starts the MCP server on stdio.
 func (s *Server) Serve(policyPath string) error {
+	s.transportMode = "stdio"
 	// Load policy if path provided
 	if policyPath != "" {
 		pol, path, err := policy.Load(policyPath)
@@ -243,7 +262,18 @@ func (s *Server) projectRoot() string {
 
 // ServeHTTP starts the MCP server on HTTP with SSE transport.
 // This keeps the server running so session state persists across calls.
+//
+// SECURITY (issue #42): unlike stdio (process-tree isolation) and Unix-domain
+// (SO_PEERCRED + UID check at accept), HTTP/SSE has no kernel-attested peer
+// identity — any local process at any UID could reach 127.0.0.1:port and
+// mint a JWT via get_token. To close that bootstrap gap, ServeHTTP writes a
+// random secret to a 0600 file under the session dir. get_token in HTTP
+// mode requires the caller to present this secret via the _bootstrap arg;
+// since the file is same-UID-only by FS permission, this matches the trust
+// boundary the other transports get for free. The secret is one-time-use
+// and removed after the first successful get_token.
 func (s *Server) ServeHTTP(policyPath string, port int) error {
+	s.transportMode = "http"
 	// Load policy if path provided
 	if policyPath != "" {
 		pol, path, err := policy.Load(policyPath)
@@ -289,6 +319,14 @@ func (s *Server) ServeHTTP(policyPath string, port int) error {
 		fmt.Fprintf(os.Stderr, "[aflock] HTTP MCP server starting (no policy loaded)\n")
 	}
 
+	// Issue #42: HTTP transport has no kernel-attested peer, so guard
+	// get_token behind a same-UID-readable bootstrap secret. Refuse to start
+	// if the secret can't be written — failing closed beats running an
+	// unauthenticated token dispenser.
+	if err := s.initHTTPBootstrapSecret(); err != nil {
+		return fmt.Errorf("init HTTP bootstrap secret: %w", err)
+	}
+
 	// Create SSE server
 	sseServer := server.NewSSEServer(s.mcpServer)
 
@@ -296,8 +334,60 @@ func (s *Server) ServeHTTP(policyPath string, port int) error {
 	addr := fmt.Sprintf("127.0.0.1:%d", port)
 	fmt.Fprintf(os.Stderr, "[aflock] MCP server listening on http://%s/sse\n", addr)
 	fmt.Fprintf(os.Stderr, "[aflock] Session ID: %s (state will persist across calls)\n", s.sessionID)
+	fmt.Fprintf(os.Stderr, "[aflock] HTTP bootstrap secret: %s (0600 — pass via _bootstrap arg on get_token)\n", s.httpBootstrapSecretPath)
 
 	return http.ListenAndServe(addr, sseServer) //nolint:gosec // G114: HTTP server with no timeout is acceptable for local MCP
+}
+
+// initHTTPBootstrapSecret generates a 32-byte random secret and writes it to
+// a 0600 file under the session dir (issue #42). Returns an error if the
+// secret cannot be generated or persisted — ServeHTTP fails closed rather
+// than running without the gate. The path is recorded on the Server so
+// handleGetToken can read it back, compare in constant time, and remove the
+// file on first successful use.
+func (s *Server) initHTTPBootstrapSecret() error {
+	raw := make([]byte, 32)
+	if _, err := rand.Read(raw); err != nil {
+		return fmt.Errorf("generate bootstrap secret: %w", err)
+	}
+	secret := hex.EncodeToString(raw)
+
+	sessionDir := s.stateManager.SessionDir(s.sessionID)
+	if err := os.MkdirAll(sessionDir, 0700); err != nil {
+		return fmt.Errorf("create session dir: %w", err)
+	}
+	path := filepath.Join(sessionDir, "http-bootstrap-secret")
+	if err := os.WriteFile(path, []byte(secret), 0600); err != nil {
+		return fmt.Errorf("write bootstrap secret: %w", err)
+	}
+
+	s.httpBootstrapSecretMu.Lock()
+	s.httpBootstrapSecret = secret
+	s.httpBootstrapSecretPath = path
+	s.httpBootstrapSecretMu.Unlock()
+	return nil
+}
+
+// consumeHTTPBootstrapSecret performs a constant-time comparison between the
+// presented secret and the in-memory secret. On match, the secret is cleared
+// from memory and the on-disk file is removed — one-time use closes the
+// window where the same secret could be replayed by a different caller
+// after it leaked (e.g., via a verbose request log).
+func (s *Server) consumeHTTPBootstrapSecret(presented string) bool {
+	s.httpBootstrapSecretMu.Lock()
+	defer s.httpBootstrapSecretMu.Unlock()
+	if s.httpBootstrapSecret == "" {
+		return false
+	}
+	if subtle.ConstantTimeCompare([]byte(presented), []byte(s.httpBootstrapSecret)) != 1 {
+		return false
+	}
+	s.httpBootstrapSecret = ""
+	if s.httpBootstrapSecretPath != "" {
+		_ = os.Remove(s.httpBootstrapSecretPath)
+		s.httpBootstrapSecretPath = ""
+	}
+	return true
 }
 
 // ServeUnix starts the MCP server on a Unix-domain-socket transport with
@@ -323,6 +413,7 @@ func (s *Server) ServeHTTP(policyPath string, port int) error {
 // client requires the operator to re-run `aflock serve --unix`. This
 // matches the stdio transport's lifecycle.
 func (s *Server) ServeUnix(policyPath, socketPath string) error {
+	s.transportMode = "unix"
 	if socketPath == "" {
 		return fmt.Errorf("socket path is required")
 	}
@@ -608,9 +699,24 @@ func (s *Server) initAuth() error {
 }
 
 // handleGetToken issues a JWT for the current session.
-func (s *Server) handleGetToken(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+//
+// In HTTP transport mode (issue #42) the caller must present the
+// one-time bootstrap secret in the _bootstrap arg. stdio and unix transports
+// already prove same-UID via process-tree isolation / SO_PEERCRED, so they
+// skip this gate.
+func (s *Server) handleGetToken(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	if s.tokenIssuer == nil {
 		return mcp.NewToolResultError("Token issuer not initialized"), nil
+	}
+
+	if s.transportMode == "http" {
+		presented, _ := request.GetArguments()["_bootstrap"].(string)
+		if presented == "" {
+			return mcp.NewToolResultError("missing _bootstrap arg; HTTP transport requires the secret written at server start"), nil
+		}
+		if !s.consumeHTTPBootstrapSecret(presented) {
+			return mcp.NewToolResultError("invalid or already-consumed bootstrap secret"), nil
+		}
 	}
 
 	ttl := 1 * time.Hour

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -368,26 +368,33 @@ func (s *Server) initHTTPBootstrapSecret() error {
 	return nil
 }
 
-// consumeHTTPBootstrapSecret performs a constant-time comparison between the
-// presented secret and the in-memory secret. On match, the secret is cleared
-// from memory and the on-disk file is removed — one-time use closes the
-// window where the same secret could be replayed by a different caller
-// after it leaked (e.g., via a verbose request log).
-func (s *Server) consumeHTTPBootstrapSecret(presented string) bool {
+// verifyHTTPBootstrapSecret performs a constant-time comparison between the
+// presented secret and the in-memory secret WITHOUT clearing on match. The
+// caller is expected to clear via clearHTTPBootstrapSecret only after the
+// downstream operation (token issuance) succeeds — otherwise a transient
+// IssueToken failure would burn the only credential the client has, locking
+// the session out until server restart (Copilot review on PR #109).
+func (s *Server) verifyHTTPBootstrapSecret(presented string) bool {
 	s.httpBootstrapSecretMu.Lock()
 	defer s.httpBootstrapSecretMu.Unlock()
 	if s.httpBootstrapSecret == "" {
 		return false
 	}
-	if subtle.ConstantTimeCompare([]byte(presented), []byte(s.httpBootstrapSecret)) != 1 {
-		return false
-	}
+	return subtle.ConstantTimeCompare([]byte(presented), []byte(s.httpBootstrapSecret)) == 1
+}
+
+// clearHTTPBootstrapSecret zeroes the in-memory secret and removes the
+// on-disk file. Idempotent. Called only after a successful get_token
+// issuance so that a one-time-use guarantee holds without burning the
+// credential on retriable failures.
+func (s *Server) clearHTTPBootstrapSecret() {
+	s.httpBootstrapSecretMu.Lock()
+	defer s.httpBootstrapSecretMu.Unlock()
 	s.httpBootstrapSecret = ""
 	if s.httpBootstrapSecretPath != "" {
 		_ = os.Remove(s.httpBootstrapSecretPath)
 		s.httpBootstrapSecretPath = ""
 	}
-	return true
 }
 
 // ServeUnix starts the MCP server on a Unix-domain-socket transport with
@@ -700,22 +707,42 @@ func (s *Server) initAuth() error {
 
 // handleGetToken issues a JWT for the current session.
 //
-// In HTTP transport mode (issue #42) the caller must present the
-// one-time bootstrap secret in the _bootstrap arg. stdio and unix transports
-// already prove same-UID via process-tree isolation / SO_PEERCRED, so they
-// skip this gate.
+// In HTTP transport mode (issue #42) the caller must prove same-UID either by
+// presenting the bootstrap secret (_bootstrap) on the first call OR by
+// presenting a valid existing JWT (_token) on subsequent calls. Either path
+// lets the legitimate client refresh tokens after expiry without a server
+// restart (Copilot review on PR #109). The bootstrap secret is consumed only
+// after a successful IssueToken — a transient signing failure must not burn
+// the credential.
+//
+// stdio and unix transports already prove same-UID via process-tree
+// isolation / SO_PEERCRED, so they skip this gate.
 func (s *Server) handleGetToken(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	if s.tokenIssuer == nil {
 		return mcp.NewToolResultError("Token issuer not initialized"), nil
 	}
 
+	// Track whether this call authenticated via bootstrap, so we can clear
+	// the secret if and only if IssueToken succeeds below.
+	usedBootstrap := false
 	if s.transportMode == "http" {
-		presented, _ := request.GetArguments()["_bootstrap"].(string)
-		if presented == "" {
-			return mcp.NewToolResultError("missing _bootstrap arg; HTTP transport requires the secret written at server start"), nil
+		args := request.GetArguments()
+		validRefresh := false
+		if existing, _ := args["_token"].(string); existing != "" {
+			if _, err := s.tokenIssuer.ValidateTokenForSessionAndPolicy(
+				existing, s.sessionID, s.computePolicyDigest()); err == nil {
+				validRefresh = true
+			}
 		}
-		if !s.consumeHTTPBootstrapSecret(presented) {
-			return mcp.NewToolResultError("invalid or already-consumed bootstrap secret"), nil
+		if !validRefresh {
+			presented, _ := args["_bootstrap"].(string)
+			if presented == "" {
+				return mcp.NewToolResultError("missing _bootstrap arg; HTTP transport requires the secret written at server start (or a valid _token for refresh)"), nil
+			}
+			if !s.verifyHTTPBootstrapSecret(presented) {
+				return mcp.NewToolResultError("invalid or already-consumed bootstrap secret"), nil
+			}
+			usedBootstrap = true
 		}
 	}
 
@@ -745,7 +772,13 @@ func (s *Server) handleGetToken(_ context.Context, request mcp.CallToolRequest) 
 		ttl,
 	)
 	if err != nil {
+		// Bootstrap secret stays intact — a retry after fixing the signer
+		// must be able to use the same credential (Copilot review on PR #109).
 		return mcp.NewToolResultError(fmt.Sprintf("Failed to issue token: %v", err)), nil
+	}
+
+	if usedBootstrap {
+		s.clearHTTPBootstrapSecret()
 	}
 
 	// Persist the token AND flip authActive under sessionMu so concurrent

--- a/internal/mcp/server_http_bootstrap_test.go
+++ b/internal/mcp/server_http_bootstrap_test.go
@@ -1,0 +1,170 @@
+package mcp
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/aflock-ai/aflock/internal/auth"
+	"github.com/aflock-ai/aflock/pkg/aflock"
+)
+
+// Issue #42 — HTTP transport has no kernel-attested peer identity, so
+// handleGetToken must require a same-UID-readable bootstrap secret. The tests
+// in this file pin that behavior against the three regressions that would
+// reopen the bug:
+//
+//   - HTTP get_token without the secret silently issues a token
+//   - HTTP get_token with the wrong secret silently issues a token
+//   - HTTP get_token's secret is reusable (replay)
+//
+// stdio + unix transports are explicitly verified to NOT require the secret,
+// so we don't add ceremony where the existing trust boundary already holds.
+
+func httpServerWithBootstrap(t *testing.T) *Server {
+	t.Helper()
+	s := newTestServerWithPolicy(t, &aflock.Policy{
+		Name:    "http-bootstrap",
+		Version: "1.0",
+		Tools:   &aflock.ToolsPolicy{Allow: []string{"Bash"}},
+	})
+	s.transportMode = "http"
+	issuer, err := auth.NewTokenIssuer()
+	if err != nil {
+		t.Fatalf("issuer: %v", err)
+	}
+	s.tokenIssuer = issuer
+	if err := s.initHTTPBootstrapSecret(); err != nil {
+		t.Fatalf("initHTTPBootstrapSecret: %v", err)
+	}
+	return s
+}
+
+func TestHandleGetToken_HTTP_DeniesWithoutSecret(t *testing.T) {
+	s := httpServerWithBootstrap(t)
+
+	result, err := s.handleGetToken(context.Background(), callRequest(nil))
+	if err != nil {
+		t.Fatalf("handleGetToken returned Go error: %v", err)
+	}
+	if result == nil || !result.IsError {
+		t.Fatalf("HTTP get_token without _bootstrap must return an error result, got: %+v", result)
+	}
+	if s.authActive.Load() {
+		t.Error("authActive must stay false when bootstrap fails")
+	}
+}
+
+func TestHandleGetToken_HTTP_DeniesWithWrongSecret(t *testing.T) {
+	s := httpServerWithBootstrap(t)
+
+	result, err := s.handleGetToken(context.Background(), callRequest(map[string]any{
+		"_bootstrap": "deadbeef-not-the-real-secret",
+	}))
+	if err != nil {
+		t.Fatalf("handleGetToken: %v", err)
+	}
+	if result == nil || !result.IsError {
+		t.Fatalf("HTTP get_token with wrong _bootstrap must return error, got: %+v", result)
+	}
+	// The real secret must still be present — a wrong attempt should not
+	// burn the secret (otherwise an attacker can DoS the legitimate client
+	// by spamming get_token with junk).
+	s.httpBootstrapSecretMu.Lock()
+	stillThere := s.httpBootstrapSecret != ""
+	s.httpBootstrapSecretMu.Unlock()
+	if !stillThere {
+		t.Error("wrong-secret attempt must not burn the real secret")
+	}
+}
+
+func TestHandleGetToken_HTTP_AcceptsCorrectSecretAndOneTime(t *testing.T) {
+	s := httpServerWithBootstrap(t)
+
+	// Read the secret off disk the way the legitimate client would.
+	secretBytes, err := os.ReadFile(s.httpBootstrapSecretPath)
+	if err != nil {
+		t.Fatalf("read secret file: %v", err)
+	}
+	pathBeforeUse := s.httpBootstrapSecretPath
+
+	result, err := s.handleGetToken(context.Background(), callRequest(map[string]any{
+		"_bootstrap": string(secretBytes),
+	}))
+	if err != nil {
+		t.Fatalf("handleGetToken: %v", err)
+	}
+	if result == nil || result.IsError {
+		t.Fatalf("HTTP get_token with correct _bootstrap must succeed, got: %+v", result)
+	}
+	if !s.authActive.Load() {
+		t.Error("authActive must flip true after successful bootstrap")
+	}
+
+	// One-time use: in-memory secret cleared.
+	s.httpBootstrapSecretMu.Lock()
+	memCleared := s.httpBootstrapSecret == ""
+	s.httpBootstrapSecretMu.Unlock()
+	if !memCleared {
+		t.Error("in-memory secret must be cleared after consumption")
+	}
+	// And the on-disk file is gone.
+	if _, statErr := os.Stat(pathBeforeUse); !os.IsNotExist(statErr) {
+		t.Errorf("on-disk secret file must be removed after consumption, stat err=%v", statErr)
+	}
+
+	// Second use with the same secret must fail — replay defense.
+	result2, err := s.handleGetToken(context.Background(), callRequest(map[string]any{
+		"_bootstrap": string(secretBytes),
+	}))
+	if err != nil {
+		t.Fatalf("handleGetToken (replay): %v", err)
+	}
+	if result2 == nil || !result2.IsError {
+		t.Errorf("replayed bootstrap secret must be rejected, got: %+v", result2)
+	}
+}
+
+func TestHandleGetToken_StdioAndUnix_DoNotRequireBootstrap(t *testing.T) {
+	for _, mode := range []string{"stdio", "unix", ""} {
+		t.Run("mode="+mode, func(t *testing.T) {
+			s := newTestServerWithPolicy(t, &aflock.Policy{
+				Name:    "no-bootstrap-" + mode,
+				Version: "1.0",
+				Tools:   &aflock.ToolsPolicy{Allow: []string{"Bash"}},
+			})
+			s.transportMode = mode
+			issuer, err := auth.NewTokenIssuer()
+			if err != nil {
+				t.Fatalf("issuer: %v", err)
+			}
+			s.tokenIssuer = issuer
+
+			result, err := s.handleGetToken(context.Background(), callRequest(nil))
+			if err != nil {
+				t.Fatalf("handleGetToken: %v", err)
+			}
+			if result == nil || result.IsError {
+				t.Fatalf("transport %q must not require _bootstrap, got: %+v", mode, result)
+			}
+		})
+	}
+}
+
+func TestInitHTTPBootstrapSecret_FilePermissions(t *testing.T) {
+	s := newTestServerWithPolicy(t, &aflock.Policy{Name: "perms", Version: "1.0"})
+	if err := s.initHTTPBootstrapSecret(); err != nil {
+		t.Fatalf("initHTTPBootstrapSecret: %v", err)
+	}
+	info, err := os.Stat(s.httpBootstrapSecretPath)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode().Perm() != 0600 {
+		t.Errorf("bootstrap secret file perms = %v, want 0600", info.Mode().Perm())
+	}
+	if dir := filepath.Dir(s.httpBootstrapSecretPath); dir == "" {
+		t.Error("secret path should live under a session dir")
+	}
+}

--- a/internal/mcp/server_http_bootstrap_test.go
+++ b/internal/mcp/server_http_bootstrap_test.go
@@ -2,9 +2,18 @@ package mcp
 
 import (
 	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/json"
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
 
 	"github.com/aflock-ai/aflock/internal/auth"
 	"github.com/aflock-ai/aflock/pkg/aflock"
@@ -150,6 +159,158 @@ func TestHandleGetToken_StdioAndUnix_DoNotRequireBootstrap(t *testing.T) {
 			}
 		})
 	}
+}
+
+// httpBootstrapFailingSigner is a crypto.Signer that always fails at signing
+// time. Used to exercise the "bootstrap secret survives a transient
+// IssueToken failure" path (Copilot review on PR #109).
+type httpBootstrapFailingSigner struct {
+	pub *ecdsa.PublicKey
+}
+
+func (f httpBootstrapFailingSigner) Public() crypto.PublicKey { return f.pub }
+func (f httpBootstrapFailingSigner) Sign(_ io.Reader, _ []byte, _ crypto.SignerOpts) ([]byte, error) {
+	return nil, errors.New("simulated signing failure")
+}
+
+// TestHandleGetToken_HTTP_BootstrapSurvivesIssueTokenFailure pins the fix for
+// the Copilot finding: if IssueToken fails AFTER the bootstrap secret was
+// verified, the secret must NOT be burned — otherwise a transient signer
+// fault permanently locks out the legitimate client.
+func TestHandleGetToken_HTTP_BootstrapSurvivesIssueTokenFailure(t *testing.T) {
+	s := newTestServerWithPolicy(t, &aflock.Policy{
+		Name: "bootstrap-rollback", Version: "1.0",
+		Tools: &aflock.ToolsPolicy{Allow: []string{"Bash"}},
+	})
+	s.transportMode = "http"
+	if err := s.initHTTPBootstrapSecret(); err != nil {
+		t.Fatalf("initHTTPBootstrapSecret: %v", err)
+	}
+	pathBefore := s.httpBootstrapSecretPath
+	secretBytes, err := os.ReadFile(pathBefore)
+	if err != nil {
+		t.Fatalf("read secret: %v", err)
+	}
+
+	// Wire a TokenIssuer whose signer fails at Sign time — exercises the
+	// realistic SPIRE-SVID-broken / KMS-handle-broken failure mode.
+	realKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	s.tokenIssuer = auth.NewTokenIssuerFromSigner(
+		httpBootstrapFailingSigner{pub: &realKey.PublicKey},
+		"failing-signer",
+	)
+
+	result, err := s.handleGetToken(context.Background(), callRequest(map[string]any{
+		"_bootstrap": string(secretBytes),
+	}))
+	if err != nil {
+		t.Fatalf("handleGetToken: %v", err)
+	}
+	if result == nil || !result.IsError {
+		t.Fatalf("expected error result on IssueToken failure, got: %+v", result)
+	}
+
+	// The secret must still be present in memory and on disk.
+	s.httpBootstrapSecretMu.Lock()
+	memKept := s.httpBootstrapSecret != ""
+	pathKept := s.httpBootstrapSecretPath
+	s.httpBootstrapSecretMu.Unlock()
+	if !memKept {
+		t.Error("in-memory secret was burned despite IssueToken failure — DoS not fixed")
+	}
+	if pathKept != pathBefore {
+		t.Errorf("on-disk secret path changed: was %q, now %q", pathBefore, pathKept)
+	}
+	if _, statErr := os.Stat(pathBefore); statErr != nil {
+		t.Errorf("on-disk secret file removed despite IssueToken failure: %v", statErr)
+	}
+	if s.authActive.Load() {
+		t.Error("authActive flipped to true despite IssueToken failure")
+	}
+}
+
+// TestHandleGetToken_HTTP_RefreshWithValidToken pins the fix for the second
+// Copilot finding: after a successful bootstrap, the client must be able to
+// refresh its JWT by presenting _token (not _bootstrap, which is consumed).
+// Otherwise HTTP sessions become unusable after the JWT expires.
+func TestHandleGetToken_HTTP_RefreshWithValidToken(t *testing.T) {
+	s := newTestServerWithPolicy(t, &aflock.Policy{
+		Name: "bootstrap-refresh", Version: "1.0",
+		Tools: &aflock.ToolsPolicy{Allow: []string{"Bash"}},
+	})
+	s.transportMode = "http"
+	issuer, err := auth.NewTokenIssuer()
+	if err != nil {
+		t.Fatalf("issuer: %v", err)
+	}
+	s.tokenIssuer = issuer
+	if err := s.initHTTPBootstrapSecret(); err != nil {
+		t.Fatalf("initHTTPBootstrapSecret: %v", err)
+	}
+	secretBytes, err := os.ReadFile(s.httpBootstrapSecretPath)
+	if err != nil {
+		t.Fatalf("read secret: %v", err)
+	}
+
+	// First call: bootstrap path issues an initial token.
+	first, err := s.handleGetToken(context.Background(), callRequest(map[string]any{
+		"_bootstrap": string(secretBytes),
+	}))
+	if err != nil {
+		t.Fatalf("bootstrap call: %v", err)
+	}
+	if first == nil || first.IsError {
+		t.Fatalf("bootstrap call must succeed, got: %+v", first)
+	}
+	firstToken := tokenFromResult(t, first)
+
+	// Second call: the bootstrap secret is gone, but presenting the existing
+	// JWT must still let the client refresh.
+	second, err := s.handleGetToken(context.Background(), callRequest(map[string]any{
+		"_token": firstToken,
+	}))
+	if err != nil {
+		t.Fatalf("refresh call: %v", err)
+	}
+	if second == nil || second.IsError {
+		t.Fatalf("refresh with valid _token must succeed after bootstrap consumed, got: %+v", second)
+	}
+	if tokenFromResult(t, second) == "" {
+		t.Error("refresh must return a fresh token")
+	}
+
+	// Third call: no _token, no _bootstrap (already consumed) → must fail.
+	bare, err := s.handleGetToken(context.Background(), callRequest(nil))
+	if err != nil {
+		t.Fatalf("bare call: %v", err)
+	}
+	if bare == nil || !bare.IsError {
+		t.Errorf("call without _token or _bootstrap must fail after secret consumed, got: %+v", bare)
+	}
+}
+
+// tokenFromResult pulls the "token" field out of handleGetToken's
+// MarshalIndent'd result payload so tests can pass it back as _token on a
+// refresh call.
+func tokenFromResult(t *testing.T, result *mcp.CallToolResult) string {
+	t.Helper()
+	if result == nil || len(result.Content) == 0 {
+		t.Fatalf("result missing text content")
+	}
+	text, ok := result.Content[0].(mcp.TextContent)
+	if !ok {
+		t.Fatalf("result content is not TextContent: %T", result.Content[0])
+	}
+	var payload struct {
+		Token string `json:"token"`
+	}
+	if err := json.Unmarshal([]byte(text.Text), &payload); err != nil {
+		t.Fatalf("parse result JSON: %v (raw: %s)", err, text.Text)
+	}
+	return payload.Token
 }
 
 func TestInitHTTPBootstrapSecret_FilePermissions(t *testing.T) {


### PR DESCRIPTION
## Summary
Closes #42. HTTP transport has no kernel-attested peer, so any local process could call `get_token` and mint a JWT. Stdio (process tree) and Unix (SO_PEERCRED) already prove same-UID for free; HTTP didn't. Now HTTP `get_token` requires a one-time bootstrap secret only same-UID processes can read.

## Details
- `ServeHTTP` writes a 32-byte random secret to `<session-dir>/http-bootstrap-secret` (0600) and logs the path to stderr. Fails closed if the secret can't be written.
- `handleGetToken` in HTTP mode requires `_bootstrap` matching the secret (constant-time compare). On success the secret is cleared from memory and the file is removed — replay returns an error.
- Wrong-secret attempts do NOT burn the real secret (prevents DoS-by-spam against the legitimate client).
- Stdio + Unix transports unchanged — no extra ceremony where the existing trust boundary already holds.
- Tests cover: missing/wrong/correct secret, one-time replay rejection, stdio+unix bypass, 0600 file perms.