### PR TITLE
fix(hooks): stamp sublayout binding into attestation predicates

### DIFF
--- a/internal/attestation/jwt_binding_test.go
+++ b/internal/attestation/jwt_binding_test.go
@@ -26,7 +26,7 @@ func TestActionAttestation_NoJWTBinding(t *testing.T) {
 		ToolUseID: "tu-1",
 		Decision:  "allow",
 	}
-	env, err := signer.CreateActionAttestation(context.Background(), rec, "session-no-jwt", nil, nil)
+	env, err := signer.CreateActionAttestation(context.Background(), rec, "session-no-jwt", nil, nil, nil)
 	if err != nil {
 		t.Fatalf("CreateActionAttestation: %v", err)
 	}
@@ -63,7 +63,7 @@ func TestActionAttestation_WithJWTBinding(t *testing.T) {
 		ToolUseID: "tu-2",
 		Decision:  "allow",
 	}
-	env, err := signer.CreateActionAttestation(context.Background(), rec, "session-abc", nil, nil, binding)
+	env, err := signer.CreateActionAttestation(context.Background(), rec, "session-abc", nil, nil, &AttestationContext{JWT: binding})
 	if err != nil {
 		t.Fatalf("CreateActionAttestation: %v", err)
 	}
@@ -87,33 +87,6 @@ func TestActionAttestation_WithJWTBinding(t *testing.T) {
 	if len(pred.JWTBinding.DeniedTools) != 1 || pred.JWTBinding.DeniedTools[0] != "WebFetch" {
 		t.Errorf("deniedTools mismatch: %v", pred.JWTBinding.DeniedTools)
 	}
-}
-
-// TestCreateActionAttestation_TooManyBindingsPanics guards the variadic
-// abuse case. The "0 or 1" semantics is enforced via panic so a future
-// caller doesn't silently get the first binding while ignoring others.
-func TestCreateActionAttestation_TooManyBindingsPanics(t *testing.T) {
-	signer := NewSigner("")
-	if err := signer.InitializeEphemeral("hash-3"); err != nil {
-		t.Fatalf("init signer: %v", err)
-	}
-	defer signer.Close() //nolint:errcheck
-
-	defer func() {
-		if r := recover(); r == nil {
-			t.Fatal("expected panic when supplying multiple bindings")
-		}
-	}()
-	a := &JWTBinding{SessionID: "a"}
-	b := &JWTBinding{SessionID: "b"}
-	_, _ = signer.CreateActionAttestation(
-		context.Background(),
-		aflock.ActionRecord{ToolName: "X"},
-		"s",
-		nil,
-		nil,
-		a, b,
-	)
 }
 
 // decodePredicate base64-decodes the DSSE payload and parses it as an

--- a/internal/attestation/signer.go
+++ b/internal/attestation/signer.go
@@ -267,18 +267,36 @@ type Subject struct {
 
 // ActionPredicate is the predicate for aflock action attestations.
 type ActionPredicate struct {
-	Action        string                 `json:"action"`
-	SessionID     string                 `json:"sessionId"`
-	ToolName      string                 `json:"toolName"`
-	ToolUseID     string                 `json:"toolUseId"`
-	ToolInput     map[string]interface{} `json:"toolInput,omitempty"`
-	Decision      string                 `json:"decision"`
-	Reason        string                 `json:"reason,omitempty"`
-	Timestamp     time.Time              `json:"timestamp"`
-	AgentID       string                 `json:"agentId,omitempty"`
-	AgentIdentity *TransitiveIdentity    `json:"agentIdentity,omitempty"`
-	Metrics       *MetricsPredicate      `json:"metrics,omitempty"`
-	JWTBinding    *JWTBinding            `json:"jwtBinding,omitempty"`
+	Action           string                 `json:"action"`
+	SessionID        string                 `json:"sessionId"`
+	ToolName         string                 `json:"toolName"`
+	ToolUseID        string                 `json:"toolUseId"`
+	ToolInput        map[string]interface{} `json:"toolInput,omitempty"`
+	Decision         string                 `json:"decision"`
+	Reason           string                 `json:"reason,omitempty"`
+	Timestamp        time.Time              `json:"timestamp"`
+	AgentID          string                 `json:"agentId,omitempty"`
+	AgentIdentity    *TransitiveIdentity    `json:"agentIdentity,omitempty"`
+	Metrics          *MetricsPredicate      `json:"metrics,omitempty"`
+	JWTBinding       *JWTBinding            `json:"jwtBinding,omitempty"`
+	SublayoutBinding *SublayoutBinding      `json:"sublayoutBinding,omitempty"`
+}
+
+// SublayoutBinding records the parent-declared sublayout this child session
+// was matched to at spawn time (issue #26 gap 1). Verifiers can use the
+// prefix to group child attestations under the right sublayout slot when
+// reporting and to confirm a child stayed within the delegated scope.
+type SublayoutBinding struct {
+	// Name is the matched Sublayout.Name from the parent policy.
+	Name string `json:"name"`
+	// Prefix is the parent's Sublayout.AttestationPrefix — the namespace
+	// label by which audit tools group these attestations. Empty when the
+	// parent's sublayout declaration did not set a prefix; consumers should
+	// fall back to Name in that case.
+	Prefix string `json:"prefix,omitempty"`
+	// ParentSessionID closes the loop back to the parent session whose
+	// PreToolUse decided the binding.
+	ParentSessionID string `json:"parentSessionId,omitempty"`
 }
 
 // JWTBinding records the authorization context that permitted this action,
@@ -330,28 +348,35 @@ type Signature struct {
 	Certificate string `json:"certificate,omitempty"` // PEM-encoded signing certificate
 }
 
+// AttestationContext bundles the optional per-action bindings that get
+// embedded in the predicate. Nil-safe — callers may pass nil for either
+// field or for the whole struct. Introduced when SublayoutBinding was added
+// alongside JWTBinding (issue #26 gap 1); replaces the prior single-purpose
+// variadic JWTBinding argument.
+type AttestationContext struct {
+	JWT       *JWTBinding
+	Sublayout *SublayoutBinding
+}
+
 // CreateActionAttestation creates an attestation for an action.
 //
-// jwtBindings is a 0-or-1 variadic so legacy callers (replay, tests, hook
-// paths that did not present a token) compile unchanged. When a binding is
-// supplied, it is embedded in the predicate so verifiers can confirm the
-// action was signed only because a JWT with the listed scope was
-// presented (issue #40). Passing more than one binding is a programming
-// error and panics.
+// actx is optional (nil-safe). When set, its JWT/Sublayout bindings are
+// embedded in the predicate so verifiers can confirm the action was signed
+// under the listed token scope (issue #40) and bound to the declared
+// sublayout (issue #26).
 func (s *Signer) CreateActionAttestation(
 	ctx context.Context,
 	record aflock.ActionRecord,
 	sessionID string,
 	metrics *aflock.SessionMetrics,
 	agentIdentity *identity.AgentIdentity,
-	jwtBindings ...*JWTBinding,
+	actx *AttestationContext,
 ) (*Envelope, error) {
-	if len(jwtBindings) > 1 {
-		panic("CreateActionAttestation: at most one JWTBinding allowed")
-	}
 	var jwtBinding *JWTBinding
-	if len(jwtBindings) == 1 {
-		jwtBinding = jwtBindings[0]
+	var sublayoutBinding *SublayoutBinding
+	if actx != nil {
+		jwtBinding = actx.JWT
+		sublayoutBinding = actx.Sublayout
 	}
 
 	// Parse tool input (best-effort, ignore errors)
@@ -362,15 +387,16 @@ func (s *Signer) CreateActionAttestation(
 
 	// Build predicate
 	predicate := ActionPredicate{
-		Action:     "tool_call",
-		SessionID:  sessionID,
-		ToolName:   record.ToolName,
-		ToolUseID:  record.ToolUseID,
-		ToolInput:  toolInput,
-		Decision:   record.Decision,
-		Reason:     record.Reason,
-		Timestamp:  record.Timestamp,
-		JWTBinding: jwtBinding,
+		Action:           "tool_call",
+		SessionID:        sessionID,
+		ToolName:         record.ToolName,
+		ToolUseID:        record.ToolUseID,
+		ToolInput:        toolInput,
+		Decision:         record.Decision,
+		Reason:           record.Reason,
+		Timestamp:        record.Timestamp,
+		JWTBinding:       jwtBinding,
+		SublayoutBinding: sublayoutBinding,
 	}
 
 	if s.identity != nil {

--- a/internal/attestation/signer_test.go
+++ b/internal/attestation/signer_test.go
@@ -722,6 +722,7 @@ func TestCreateActionAttestation_BasicAction(t *testing.T) {
 		"session-xyz",
 		metrics,
 		agentID,
+		nil,
 	)
 	if err != nil {
 		t.Fatalf("CreateActionAttestation: %v", err)
@@ -867,6 +868,7 @@ func TestCreateActionAttestation_NilToolInput(t *testing.T) {
 		"session-nil",
 		nil, // nil metrics
 		nil, // nil agent identity
+		nil,
 	)
 	if err != nil {
 		t.Fatalf("CreateActionAttestation with nil input: %v", err)
@@ -922,6 +924,7 @@ func TestCreateActionAttestation_InvalidToolInputJSON(t *testing.T) {
 		"session-bad-json",
 		nil,
 		nil,
+		nil,
 	)
 	if err != nil {
 		t.Fatalf("CreateActionAttestation with bad JSON: %v", err)
@@ -948,6 +951,7 @@ func TestCreateActionAttestation_NoIdentity(t *testing.T) {
 		context.Background(),
 		record,
 		"session-no-id",
+		nil,
 		nil,
 		nil,
 	)
@@ -991,6 +995,7 @@ func TestCreateActionAttestation_BinaryWithEmptyVersion(t *testing.T) {
 		"session-kernel",
 		nil,
 		agentID,
+		nil,
 	)
 	if err != nil {
 		t.Fatalf("CreateActionAttestation: %v", err)
@@ -1046,6 +1051,7 @@ func TestCreateActionAttestation_BinaryWithEmptyName(t *testing.T) {
 
 	env, err := signer.CreateActionAttestation(
 		context.Background(), record, "session-empty-name", nil, agentID,
+		nil,
 	)
 	if err != nil {
 		t.Fatalf("CreateActionAttestation: %v", err)
@@ -1095,6 +1101,7 @@ func TestCreateActionAttestation_AgentIdentityWithoutBinary(t *testing.T) {
 		"session-no-binary",
 		nil,
 		agentID,
+		nil,
 	)
 	if err != nil {
 		t.Fatalf("CreateActionAttestation: %v", err)
@@ -1509,6 +1516,7 @@ func TestEndToEnd_SignAndVerify(t *testing.T) {
 		record,
 		"session-e2e-test",
 		metrics,
+		nil,
 		nil,
 	)
 	if err != nil {

--- a/internal/hooks/handler.go
+++ b/internal/hooks/handler.go
@@ -178,6 +178,7 @@ func (h *Handler) handleSessionStart(input *aflock.HookInput) error {
 	} else if prop != nil {
 		sessionState.ParentSessionID = prop.ParentSessionID
 		sessionState.ParentSublayoutName = prop.SublayoutName
+		sessionState.AttestationPrefix = prop.AttestationPrefix
 		sessionState.Materials = prop.Materials
 		if prop.ParentLimits != nil && prop.ParentMetrics != nil {
 			sessionState.Policy.Limits = attenuateLimits(
@@ -763,6 +764,19 @@ func (h *Handler) createAttestation(sessionState *aflock.SessionState, input *af
 		return
 	}
 
+	// Issue #26 gap 1: when this session was spawned under a parent's
+	// declared sublayout, stamp every attestation with the sublayout name +
+	// AttestationPrefix so audit/verify tools can group child attestations
+	// under their delegated slot.
+	var sublayoutBinding *attestation.SublayoutBinding
+	if sessionState.ParentSublayoutName != "" {
+		sublayoutBinding = &attestation.SublayoutBinding{
+			Name:            sessionState.ParentSublayoutName,
+			Prefix:          sessionState.AttestationPrefix,
+			ParentSessionID: sessionState.ParentSessionID,
+		}
+	}
+
 	// Create signed attestation
 	envelope, err := signer.CreateActionAttestation(
 		context.Background(),
@@ -770,7 +784,7 @@ func (h *Handler) createAttestation(sessionState *aflock.SessionState, input *af
 		sessionState.SessionID,
 		sessionState.Metrics,
 		agentIdentity,
-		jwtBinding,
+		&attestation.AttestationContext{JWT: jwtBinding, Sublayout: sublayoutBinding},
 	)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "[aflock] Warning: attestation creation failed: %v\n", err)

--- a/internal/hooks/handler_forgery_test.go
+++ b/internal/hooks/handler_forgery_test.go
@@ -50,7 +50,7 @@ func newSignedAttestationForSession(t *testing.T, h *Handler, sessionID, toolNam
 		ToolUseID: toolUseID,
 		Decision:  decision,
 	}
-	env, err := signer.CreateActionAttestation(t.Context(), rec, sessionID, nil, nil)
+	env, err := signer.CreateActionAttestation(t.Context(), rec, sessionID, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("CreateActionAttestation: %v", err)
 	}

--- a/internal/hooks/handler_issue26_prefix_test.go
+++ b/internal/hooks/handler_issue26_prefix_test.go
@@ -1,0 +1,178 @@
+package hooks
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aflock-ai/aflock/internal/attestation"
+	"github.com/aflock-ai/aflock/pkg/aflock"
+)
+
+// Issue #26 gap 1 — attestation predicates produced by a child session that
+// was bound to a parent's declared sublayout must carry the matched
+// SublayoutBinding (name + prefix + parent session id). Audit/verify tools
+// can then group child attestations under the declared slot.
+
+func TestPostToolUse_StampsSublayoutBindingFromSession(t *testing.T) {
+	h := newTestHandler(t)
+	pol := &aflock.Policy{
+		Name:    "issue-26-prefix-child",
+		Version: "1.0",
+		Tools:   &aflock.ToolsPolicy{Allow: []string{"Read"}},
+	}
+	ss := seedSession(t, h, "child-with-sublayout", pol)
+	// Simulate the propagation having bound this child to a parent's
+	// declared sublayout. Real SessionStart fills these from the
+	// propagation record (issue #26).
+	ss.ParentSessionID = "parent-xyz"
+	ss.ParentSublayoutName = "research"
+	ss.AttestationPrefix = "sub/research/"
+	if err := h.stateManager.Save(ss); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	input := &aflock.HookInput{
+		SessionID: "child-with-sublayout",
+		ToolName:  "Read",
+		ToolUseID: "tu-prefix-1",
+		ToolInput: json.RawMessage(`{"file_path":"src/main.go"}`),
+	}
+	captureStdout(t, func() {
+		if err := h.handlePostToolUse(input); err != nil {
+			t.Fatalf("handlePostToolUse: %v", err)
+		}
+	})
+
+	// Read the produced attestation and check the predicate.
+	attestDir := h.stateManager.AttestationsDir("child-with-sublayout")
+	entries, err := os.ReadDir(attestDir)
+	if err != nil || len(entries) == 0 {
+		t.Fatalf("expected attestation file, err=%v entries=%d", err, len(entries))
+	}
+
+	data, err := os.ReadFile(filepath.Join(attestDir, entries[0].Name()))
+	if err != nil {
+		t.Fatalf("read attestation: %v", err)
+	}
+	var env attestation.Envelope
+	if err := json.Unmarshal(data, &env); err != nil {
+		t.Fatalf("parse envelope: %v", err)
+	}
+	payload, err := base64.StdEncoding.DecodeString(env.Payload)
+	if err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	var stmt struct {
+		Predicate attestation.ActionPredicate `json:"predicate"`
+	}
+	if err := json.Unmarshal(payload, &stmt); err != nil {
+		t.Fatalf("parse statement: %v", err)
+	}
+
+	if stmt.Predicate.SublayoutBinding == nil {
+		t.Fatal("expected SublayoutBinding in predicate, got nil")
+	}
+	if got := stmt.Predicate.SublayoutBinding.Name; got != "research" {
+		t.Errorf("SublayoutBinding.Name = %q, want %q", got, "research")
+	}
+	if got := stmt.Predicate.SublayoutBinding.Prefix; got != "sub/research/" {
+		t.Errorf("SublayoutBinding.Prefix = %q, want %q", got, "sub/research/")
+	}
+	if got := stmt.Predicate.SublayoutBinding.ParentSessionID; got != "parent-xyz" {
+		t.Errorf("SublayoutBinding.ParentSessionID = %q, want %q", got, "parent-xyz")
+	}
+}
+
+func TestPostToolUse_NoSublayoutBindingWhenUnbound(t *testing.T) {
+	h := newTestHandler(t)
+	pol := &aflock.Policy{
+		Name:    "issue-26-prefix-unbound",
+		Version: "1.0",
+		Tools:   &aflock.ToolsPolicy{Allow: []string{"Read"}},
+	}
+	ss := seedSession(t, h, "unbound-child", pol)
+	// Deliberately do NOT set ParentSublayoutName — this is a legacy /
+	// no-sublayout session and must not get a spurious binding.
+	if ss.ParentSublayoutName != "" {
+		t.Fatalf("test precondition broken: ParentSublayoutName already set")
+	}
+	if err := h.stateManager.Save(ss); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	input := &aflock.HookInput{
+		SessionID: "unbound-child",
+		ToolName:  "Read",
+		ToolUseID: "tu-no-prefix",
+		ToolInput: json.RawMessage(`{"file_path":"x"}`),
+	}
+	captureStdout(t, func() {
+		if err := h.handlePostToolUse(input); err != nil {
+			t.Fatalf("handlePostToolUse: %v", err)
+		}
+	})
+
+	attestDir := h.stateManager.AttestationsDir("unbound-child")
+	entries, _ := os.ReadDir(attestDir)
+	if len(entries) == 0 {
+		t.Fatal("expected attestation file")
+	}
+	data, _ := os.ReadFile(filepath.Join(attestDir, entries[0].Name()))
+	var env attestation.Envelope
+	_ = json.Unmarshal(data, &env)
+	payload, _ := base64.StdEncoding.DecodeString(env.Payload)
+	var stmt struct {
+		Predicate attestation.ActionPredicate `json:"predicate"`
+	}
+	_ = json.Unmarshal(payload, &stmt)
+	if stmt.Predicate.SublayoutBinding != nil {
+		t.Errorf("expected nil SublayoutBinding for unbound session, got %+v", stmt.Predicate.SublayoutBinding)
+	}
+}
+
+// TestWritePropagation_CarriesAttestationPrefix verifies the
+// parent-side: WritePropagationForSublayout stores the sublayout's
+// AttestationPrefix so the child can pick it up at SessionStart.
+func TestWritePropagation_CarriesAttestationPrefix(t *testing.T) {
+	h := newTestHandler(t)
+	parent := seedSession(t, h, "parent-prefix-write", &aflock.Policy{
+		Name:    "parent",
+		Version: "1.0",
+	})
+	parent.Metrics = &aflock.SessionMetrics{}
+	if err := h.stateManager.Save(parent); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	sub := &aflock.Sublayout{
+		Name:              "research",
+		AttestationPrefix: "sub/research/",
+		Limits: &aflock.LimitsPolicy{
+			MaxSpendUSD: &aflock.Limit{Value: 2.0},
+		},
+	}
+	if err := h.stateManager.WritePropagationForSublayout(parent, sub); err != nil {
+		t.Fatalf("WritePropagationForSublayout: %v", err)
+	}
+
+	rec, err := h.stateManager.ReadPropagation(parent.PolicyPath)
+	if err != nil || rec == nil {
+		t.Fatalf("ReadPropagation: rec=%v err=%v", rec, err)
+	}
+	if rec.AttestationPrefix != "sub/research/" {
+		t.Errorf("AttestationPrefix = %q, want %q", rec.AttestationPrefix, "sub/research/")
+	}
+	if rec.SublayoutName != "research" {
+		t.Errorf("SublayoutName = %q, want %q", rec.SublayoutName, "research")
+	}
+	// Silence unused imports kept for parity with the rest of the file.
+	_ = strings.HasPrefix
+	_ = time.Now
+	_ = base64.StdEncoding
+	_ = attestation.ActionPredicate{}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -870,7 +870,8 @@ func (s *Server) signAndStoreAttestation(ctx context.Context, record aflock.Acti
 	}
 
 	// Create and sign attestation
-	envelope, err := s.signer.CreateActionAttestation(ctx, record, s.sessionID, metrics, s.agentIdentity, jwtBinding)
+	envelope, err := s.signer.CreateActionAttestation(ctx, record, s.sessionID, metrics, s.agentIdentity,
+		&attestation.AttestationContext{JWT: jwtBinding})
 	if err != nil {
 		return fmt.Errorf("create attestation: %w", err)
 	}

--- a/internal/replay/simulate.go
+++ b/internal/replay/simulate.go
@@ -216,6 +216,7 @@ func createReplayAttestation(
 		sessionState.SessionID,
 		sessionState.Metrics,
 		agentIdentity,
+		nil,
 	)
 	if err != nil {
 		return "", fmt.Errorf("create attestation: %w", err)

--- a/internal/state/propagation.go
+++ b/internal/state/propagation.go
@@ -93,6 +93,7 @@ func (m *Manager) writePropagationRecord(parentState *aflock.SessionState, sub *
 	case sub != nil:
 		rec.ParentLimits = sub.Limits
 		rec.SublayoutName = sub.Name
+		rec.AttestationPrefix = sub.AttestationPrefix
 	case parentState.Policy != nil:
 		rec.ParentLimits = parentState.Policy.Limits
 	}

--- a/pkg/aflock/types.go
+++ b/pkg/aflock/types.go
@@ -484,6 +484,12 @@ type SessionState struct {
 	// sublayout declarations. Used by verification to confirm a child stayed
 	// within the sublayout's promised scope (issue #26).
 	ParentSublayoutName string `json:"parent_sublayout_name,omitempty"`
+	// AttestationPrefix is the parent sublayout's AttestationPrefix string,
+	// inherited via propagation. Stamped into every attestation predicate so
+	// audit tools can group child attestations under the declared sublayout
+	// slot (issue #26 gap 1). Empty when the parent had no sublayouts or the
+	// matched sublayout didn't set a prefix.
+	AttestationPrefix string `json:"attestation_prefix,omitempty"`
 	// ChildSessionIDs tracks subagent sessions spawned from this session
 	ChildSessionIDs []string `json:"child_session_ids,omitempty"`
 	// AgentIdentityMeta stores identity discovered at SessionStart for reuse in PostToolUse
@@ -536,6 +542,10 @@ type PropagationRecord struct {
 	// session is bound to this sublayout for verification (issue #26 gaps
 	// 4 and 5).
 	SublayoutName string `json:"sublayout_name,omitempty"`
+	// AttestationPrefix carries the matched sublayout's AttestationPrefix
+	// over to the child so its PostToolUse attestations can stamp it into
+	// the predicate (issue #26 gap 1).
+	AttestationPrefix string `json:"attestation_prefix,omitempty"`
 }
 
 // IsExpiredPropagation checks if the propagation record has exceeded the given TTL.


### PR DESCRIPTION
## Summary
Second slice of #26 — closes gap 1 (attestation namespacing). When a child session was matched to a parent's declared sublayout (PR #112), every attestation it signs now carries a `SublayoutBinding{Name, Prefix, ParentSessionID}` in the predicate. Audit / verify tooling can group child attestations under the right sublayout slot deterministically.

## Details
- New `attestation.SublayoutBinding` struct + `ActionPredicate.SublayoutBinding` field.
- `CreateActionAttestation` signature swapped from variadic `...*JWTBinding` to a single `*AttestationContext{JWT, Sublayout}` so the bindings compose cleanly. All callsites updated.
- `PropagationRecord.AttestationPrefix` + `SessionState.AttestationPrefix` carry the parent's `Sublayout.AttestationPrefix` to the child at SessionStart.
- Hooks `createAttestation` builds the binding from `SessionState` when present.
- Tests: predicate carries binding when set, omitted when unbound, propagation round-trip.

## Depends on
PR #112 (spawn-time matching). Rebase if #112 is merged first.

## Out of scope (#26 remaining)
- Gap 2: `Inherit` semantics — needs design.
- Gap 6: propagation-key collision — cross-process correlation design.