### PR TITLE
fix(attestation): require JWT to sign once auth is active

### DIFF
--- a/internal/hooks/handler.go
+++ b/internal/hooks/handler.go
@@ -730,9 +730,16 @@ func (h *Handler) createAttestation(sessionState *aflock.SessionState, input *af
 	// Build the JWT binding for the attestation predicate (#40). PreToolUse
 	// already validated the token (#48); we re-validate here so the binding
 	// reflects ground truth at signing time, not state captured upstream.
-	// Failure to validate skips the binding but still produces an attestation
-	// — consistent with "attestation is evidence, not enforcement."
 	jwtBinding := h.buildJWTBindingForSession(sessionState)
+
+	// Issue #40 hardening: if SessionStart issued a JWT for this session
+	// (the normal path), refuse to sign without a successful JWT binding.
+	// Sessions without an AuthToken (legacy / no-policy) keep the old
+	// behavior so this is not a backward-incompatible break.
+	if sessionState.AuthToken != "" && jwtBinding == nil {
+		fmt.Fprintf(os.Stderr, "[aflock] Skipping attestation: JWT validation failed at signing time (issue #40)\n")
+		return
+	}
 
 	// Create signed attestation
 	envelope, err := signer.CreateActionAttestation(

--- a/internal/hooks/handler_issue40_test.go
+++ b/internal/hooks/handler_issue40_test.go
@@ -1,0 +1,50 @@
+package hooks
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/aflock-ai/aflock/pkg/aflock"
+)
+
+// Issue #40 — hooks createAttestation must refuse to sign once SessionStart
+// has issued a JWT but per-call validation fails (expired, wrong policy
+// digest, missing pubkey on disk). Without this gate, a compromised agent
+// could keep producing attestations after the JWT became invalid.
+func TestPostToolUse_RefusesSigningWhenJWTValidationFails(t *testing.T) {
+	h := newTestHandler(t)
+	pol := &aflock.Policy{
+		Name:  "issue-40-hooks",
+		Tools: &aflock.ToolsPolicy{Allow: []string{"Read"}},
+	}
+	ss := seedSession(t, h, "session-issue-40", pol)
+
+	// Simulate the realistic broken path: AuthToken was issued but the
+	// pubkey persisted alongside it is gone (e.g., deleted, corrupted, or
+	// the session was migrated). buildJWTBindingForSession will return nil
+	// and the new gate must skip signing.
+	ss.AuthToken = "ey.bogus.token.signed-by-nobody"
+	if err := h.stateManager.Save(ss); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	_ = os.Remove(h.stateManager.SessionDir("session-issue-40") + "/jwt-pubkey.pem")
+
+	input := &aflock.HookInput{
+		SessionID: "session-issue-40",
+		ToolName:  "Read",
+		ToolUseID: "tu-issue-40",
+		ToolInput: json.RawMessage(`{"file_path":"x"}`),
+	}
+	captureStdout(t, func() {
+		if err := h.handlePostToolUse(input); err != nil {
+			t.Fatalf("handlePostToolUse: %v", err)
+		}
+	})
+
+	attestDir := h.stateManager.AttestationsDir("session-issue-40")
+	entries, _ := os.ReadDir(attestDir)
+	if len(entries) != 0 {
+		t.Errorf("attestation produced despite failed JWT validation (issue #40), files: %d", len(entries))
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -849,13 +849,17 @@ func (s *Server) validateJWT(request mcp.CallToolRequest) (*auth.AflockClaims, e
 
 // signAndStoreAttestation creates a signed attestation for an action and stores it to disk.
 //
-// jwtBinding may be nil — for graceful-adoption calls that arrived before
-// any get_token, or for paths where no JWT was presented. When non-nil it
-// is embedded in the predicate so verifiers can prove the action was
-// signed only under the listed token scope (issue #40).
+// jwtBinding is required once authActive is true — i.e., after the first
+// successful get_token. Before that ("graceful adoption"), nil is accepted
+// to preserve the documented pre-bootstrap window. This closes the issue
+// #40 gap where any caller could mint an attestation regardless of JWT
+// scope as long as it happened to bypass the tool-handler validation path.
 func (s *Server) signAndStoreAttestation(ctx context.Context, record aflock.ActionRecord, jwtBinding *attestation.JWTBinding) error {
 	if !s.signingEnabled {
 		return fmt.Errorf("attestation signing unavailable (SPIRE, Fulcio, and ephemeral all failed)")
+	}
+	if jwtBinding == nil && s.authActive.Load() {
+		return fmt.Errorf("JWT required for attestation signing once auth is active (issue #40)")
 	}
 
 	// Get session metrics
@@ -1495,10 +1499,17 @@ func (s *Server) handleGetSession(ctx context.Context, request mcp.CallToolReque
 
 // handleSignAttestation signs an attestation for arbitrary data.
 func (s *Server) handleSignAttestation(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) { //nolint:gocognit // attestation signing requires complex validation
-	// JWT authorization check — signing is the most sensitive operation
-	if claims, err := s.validateJWT(request); err != nil {
+	// JWT authorization check — signing is the most sensitive operation.
+	// Issue #40: once authActive is true, claims must be present (no
+	// graceful-adoption escape for the explicit signing tool).
+	claims, err := s.validateJWT(request)
+	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("Authorization denied: %v", err)), nil
-	} else if claims != nil && !auth.IsToolAllowed("sign_attestation", claims.AllowedTools, claims.DeniedTools) {
+	}
+	if claims == nil && s.authActive.Load() {
+		return mcp.NewToolResultError("Authorization denied: sign_attestation requires a valid JWT once auth is active (issue #40)"), nil
+	}
+	if claims != nil && !auth.IsToolAllowed("sign_attestation", claims.AllowedTools, claims.DeniedTools) {
 		return mcp.NewToolResultError("Authorization denied: tool 'sign_attestation' not permitted by token scope"), nil
 	}
 

--- a/internal/mcp/server_issue40_test.go
+++ b/internal/mcp/server_issue40_test.go
@@ -1,0 +1,79 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aflock-ai/aflock/internal/attestation"
+	"github.com/aflock-ai/aflock/internal/auth"
+	"github.com/aflock-ai/aflock/pkg/aflock"
+)
+
+// Issue #40 — attestation signing must require a JWT once auth is active.
+// Before that ("graceful adoption" / pre-bootstrap window) nil is still
+// accepted to preserve existing behavior.
+
+func TestSignAndStoreAttestation_RefusesNilBindingWhenAuthActive(t *testing.T) {
+	s := newTestServerWithPolicy(t, &aflock.Policy{
+		Name: "issue-40-mcp-sign", Version: "1.0",
+		Tools: &aflock.ToolsPolicy{Allow: []string{"Bash"}},
+	})
+	issuer, err := auth.NewTokenIssuer()
+	if err != nil {
+		t.Fatalf("issuer: %v", err)
+	}
+	s.tokenIssuer = issuer
+	s.signingEnabled = true
+	s.signer = attestation.NewSigner("")
+	if err := s.signer.InitializeEphemeral("test"); err != nil {
+		t.Fatalf("InitializeEphemeral: %v", err)
+	}
+
+	// Pre-authActive: nil binding accepted (graceful adoption window).
+	if err := s.signAndStoreAttestation(context.Background(), aflock.ActionRecord{
+		ToolName: "Bash", ToolUseID: "tu-1", Decision: "allow",
+	}, nil); err != nil {
+		t.Errorf("pre-authActive nil binding must be accepted, got: %v", err)
+	}
+
+	// Post-authActive: nil binding must be rejected.
+	s.authActive.Store(true)
+	if err := s.signAndStoreAttestation(context.Background(), aflock.ActionRecord{
+		ToolName: "Bash", ToolUseID: "tu-2", Decision: "allow",
+	}, nil); err == nil {
+		t.Error("post-authActive nil binding must be rejected (issue #40)")
+	}
+}
+
+func TestHandleSignAttestation_RefusesNoClaimsWhenAuthActive(t *testing.T) {
+	s := newTestServerWithPolicy(t, &aflock.Policy{
+		Name: "issue-40-handle-sign", Version: "1.0",
+		Tools: &aflock.ToolsPolicy{Allow: []string{"sign_attestation"}},
+	})
+	issuer, err := auth.NewTokenIssuer()
+	if err != nil {
+		t.Fatalf("issuer: %v", err)
+	}
+	s.tokenIssuer = issuer
+	s.signingEnabled = true
+	s.signer = attestation.NewSigner("")
+	if err := s.signer.InitializeEphemeral("test"); err != nil {
+		t.Fatalf("InitializeEphemeral: %v", err)
+	}
+	s.authActive.Store(true)
+
+	// No _token presented while authActive — validateJWT errors out, but
+	// even if it returned nil claims silently, the explicit gate must
+	// still reject. The error message must cite #40 so future maintainers
+	// can trace the change.
+	result, err := s.handleSignAttestation(context.Background(), callRequest(map[string]any{
+		"predicate_type": "https://example.com/p/v1",
+		"predicate":      map[string]any{"k": "v"},
+	}))
+	if err != nil {
+		t.Fatalf("handleSignAttestation: %v", err)
+	}
+	if result == nil || !result.IsError {
+		t.Fatalf("authActive + no JWT must reject sign_attestation, got: %+v", result)
+	}
+}


### PR DESCRIPTION
## Summary
Closes #40 (Phase 1). Attestation signing previously proceeded even when no JWT was presented, so a caller that bypassed the tool-handler validation could still mint a signed envelope. Now: once auth is active (post first `get_token`, or `AuthToken` set at SessionStart), signing without a valid JWT is refused.

## Details
- `signAndStoreAttestation` (MCP): rejects nil `jwtBinding` when `authActive` is true.
- `handleSignAttestation` (MCP `sign_attestation` tool): rejects nil claims when `authActive` is true.
- `createAttestation` (hooks): if SessionStart issued an `AuthToken` and per-call JWT binding fails, skip signing instead of producing an unscoped attestation.
- Pre-bootstrap / no-policy sessions keep working — gate only activates once auth is established.
- Phase 2 (true key separation in hooks mode) is the larger architectural change; tracked under #62.