### PR TITLE
fix(hooks): match Agent/Task spawns to declared sublayouts at PreToolUse

### DIFF
--- a/internal/hooks/handler.go
+++ b/internal/hooks/handler.go
@@ -1483,7 +1483,7 @@ func matchSublayoutForSpawn(toolName string, toolInput json.RawMessage, sublayou
 		return nil, false
 	}
 	subagentType := ""
-	if toolName == "Task" && len(toolInput) > 0 {
+	if (toolName == "Task" || toolName == "Agent") && len(toolInput) > 0 {
 		var t aflock.TaskToolInput
 		if err := json.Unmarshal(toolInput, &t); err == nil {
 			subagentType = t.SubagentType

--- a/internal/hooks/handler.go
+++ b/internal/hooks/handler.go
@@ -177,13 +177,14 @@ func (h *Handler) handleSessionStart(input *aflock.HookInput) error {
 		fmt.Fprintf(os.Stderr, "[aflock] Warning: failed to read propagation: %v\n", propErr)
 	} else if prop != nil {
 		sessionState.ParentSessionID = prop.ParentSessionID
+		sessionState.ParentSublayoutName = prop.SublayoutName
 		sessionState.Materials = prop.Materials
 		if prop.ParentLimits != nil && prop.ParentMetrics != nil {
 			sessionState.Policy.Limits = attenuateLimits(
 				sessionState.Policy.Limits, prop.ParentLimits, prop.ParentMetrics)
 		}
-		fmt.Fprintf(os.Stderr, "[aflock] Inherited %d materials from parent session %s\n",
-			len(prop.Materials), prop.ParentSessionID)
+		fmt.Fprintf(os.Stderr, "[aflock] Inherited %d materials from parent session %s (sublayout=%q)\n",
+			len(prop.Materials), prop.ParentSessionID, prop.SublayoutName)
 	}
 
 	// Issue JWT for this session — binds agent identity, policy, and grants
@@ -541,11 +542,32 @@ func (h *Handler) handlePreToolUse(input *aflock.HookInput) error {
 		output.ExitWithWarning(fmt.Sprintf("Failed to save session state: %v", err))
 	}
 
-	// If this is a subagent spawn, write propagation file so the child
-	// session inherits materials and attenuated limits (Section 5: sublayout delegation).
-	if isSubagentSpawn(input.ToolName) && sessionState.PolicyPath != "" {
-		if err := h.stateManager.WritePropagation(sessionState); err != nil {
-			fmt.Fprintf(os.Stderr, "[aflock] Warning: failed to write propagation: %v\n", err)
+	// If this is a subagent spawn, match it against declared sublayouts and
+	// either refuse or bind propagation accordingly (issue #26 gaps 4 + 5).
+	if isSubagentSpawn(input.ToolName) && sessionState.PolicyPath != "" && sessionState.Policy != nil {
+		matched, hasDecl := matchSublayoutForSpawn(input.ToolName, input.ToolInput, sessionState.Policy.Sublayouts)
+		switch {
+		case hasDecl && matched == nil:
+			// Sublayouts declared but spawn does not match any of them — R3-291.
+			return output.Write(output.PreToolUseDeny(fmt.Sprintf(
+				"[aflock] BLOCKED: subagent spawn does not match any declared sublayout (tool=%s)",
+				input.ToolName)))
+		case hasDecl && matched != nil:
+			// Sublayout limits must already attenuate vs parent's limits;
+			// refusing at spawn time means a bad policy can't slip through.
+			if violations := attenuationViolations(sessionState.Policy.Limits, matched.Limits); len(violations) > 0 {
+				return output.Write(output.PreToolUseDeny(fmt.Sprintf(
+					"[aflock] BLOCKED: sublayout %q violates parent attenuation: %s",
+					matched.Name, strings.Join(violations, "; "))))
+			}
+			if err := h.stateManager.WritePropagationForSublayout(sessionState, matched); err != nil {
+				fmt.Fprintf(os.Stderr, "[aflock] Warning: failed to write propagation: %v\n", err)
+			}
+		default:
+			// No sublayout declarations — keep legacy unconstrained behavior.
+			if err := h.stateManager.WritePropagation(sessionState); err != nil {
+				fmt.Fprintf(os.Stderr, "[aflock] Warning: failed to write propagation: %v\n", err)
+			}
 		}
 	}
 
@@ -1441,6 +1463,67 @@ func attestationMatchesName(path, name string) bool {
 // isSubagentSpawn returns true if the tool triggers a subagent spawn.
 func isSubagentSpawn(toolName string) bool {
 	return toolName == "Agent" || toolName == "Task"
+}
+
+// matchSublayoutForSpawn finds the declared sublayout this spawn should bind
+// to (issue #26 gap 5). Match key is the Task tool's subagent_type field
+// against Sublayout.Name; Agent spawns without a typed sub_agent_type don't
+// carry a binding signal today and match nothing.
+//
+// Returns (matched, hasDeclarations):
+//   - hasDeclarations=false when the parent policy declared no sublayouts —
+//     keeps the pre-issue-#26 behavior (unconstrained delegation, propagation
+//     written with parent's own limits).
+//   - hasDeclarations=true, matched=nil when sublayouts exist but the spawn
+//     didn't match any of them — PreToolUse refuses the spawn (R3-291).
+//   - hasDeclarations=true, matched!=nil when a sublayout name matches —
+//     propagation uses the sublayout's promised limits.
+func matchSublayoutForSpawn(toolName string, toolInput json.RawMessage, sublayouts []aflock.Sublayout) (matched *aflock.Sublayout, hasDeclarations bool) {
+	if len(sublayouts) == 0 {
+		return nil, false
+	}
+	subagentType := ""
+	if toolName == "Task" && len(toolInput) > 0 {
+		var t aflock.TaskToolInput
+		if err := json.Unmarshal(toolInput, &t); err == nil {
+			subagentType = t.SubagentType
+		}
+	}
+	if subagentType == "" {
+		return nil, true
+	}
+	for i := range sublayouts {
+		if sublayouts[i].Name == subagentType {
+			return &sublayouts[i], true
+		}
+	}
+	return nil, true
+}
+
+// attenuationViolations checks that sublayout limits are <= parent limits.
+// Mirrors verify.verifyAttenuation but lives here so spawn-time enforcement
+// (issue #26 gap 4) doesn't pull in the verify package's dependencies.
+// Empty result means the sublayout is validly attenuated.
+func attenuationViolations(parent, sub *aflock.LimitsPolicy) []string {
+	if sub == nil || parent == nil {
+		return nil
+	}
+	var violations []string
+	check := func(name string, p, s *aflock.Limit) {
+		if p == nil || s == nil {
+			return
+		}
+		if s.Value > p.Value {
+			violations = append(violations, fmt.Sprintf("%s: sublayout %.2f > parent %.2f", name, s.Value, p.Value))
+		}
+	}
+	check("maxSpendUSD", parent.MaxSpendUSD, sub.MaxSpendUSD)
+	check("maxTokensIn", parent.MaxTokensIn, sub.MaxTokensIn)
+	check("maxTokensOut", parent.MaxTokensOut, sub.MaxTokensOut)
+	check("maxTurns", parent.MaxTurns, sub.MaxTurns)
+	check("maxWallTimeSeconds", parent.MaxWallTimeSeconds, sub.MaxWallTimeSeconds)
+	check("maxToolCalls", parent.MaxToolCalls, sub.MaxToolCalls)
+	return violations
 }
 
 // attenuateLimits computes effective limits for a child session.

--- a/internal/hooks/handler_issue26_test.go
+++ b/internal/hooks/handler_issue26_test.go
@@ -1,0 +1,186 @@
+package hooks
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/aflock-ai/aflock/pkg/aflock"
+)
+
+// Issue #26 — spawn-time sublayout matching + refusal + attenuation gate.
+// These tests pin the three new gates in PreToolUse handling of
+// Agent/Task spawns:
+//
+//  1. Sublayouts declared, spawn matches by subagent_type → propagation
+//     carries the matched sublayout name and its promised limits.
+//  2. Sublayouts declared, spawn doesn't match → refused (R3-291).
+//  3. Matched sublayout has limits HIGHER than parent → refused at
+//     spawn time (attenuation violation).
+
+func policyWithSublayouts(subs ...aflock.Sublayout) *aflock.Policy {
+	return &aflock.Policy{
+		Name:    "issue-26",
+		Version: "1.0",
+		Tools:   &aflock.ToolsPolicy{Allow: []string{"Task", "Agent"}},
+		Limits: &aflock.LimitsPolicy{
+			MaxSpendUSD: &aflock.Limit{Value: 10.0, Enforcement: "fail-fast"},
+		},
+		Sublayouts: subs,
+	}
+}
+
+func TestSpawn_MatchingSublayout_BindsAndAttenuates(t *testing.T) {
+	h := newTestHandler(t)
+	pol := policyWithSublayouts(aflock.Sublayout{
+		Name:   "research",
+		Policy: "./research.aflock",
+		Limits: &aflock.LimitsPolicy{
+			MaxSpendUSD: &aflock.Limit{Value: 2.0, Enforcement: "fail-fast"},
+		},
+	})
+	ss := seedSession(t, h, "parent-match", pol)
+	ss.Materials = append(ss.Materials, aflock.MaterialClassification{
+		Label: "internal", Source: "Read:/x.go", Timestamp: time.Now(),
+	})
+	if err := h.stateManager.Save(ss); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	input := &aflock.HookInput{
+		SessionID: "parent-match",
+		ToolName:  "Task",
+		ToolInput: json.RawMessage(`{"prompt":"go research","subagent_type":"research"}`),
+	}
+	got := captureStdout(t, func() {
+		if err := h.handlePreToolUse(input); err != nil {
+			t.Fatalf("handlePreToolUse: %v", err)
+		}
+	})
+
+	var out aflock.HookOutput
+	if err := json.Unmarshal([]byte(got), &out); err != nil {
+		t.Fatalf("unmarshal: %v (raw: %s)", err, got)
+	}
+	if out.HookSpecificOutput == nil || out.HookSpecificOutput.PermissionDecision != aflock.DecisionAllow {
+		t.Fatalf("expected allow, got %+v", out.HookSpecificOutput)
+	}
+
+	rec, err := h.stateManager.ReadPropagation(ss.PolicyPath)
+	if err != nil || rec == nil {
+		t.Fatalf("expected propagation record, err=%v rec=%v", err, rec)
+	}
+	if rec.SublayoutName != "research" {
+		t.Errorf("SublayoutName = %q, want %q", rec.SublayoutName, "research")
+	}
+	if rec.ParentLimits == nil || rec.ParentLimits.MaxSpendUSD == nil || rec.ParentLimits.MaxSpendUSD.Value != 2.0 {
+		t.Errorf("ParentLimits should be sublayout-promised (2.0), got %+v", rec.ParentLimits)
+	}
+}
+
+func TestSpawn_UnmatchedSublayout_Refused(t *testing.T) {
+	h := newTestHandler(t)
+	pol := policyWithSublayouts(aflock.Sublayout{
+		Name: "research",
+		Limits: &aflock.LimitsPolicy{
+			MaxSpendUSD: &aflock.Limit{Value: 2.0},
+		},
+	})
+	ss := seedSession(t, h, "parent-unmatched", pol)
+	_ = ss
+
+	input := &aflock.HookInput{
+		SessionID: "parent-unmatched",
+		ToolName:  "Task",
+		ToolInput: json.RawMessage(`{"prompt":"x","subagent_type":"lint"}`), // not declared
+	}
+	got := captureStdout(t, func() {
+		if err := h.handlePreToolUse(input); err != nil {
+			t.Fatalf("handlePreToolUse: %v", err)
+		}
+	})
+
+	var out aflock.HookOutput
+	if err := json.Unmarshal([]byte(got), &out); err != nil {
+		t.Fatalf("unmarshal: %v (raw: %s)", err, got)
+	}
+	if out.HookSpecificOutput == nil || out.HookSpecificOutput.PermissionDecision != aflock.DecisionDeny {
+		t.Errorf("unmatched subagent_type must be refused, got %+v", out.HookSpecificOutput)
+	}
+
+	// And no propagation should have been written.
+	rec, _ := h.stateManager.ReadPropagation(ss.PolicyPath)
+	if rec != nil {
+		t.Error("refused spawn must not write a propagation record")
+	}
+}
+
+func TestSpawn_AttenuationViolation_Refused(t *testing.T) {
+	h := newTestHandler(t)
+	// Sublayout promises HIGHER spend than parent allows — invalid policy
+	// that must be refused at spawn time (issue #26 gap 4).
+	pol := policyWithSublayouts(aflock.Sublayout{
+		Name: "greedy",
+		Limits: &aflock.LimitsPolicy{
+			MaxSpendUSD: &aflock.Limit{Value: 100.0},
+		},
+	})
+	ss := seedSession(t, h, "parent-greedy", pol)
+	_ = ss
+
+	input := &aflock.HookInput{
+		SessionID: "parent-greedy",
+		ToolName:  "Task",
+		ToolInput: json.RawMessage(`{"prompt":"x","subagent_type":"greedy"}`),
+	}
+	got := captureStdout(t, func() {
+		if err := h.handlePreToolUse(input); err != nil {
+			t.Fatalf("handlePreToolUse: %v", err)
+		}
+	})
+
+	var out aflock.HookOutput
+	if err := json.Unmarshal([]byte(got), &out); err != nil {
+		t.Fatalf("unmarshal: %v (raw: %s)", err, got)
+	}
+	if out.HookSpecificOutput == nil || out.HookSpecificOutput.PermissionDecision != aflock.DecisionDeny {
+		t.Errorf("attenuation-violating sublayout must be refused, got %+v", out.HookSpecificOutput)
+	}
+}
+
+func TestSpawn_NoSublayoutsDeclared_LegacyBehaviorPreserved(t *testing.T) {
+	h := newTestHandler(t)
+	pol := &aflock.Policy{
+		Name:    "legacy",
+		Version: "1.0",
+		Tools:   &aflock.ToolsPolicy{Allow: []string{"Task"}},
+	}
+	ss := seedSession(t, h, "parent-legacy", pol)
+	_ = ss
+
+	input := &aflock.HookInput{
+		SessionID: "parent-legacy",
+		ToolName:  "Task",
+		ToolInput: json.RawMessage(`{"prompt":"x","subagent_type":"anything"}`),
+	}
+	got := captureStdout(t, func() {
+		if err := h.handlePreToolUse(input); err != nil {
+			t.Fatalf("handlePreToolUse: %v", err)
+		}
+	})
+
+	var out aflock.HookOutput
+	if err := json.Unmarshal([]byte(got), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.HookSpecificOutput == nil || out.HookSpecificOutput.PermissionDecision != aflock.DecisionAllow {
+		t.Errorf("no sublayouts declared must allow (legacy compat), got %+v", out.HookSpecificOutput)
+	}
+	rec, _ := h.stateManager.ReadPropagation(ss.PolicyPath)
+	if rec == nil {
+		t.Fatal("legacy path must still write propagation with parent's limits")
+	}
+	if rec.SublayoutName != "" {
+		t.Errorf("legacy path must leave SublayoutName empty, got %q", rec.SublayoutName)
+	}
+}

--- a/internal/hooks/handler_issue26_test.go
+++ b/internal/hooks/handler_issue26_test.go
@@ -184,3 +184,45 @@ func TestSpawn_NoSublayoutsDeclared_LegacyBehaviorPreserved(t *testing.T) {
 		t.Errorf("legacy path must leave SublayoutName empty, got %q", rec.SublayoutName)
 	}
 }
+
+// TestSpawn_AgentToolName_MatchesSubagentType pins the regression caught
+// during real-Claude integration testing: Claude Code's subagent spawn
+// tool is named "Agent" (not "Task" — Task is a different family). An
+// earlier version of matchSublayoutForSpawn only parsed subagent_type when
+// toolName == "Task", causing every Agent spawn to be reported as
+// "no match" and refused, even when the requested sublayout was declared.
+func TestSpawn_AgentToolName_MatchesSubagentType(t *testing.T) {
+	h := newTestHandler(t)
+	pol := policyWithSublayouts(aflock.Sublayout{
+		Name:   "general-purpose",
+		Policy: "./gp.aflock",
+		Limits: &aflock.LimitsPolicy{
+			MaxSpendUSD: &aflock.Limit{Value: 1.0},
+		},
+	})
+	ss := seedSession(t, h, "parent-agent-tool", pol)
+	_ = ss
+
+	for _, toolName := range []string{"Agent", "Task"} {
+		t.Run("toolName="+toolName, func(t *testing.T) {
+			input := &aflock.HookInput{
+				SessionID: "parent-agent-tool",
+				ToolName:  toolName,
+				ToolInput: json.RawMessage(`{"prompt":"x","subagent_type":"general-purpose"}`),
+			}
+			got := captureStdout(t, func() {
+				if err := h.handlePreToolUse(input); err != nil {
+					t.Fatalf("handlePreToolUse: %v", err)
+				}
+			})
+			var out aflock.HookOutput
+			if err := json.Unmarshal([]byte(got), &out); err != nil {
+				t.Fatalf("unmarshal: %v (raw: %s)", err, got)
+			}
+			if out.HookSpecificOutput == nil || out.HookSpecificOutput.PermissionDecision != aflock.DecisionAllow {
+				t.Errorf("matching sublayout via tool=%q must be allowed, got %+v",
+					toolName, out.HookSpecificOutput)
+			}
+		})
+	}
+}

--- a/internal/hooks/handler_test.go
+++ b/internal/hooks/handler_test.go
@@ -14,13 +14,34 @@ import (
 )
 
 // newTestHandler creates a Handler with state rooted in a temp directory.
+//
+// Note: propagation files live at ~/.aflock/propagation/ regardless of the
+// test's tmp state dir (pre-existing — see internal/state/propagation.go).
+// Multiple tests share that directory. Under PR #114's accumulate-per-write
+// semantics, a leftover from a prior test will be picked up by a later
+// test's FIFO ReadPropagation. Scrub at start and end of every test using
+// this helper so tests are deterministic.
 func newTestHandler(t *testing.T) *Handler {
 	t.Helper()
+	scrubSharedPropagation()
+	t.Cleanup(scrubSharedPropagation)
 	tmpDir := t.TempDir()
 	h := &Handler{
 		stateManager: state.NewManager(tmpDir),
 	}
 	return h
+}
+
+// scrubSharedPropagation removes every file under ~/.aflock/propagation/ so
+// the next test starts with an empty pool. Safe because handler tests are
+// not parallel and the propagation dir holds no production state during a
+// test run.
+func scrubSharedPropagation() {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return
+	}
+	_ = os.RemoveAll(filepath.Join(home, ".aflock", "propagation"))
 }
 
 // seedSession initializes a session with the given policy and returns the

--- a/internal/state/propagation.go
+++ b/internal/state/propagation.go
@@ -60,10 +60,23 @@ func propagationFilename(policyPath string) (string, error) {
 }
 
 // WritePropagation writes a propagation file so that a child session can
-// inherit the parent's materials, metrics, and attenuated limits. Each call
-// produces a distinct file (issue #26 gap 6) — concurrent spawns of the
-// same policy no longer overwrite each other.
+// inherit the parent's materials, metrics, and attenuated limits. Used when
+// the parent declares no sublayouts (legacy / unconstrained delegation).
+// Each call produces a distinct file (issue #26 gap 6) — concurrent spawns
+// of the same policy no longer overwrite each other.
 func (m *Manager) WritePropagation(parentState *aflock.SessionState) error {
+	return m.writePropagationRecord(parentState, nil)
+}
+
+// WritePropagationForSublayout writes a propagation file scoped to the
+// matched sublayout (issue #26). The propagated ParentLimits are the
+// sublayout's promised ceiling, not the parent's full limits — so the child
+// is bound to the slice of authority the policy explicitly delegated.
+func (m *Manager) WritePropagationForSublayout(parentState *aflock.SessionState, sub *aflock.Sublayout) error {
+	return m.writePropagationRecord(parentState, sub)
+}
+
+func (m *Manager) writePropagationRecord(parentState *aflock.SessionState, sub *aflock.Sublayout) error {
 	dir := propagationBaseDir()
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return fmt.Errorf("create propagation dir: %w", err)
@@ -76,7 +89,11 @@ func (m *Manager) WritePropagation(parentState *aflock.SessionState) error {
 		ParentMetrics:   parentState.Metrics,
 		CreatedAt:       time.Now(),
 	}
-	if parentState.Policy != nil {
+	switch {
+	case sub != nil:
+		rec.ParentLimits = sub.Limits
+		rec.SublayoutName = sub.Name
+	case parentState.Policy != nil:
 		rec.ParentLimits = parentState.Policy.Limits
 	}
 

--- a/pkg/aflock/types.go
+++ b/pkg/aflock/types.go
@@ -479,6 +479,11 @@ type SessionState struct {
 	Materials []MaterialClassification `json:"materials,omitempty"`
 	// ParentSessionID is set when this session was spawned by a parent agent
 	ParentSessionID string `json:"parent_session_id,omitempty"`
+	// ParentSublayoutName is the name of the parent's declared sublayout this
+	// child was bound to at spawn time. Empty when the parent had no
+	// sublayout declarations. Used by verification to confirm a child stayed
+	// within the sublayout's promised scope (issue #26).
+	ParentSublayoutName string `json:"parent_sublayout_name,omitempty"`
 	// ChildSessionIDs tracks subagent sessions spawned from this session
 	ChildSessionIDs []string `json:"child_session_ids,omitempty"`
 	// AgentIdentityMeta stores identity discovered at SessionStart for reuse in PostToolUse
@@ -525,6 +530,12 @@ type PropagationRecord struct {
 	ParentMetrics   *SessionMetrics          `json:"parent_metrics"`
 	ParentLimits    *LimitsPolicy            `json:"parent_limits,omitempty"`
 	CreatedAt       time.Time                `json:"created_at"`
+	// SublayoutName is the name of the declared parent sublayout this spawn
+	// was matched against at PreToolUse time. Empty when the parent declared
+	// no sublayouts (legacy / unconstrained delegation). When set, the child
+	// session is bound to this sublayout for verification (issue #26 gaps
+	// 4 and 5).
+	SublayoutName string `json:"sublayout_name,omitempty"`
 }
 
 // IsExpiredPropagation checks if the propagation record has exceeded the given TTL.


### PR DESCRIPTION
## Summary
First slice of #26 — closes gaps 4 (R3-291 enforcement) and 5 (spawn-to-sublayout binding). At PreToolUse for Agent/Task: match by `subagent_type` against declared sublayouts, refuse mismatches and attenuation violations, write propagation tagged with the matched sublayout name.

## Details
- `matchSublayoutForSpawn` parses `subagent_type` from the Task input and looks it up against `policy.Sublayouts[].Name`.
- Sublayouts declared + no match → deny (R3-291).
- Sublayouts declared + match → check attenuation (`sublayout.Limits ≤ parent.Limits`), refuse if violated, write propagation with the sublayout's promised limits and name.
- No sublayouts declared → legacy behavior preserved (write propagation with parent's own limits).
- `PropagationRecord.SublayoutName` + `SessionState.ParentSublayoutName` carry the binding to the child for later verification.

## Out of scope (follow-ups)
- Gap 6 (propagation-key collision on concurrent same-policy spawns) — needs cross-process correlation design (env passthrough or per-spawn discovery).
- Gap 1 (attestation namespacing via `AttestationPrefix`) — next PR in this series.
- Gap 2 (`Inherit` semantics) — needs design call.
- Gap 3 already shipped (`verifySublayouts` exists in `internal/verify/verifier.go`).