### PR TITLE
fix(auth): persist Policy.RawDigest so hook subprocesses can validate the JWT

### DIFF
--- a/internal/auth/jwt_test.go
+++ b/internal/auth/jwt_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -242,6 +243,35 @@ func TestPolicyDigestBinding(t *testing.T) {
 	assert.NotEqual(t, claims1.PolicyDigest, claims2.PolicyDigest)
 	assert.NotEmpty(t, claims1.PolicyDigest)
 	assert.NotEmpty(t, claims2.PolicyDigest)
+}
+
+// TestPolicyDigest_SurvivesStateJSONRoundTrip pins the fix for the hooks
+// JWT-validation bug: a Policy with RawDigest set must round-trip through
+// JSON without losing the digest, so subprocess hooks that load
+// SessionState from disk compute the same digest the JWT was bound to at
+// SessionStart. Before the fix, RawDigest had `json:"-"` and was stripped
+// from state.json — re-marshaling the parsed struct then produced a
+// different digest and every PreToolUse call was rejected as "token bound
+// to a different policy version".
+func TestPolicyDigest_SurvivesStateJSONRoundTrip(t *testing.T) {
+	pol := &aflock.Policy{
+		Name:      "round-trip",
+		Version:   "1.0",
+		RawDigest: "deadbeefcafef00d1234567890abcdef",
+	}
+	before := ComputePolicyDigest(pol)
+	require.Equal(t, "deadbeefcafef00d1234567890abcdef", before)
+
+	data, err := json.Marshal(pol)
+	require.NoError(t, err)
+
+	var restored aflock.Policy
+	require.NoError(t, json.Unmarshal(data, &restored))
+
+	after := ComputePolicyDigest(&restored)
+	assert.Equal(t, before, after,
+		"RawDigest must survive JSON round-trip — otherwise hook subprocesses reject the parent's JWT")
+	assert.Equal(t, "deadbeefcafef00d1234567890abcdef", restored.RawDigest)
 }
 
 func TestNilPolicy(t *testing.T) {

--- a/pkg/aflock/types.go
+++ b/pkg/aflock/types.go
@@ -161,11 +161,16 @@ type Policy struct {
 	Functionaries        []Functionary     `json:"functionaries,omitempty"` // Legacy, use Steps.Functionaries instead
 
 	// RawDigest is the SHA-256 hex digest of the raw policy file bytes captured
-	// at load time. Stored here (json:"-") so callers can bind tokens and
-	// attestations to the exact file the user reviewed/signed, rather than
-	// re-marshaling the parsed struct (which can normalize formatting and
-	// produce a different digest for byte-identical input — issue #61 / L5).
-	RawDigest string `json:"-"`
+	// at load time. Persisted into state.json so subprocess hooks (PreToolUse,
+	// PostToolUse, Stop) recover the same digest the JWT was bound to at
+	// SessionStart — without this, the parent process's parsed Policy struct
+	// would re-marshal to different bytes (key order, whitespace) and JWT
+	// validation would reject every tool call as "token bound to a different
+	// policy version". The original justification for binding to raw bytes
+	// (rather than re-marshal) is issue #61 / L5; this field's value is the
+	// frozen digest captured at SessionStart, intentionally not recomputed
+	// from the on-disk file mid-session.
+	RawDigest string `json:"rawDigest,omitempty"`
 }
 
 // Root represents a trust anchor (CA certificate) for signature verification.


### PR DESCRIPTION
## Summary
`Policy.RawDigest` had `json:"-"` so it was stripped from `state.json`. When a hook subprocess (PreToolUse, PostToolUse, Stop) loaded state and called `ComputePolicyDigest`, the empty `RawDigest` forced a re-marshal of the parsed struct → different bytes → different SHA → the JWT issued at SessionStart was rejected as "token bound to a different policy version" on every tool call.

## Fix
One-line change: `json:"rawDigest,omitempty"` instead of `json:"-"`. The digest captured at SessionStart now survives the state round-trip, and the hook subprocess returns the same value the JWT was bound to.

## Why this is correct
- The original justification for binding to raw file bytes (issue #61 / L5) is preserved.
- The digest is intentionally frozen at SessionStart — policy file edits mid-session don't retroactively invalidate the token, which matches the existing "policy captured at SessionStart" model.
- Token still rejects across different policies / sessions (verified by `TestPolicyDigestBinding`).

## Test
New `TestPolicyDigest_SurvivesStateJSONRoundTrip` pins the regression: build a Policy with RawDigest, marshal/unmarshal, assert `ComputePolicyDigest` returns the same value.