### PR TITLE
fix(state): write each propagation to a unique filename

### DIFF
--- a/internal/state/propagation.go
+++ b/internal/state/propagation.go
@@ -1,11 +1,14 @@
 package state
 
 import (
+	"crypto/rand"
 	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"time"
 
 	"github.com/aflock-ai/aflock/pkg/aflock"
@@ -25,19 +28,41 @@ func propagationBaseDir() string {
 	return expandPath("~/.aflock/" + propagationDir)
 }
 
-// propagationKey returns a deterministic filename for a given policy path.
-// Uses SHA-256 of the absolute path so different policies don't collide.
-func propagationKey(policyPath string) string {
+// propagationKeyPrefix returns the deterministic per-policy prefix used to
+// group all propagation files for the given policy path. SHA-256 of the
+// absolute path keeps different policies in disjoint namespaces.
+//
+// Earlier versions of this code used the prefix as the WHOLE filename, which
+// meant two concurrent parent spawns of the same policy raced on a single
+// file and one's record silently overwrote the other (issue #26 gap 6). The
+// prefix is now combined with a per-call nonce in propagationFilename so
+// every Write produces a distinct file.
+func propagationKeyPrefix(policyPath string) string {
 	abs, err := filepath.Abs(policyPath)
 	if err != nil {
 		abs = policyPath
 	}
 	h := sha256.Sum256([]byte(abs))
-	return fmt.Sprintf("%x.json", h)
+	return hex.EncodeToString(h[:])
+}
+
+// propagationFilename returns a unique filename for a fresh propagation
+// record under the given policy's prefix. Combines a monotonic timestamp
+// with 8 random bytes so concurrent writers from different processes can
+// never collide (issue #26 gap 6).
+func propagationFilename(policyPath string) (string, error) {
+	prefix := propagationKeyPrefix(policyPath)
+	var nonce [8]byte
+	if _, err := rand.Read(nonce[:]); err != nil {
+		return "", fmt.Errorf("generate propagation nonce: %w", err)
+	}
+	return fmt.Sprintf("%s.%d-%s.json", prefix, time.Now().UnixNano(), hex.EncodeToString(nonce[:])), nil
 }
 
 // WritePropagation writes a propagation file so that a child session can
-// inherit the parent's materials, metrics, and attenuated limits.
+// inherit the parent's materials, metrics, and attenuated limits. Each call
+// produces a distinct file (issue #26 gap 6) — concurrent spawns of the
+// same policy no longer overwrite each other.
 func (m *Manager) WritePropagation(parentState *aflock.SessionState) error {
 	dir := propagationBaseDir()
 	if err := os.MkdirAll(dir, 0700); err != nil {
@@ -60,8 +85,11 @@ func (m *Manager) WritePropagation(parentState *aflock.SessionState) error {
 		return fmt.Errorf("marshal propagation: %w", err)
 	}
 
-	key := propagationKey(parentState.PolicyPath)
-	path := filepath.Join(dir, key)
+	name, err := propagationFilename(parentState.PolicyPath)
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(dir, name)
 	if err := os.WriteFile(path, data, 0600); err != nil {
 		return fmt.Errorf("write propagation: %w", err)
 	}
@@ -69,48 +97,107 @@ func (m *Manager) WritePropagation(parentState *aflock.SessionState) error {
 	return nil
 }
 
-// ReadPropagation reads and consumes (via an atomic rename) a propagation file
-// for the given policy path. Returns nil if no file exists or if the record is
+// ReadPropagation reads and consumes a single propagation file for the
+// given policy path. Returns nil if no file exists or all that exist are
 // expired.
 //
-// Consume-once semantics: the file is first renamed to a unique marker path
-// before being read. os.Rename on the same filesystem is atomic and only one
-// caller can succeed, so two concurrent children racing on the same propagation
-// file cannot both observe the record (issue #58 / L4).
+// Multi-file claim: parents may have written several files (issue #26 gap
+// 6), one per spawn. ReadPropagation enumerates all files matching the
+// policy prefix, picks the oldest first (FIFO so children consume in
+// spawn order), and atomically claims it via rename. Concurrent readers
+// racing on the same file resolve via rename's atomicity — only one wins,
+// the other tries the next file. Expired records are removed in passing so
+// stale state doesn't block fresh children indefinitely.
 func (m *Manager) ReadPropagation(policyPath string) (*aflock.PropagationRecord, error) {
-	key := propagationKey(policyPath)
+	prefix := propagationKeyPrefix(policyPath)
 	dir := propagationBaseDir()
-	path := filepath.Join(dir, key)
 
-	// Atomically claim the propagation file. Use a unique suffix so concurrent
-	// readers that both attempt a rename resolve to different targets; only the
-	// one whose source rename succeeds observes the record.
-	claimed := filepath.Join(dir, fmt.Sprintf("%s.consumed.%d.%d", key, os.Getpid(), time.Now().UnixNano()))
-	if err := os.Rename(path, claimed); err != nil {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("claim propagation: %w", err)
+		return nil, fmt.Errorf("read propagation dir: %w", err)
 	}
-	defer func() {
+
+	type candidate struct {
+		name    string
+		modTime time.Time
+	}
+	var candidates []candidate
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		// Skip files that don't belong to this policy or are already
+		// in-flight consumption markers (which carry ".consumed." in
+		// the suffix).
+		if len(name) < len(prefix)+1 || name[:len(prefix)] != prefix || name[len(prefix)] != '.' {
+			continue
+		}
+		if containsConsumedMarker(name) {
+			continue
+		}
+		info, infoErr := entry.Info()
+		if infoErr != nil {
+			continue
+		}
+		candidates = append(candidates, candidate{name: name, modTime: info.ModTime()})
+	}
+
+	// FIFO: oldest first.
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].modTime.Before(candidates[j].modTime)
+	})
+
+	for _, c := range candidates {
+		path := filepath.Join(dir, c.name)
+		claimed := filepath.Join(dir, fmt.Sprintf("%s.consumed.%d.%d", c.name, os.Getpid(), time.Now().UnixNano()))
+		if err := os.Rename(path, claimed); err != nil {
+			if os.IsNotExist(err) {
+				// Another reader won the race on this file — try the next one.
+				continue
+			}
+			return nil, fmt.Errorf("claim propagation: %w", err)
+		}
+
+		data, err := os.ReadFile(claimed) //nolint:gosec // G304: path derived from validated entry under propagation dir
+		if err != nil {
+			_ = os.Remove(claimed)
+			return nil, fmt.Errorf("read propagation: %w", err)
+		}
+
+		var rec aflock.PropagationRecord
+		if err := json.Unmarshal(data, &rec); err != nil {
+			_ = os.Remove(claimed)
+			return nil, fmt.Errorf("parse propagation: %w", err)
+		}
+
 		_ = os.Remove(claimed)
-	}()
 
-	data, err := os.ReadFile(claimed) //nolint:gosec // G304: path derived from validated key under propagation dir
-	if err != nil {
-		return nil, fmt.Errorf("read propagation: %w", err)
+		// Expired records are silently skipped — don't waste a fresh spawn
+		// on stale state. Continue scanning for a live one.
+		if rec.IsExpiredPropagation(PropagationTTL) {
+			continue
+		}
+		return &rec, nil
 	}
 
-	var rec aflock.PropagationRecord
-	if err := json.Unmarshal(data, &rec); err != nil {
-		return nil, fmt.Errorf("parse propagation: %w", err)
-	}
+	return nil, nil
+}
 
-	if rec.IsExpiredPropagation(PropagationTTL) {
-		return nil, nil
+// containsConsumedMarker reports whether the filename has the ".consumed."
+// substring that ReadPropagation writes during atomic claim. Skipping these
+// keeps a concurrent reader from trying to claim a marker that's already in
+// the cleanup window.
+func containsConsumedMarker(name string) bool {
+	for i := 0; i+len(".consumed.") <= len(name); i++ {
+		if name[i:i+len(".consumed.")] == ".consumed." {
+			return true
+		}
 	}
-
-	return &rec, nil
+	return false
 }
 
 // CleanStalePropagation removes propagation files older than 2x TTL.

--- a/internal/state/propagation_issue26_test.go
+++ b/internal/state/propagation_issue26_test.go
@@ -1,0 +1,178 @@
+package state
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/aflock-ai/aflock/pkg/aflock"
+)
+
+// Issue #26 gap 6 — multiple spawns of the same parent policy must each
+// produce a distinct propagation file so concurrent children can all claim
+// inheritance. The old code keyed by policy path only and silently
+// overwrote, leaving all-but-one child empty-handed.
+//
+// NOTE on isolation: propagationBaseDir() points at ~/.aflock/propagation/
+// (real user home, not the test's tmpDir — pre-existing behavior). Each
+// test here uses a unique policy path and cleans up its own files at
+// teardown so cross-test pollution stays bounded.
+
+func uniquePolicyPath(t *testing.T) string {
+	t.Helper()
+	return "/test-issue26/" + t.Name() + "/.aflock"
+}
+
+// cleanupPropagation removes any leftover files for the test's policy path
+// at end of test, defending against state shared via the real ~/.aflock
+// dir from concurrent failures.
+func cleanupPropagation(t *testing.T, policyPath string) {
+	t.Helper()
+	t.Cleanup(func() {
+		prefix := propagationKeyPrefix(policyPath)
+		dir := propagationBaseDir()
+		entries, _ := os.ReadDir(dir)
+		for _, e := range entries {
+			if e.IsDir() {
+				continue
+			}
+			name := e.Name()
+			if len(name) >= len(prefix) && name[:len(prefix)] == prefix {
+				_ = os.Remove(filepath.Join(dir, name))
+			}
+		}
+	})
+}
+
+func TestPropagation_ConcurrentWritesAreDistinctFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	m := NewManager(tmpDir)
+	policyPath := uniquePolicyPath(t)
+	cleanupPropagation(t, policyPath)
+
+	const N = 5
+	for i := 0; i < N; i++ {
+		parent := testParentState()
+		parent.PolicyPath = policyPath
+		parent.SessionID = "parent"
+		if err := m.WritePropagation(parent); err != nil {
+			t.Fatalf("WritePropagation %d: %v", i, err)
+		}
+	}
+
+	prefix := propagationKeyPrefix(policyPath)
+	entries, err := os.ReadDir(propagationBaseDir())
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	count := 0
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if len(name) > len(prefix) && name[:len(prefix)] == prefix && !containsConsumedMarker(name) {
+			count++
+		}
+	}
+	if count != N {
+		t.Errorf("expected %d distinct propagation files, got %d", N, count)
+	}
+}
+
+func TestPropagation_MultipleReadersEachGetARecord(t *testing.T) {
+	tmpDir := t.TempDir()
+	m := NewManager(tmpDir)
+	policyPath := uniquePolicyPath(t)
+	cleanupPropagation(t, policyPath)
+
+	const N = 4
+	for i := 0; i < N; i++ {
+		parent := testParentState()
+		parent.PolicyPath = policyPath
+		if err := m.WritePropagation(parent); err != nil {
+			t.Fatalf("WritePropagation %d: %v", i, err)
+		}
+	}
+
+	results := make([]*aflock.PropagationRecord, N)
+	errs := make([]error, N)
+	var wg sync.WaitGroup
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			rec, err := m.ReadPropagation(policyPath)
+			results[i] = rec
+			errs[i] = err
+		}(i)
+	}
+	wg.Wait()
+
+	wins := 0
+	for i, rec := range results {
+		if errs[i] != nil {
+			t.Errorf("reader %d returned error: %v", i, errs[i])
+		}
+		if rec != nil {
+			wins++
+		}
+	}
+	if wins != N {
+		t.Errorf("expected all %d readers to claim a record, got %d", N, wins)
+	}
+
+	rec, err := m.ReadPropagation(policyPath)
+	if err != nil {
+		t.Fatalf("trailing ReadPropagation: %v", err)
+	}
+	if rec != nil {
+		t.Errorf("expected nil after pool drained, got record from session %q", rec.ParentSessionID)
+	}
+}
+
+func TestPropagation_PrefixOnlyMatchesOwnPolicy(t *testing.T) {
+	tmpDir := t.TempDir()
+	m := NewManager(tmpDir)
+	pathA := uniquePolicyPath(t) + "/a"
+	pathB := uniquePolicyPath(t) + "/b"
+	cleanupPropagation(t, pathA)
+	cleanupPropagation(t, pathB)
+
+	parentA := testParentState()
+	parentA.PolicyPath = pathA
+	parentB := testParentState()
+	parentB.PolicyPath = pathB
+
+	if err := m.WritePropagation(parentA); err != nil {
+		t.Fatalf("WritePropagation A: %v", err)
+	}
+	if err := m.WritePropagation(parentB); err != nil {
+		t.Fatalf("WritePropagation B: %v", err)
+	}
+
+	rec, err := m.ReadPropagation(pathA)
+	if err != nil || rec == nil {
+		t.Fatalf("ReadPropagation A: rec=%v err=%v", rec, err)
+	}
+	if rec.PolicyPath != pathA {
+		t.Errorf("got record for %q, want %q", rec.PolicyPath, pathA)
+	}
+
+	rec, err = m.ReadPropagation(pathA)
+	if err != nil {
+		t.Fatalf("trailing read A: %v", err)
+	}
+	if rec != nil {
+		t.Error("A pool should be empty after consume")
+	}
+
+	rec, err = m.ReadPropagation(pathB)
+	if err != nil || rec == nil {
+		t.Fatalf("ReadPropagation B: rec=%v err=%v", rec, err)
+	}
+	if rec.PolicyPath != pathB {
+		t.Errorf("got record for %q, want %q", rec.PolicyPath, pathB)
+	}
+}

--- a/internal/state/propagation_test.go
+++ b/internal/state/propagation_test.go
@@ -111,9 +111,9 @@ func TestPropagation_TTLExpiration(t *testing.T) {
 		t.Fatalf("WritePropagation: %v", err)
 	}
 
-	// Tamper with the file to set an old CreatedAt
-	key := propagationKey(parent.PolicyPath)
-	path := filepath.Join(propagationBaseDir(), key)
+	// Tamper with the file to set an old CreatedAt. Files now have a random
+	// per-write suffix (issue #26 gap 6) so look up by the policy's prefix.
+	path := singlePropagationFile(t, parent.PolicyPath)
 	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("read propagation file: %v", err)
@@ -179,12 +179,13 @@ func TestPropagation_MalformedJSON(t *testing.T) {
 	tmpDir := t.TempDir()
 	m := NewManager(tmpDir)
 
-	// Write garbage to the propagation file
+	// Write garbage to the propagation file. Use the prefix-only key form so
+	// ReadPropagation finds it via its enumeration step (issue #26 gap 6).
 	dir := propagationBaseDir()
-	os.MkdirAll(dir, 0700)
-	key := propagationKey("/project/.aflock")
-	path := filepath.Join(dir, key)
-	os.WriteFile(path, []byte("not json{{{"), 0600)
+	_ = os.MkdirAll(dir, 0700)
+	prefix := propagationKeyPrefix("/project/.aflock")
+	path := filepath.Join(dir, prefix+".garbage.json")
+	_ = os.WriteFile(path, []byte("not json{{{"), 0600)
 
 	rec, err := m.ReadPropagation("/project/.aflock")
 	if err == nil {
@@ -331,14 +332,46 @@ func TestPropagation_ConcurrentConsumeOnce(t *testing.T) {
 }
 
 func TestPropagationKey_Deterministic(t *testing.T) {
-	k1 := propagationKey("/project/.aflock")
-	k2 := propagationKey("/project/.aflock")
+	k1 := propagationKeyPrefix("/project/.aflock")
+	k2 := propagationKeyPrefix("/project/.aflock")
 	if k1 != k2 {
-		t.Errorf("same path should produce same key: %q != %q", k1, k2)
+		t.Errorf("same path should produce same prefix: %q != %q", k1, k2)
 	}
 
-	k3 := propagationKey("/other/.aflock")
+	k3 := propagationKeyPrefix("/other/.aflock")
 	if k1 == k3 {
-		t.Error("different paths should produce different keys")
+		t.Error("different paths should produce different prefixes")
 	}
+}
+
+// singlePropagationFile locates the single propagation file under the test's
+// state dir for the given policy path, failing if there is none or more than
+// one. Helper for tests that need to introspect or tamper with the on-disk
+// file when filenames carry a random per-write suffix (issue #26 gap 6).
+func singlePropagationFile(t *testing.T, policyPath string) string {
+	t.Helper()
+	prefix := propagationKeyPrefix(policyPath)
+	dir := propagationBaseDir()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read propagation dir: %v", err)
+	}
+	var found []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if len(name) < len(prefix)+1 || name[:len(prefix)] != prefix || name[len(prefix)] != '.' {
+			continue
+		}
+		if containsConsumedMarker(name) {
+			continue
+		}
+		found = append(found, filepath.Join(dir, name))
+	}
+	if len(found) != 1 {
+		t.Fatalf("expected exactly 1 propagation file for %q, got %d", policyPath, len(found))
+	}
+	return found[0]
 }


### PR DESCRIPTION
## Summary
Third slice of #26 — closes gap 6 (propagation key collision). Each `WritePropagation` call now produces a distinct file under the policy's deterministic prefix; `ReadPropagation` enumerates the pool and atomically claims one. Concurrent same-policy spawns no longer overwrite each other, and concurrent readers each get their own record.

## Details
- Filename = `<sha256(policyPath)>.<nanos>-<8 random bytes>.json`, written by `WritePropagation`.
- `ReadPropagation` lists files matching the policy's prefix, sorts FIFO by mtime, tries `os.Rename` on each until one claim succeeds. Skips expired and `.consumed.` marker files.
- Tests: distinct files per write, all concurrent readers get a record, prefix-isolation between policies. Existing tests updated to look up by prefix.
- Independent of #112 / #113 — purely changes the propagation file lifecycle.

## Out of scope
- Parent → child correlation (which child should get which propagation when sublayouts differ). Without an env-passthrough or transcript-correlated signal from Claude Code, the pool is FIFO-per-policy. Filed as follow-up if needed.