### PR TITLE
feat(auth): warn-vs-enforce split for cost-based limits by auth mode

### DIFF
--- a/internal/auth/claudeauth/detect.go
+++ b/internal/auth/claudeauth/detect.go
@@ -1,0 +1,124 @@
+// Package claudeauth detects which authentication mode claude-code is
+// using for the current session: pay-per-token API key vs subscription
+// (Pro/Max OAuth).
+//
+// Why this matters: aflock's JSONL-derived metrics (tokens, cost) match
+// what Anthropic actually bills only under API-key mode, where the
+// public per-token rates apply directly. Under subscription, Anthropic
+// uses an internal accounting that JSONL-based tracking cannot reproduce
+// (claude-code's internal haiku-routing calls + opus system calls land
+// in the bill but never in the transcript). So cost-based limits like
+// maxSpendUSD should enforce under API-key mode and be advisory-only
+// under subscription mode. Closes #111.
+//
+// Detection precedence (first match wins):
+//  1. AFLOCK_AUTH_MODE env var ("api_key" | "subscription") — explicit override
+//  2. ANTHROPIC_API_KEY env var present — claude-code uses key over OAuth
+//  3. ~/.claude/.credentials.json contains an apiKey field — API key
+//  4. ~/.claude/.credentials.json contains a claudeAiOauth block — subscription
+//  5. macOS Keychain has "Claude Code-credentials" entry — subscription
+//  6. Otherwise — Unknown (caller should treat as subscription for advisory safety)
+package claudeauth
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+)
+
+// Mode names the authentication mode claude-code is using.
+type Mode string
+
+const (
+	// ModeAPIKey indicates claude-code is billing per token via an
+	// Anthropic API key (env var, .credentials.json apiKey, etc.).
+	// JSONL-derived cost numbers match actual billing under this mode.
+	ModeAPIKey Mode = "api_key"
+
+	// ModeSubscription indicates claude-code is using Pro/Max OAuth
+	// (Anthropic Console subscription). JSONL-derived cost numbers
+	// will NOT match Claude /usage's $ because subscription accounting
+	// is internal to Anthropic.
+	ModeSubscription Mode = "subscription"
+
+	// ModeUnknown means detection could not conclude. Callers should
+	// treat this as subscription-equivalent for the purpose of cost
+	// limit enforcement — better to advise than to falsely deny when
+	// the auth signal is ambiguous.
+	ModeUnknown Mode = "unknown"
+)
+
+// Detect returns the auth mode claude-code is using for the current
+// session. Best-effort and side-effect-free: never prompts the user, never
+// reads secret material, never writes anything. On macOS the keychain
+// probe lists the entry's metadata only (no password access prompt).
+func Detect() Mode {
+	if m := envOverride(); m != ModeUnknown {
+		return m
+	}
+	if os.Getenv("ANTHROPIC_API_KEY") != "" {
+		return ModeAPIKey
+	}
+	if m := detectFromCredentialsFile(); m != ModeUnknown {
+		return m
+	}
+	if runtime.GOOS == "darwin" && macosKeychainHasClaudeCode() {
+		return ModeSubscription
+	}
+	return ModeUnknown
+}
+
+func envOverride() Mode {
+	switch os.Getenv("AFLOCK_AUTH_MODE") {
+	case string(ModeAPIKey):
+		return ModeAPIKey
+	case string(ModeSubscription):
+		return ModeSubscription
+	}
+	return ModeUnknown
+}
+
+// credentialsFile mirrors the subset of ~/.claude/.credentials.json that
+// signals auth mode. claude-code has used both shapes historically:
+// `apiKey` (string) for API-key mode and `claudeAiOauth` (object) for
+// OAuth. Other fields are ignored. We never read the secret material;
+// only the presence of these keys.
+type credentialsFile struct {
+	APIKey        string          `json:"apiKey,omitempty"`
+	ClaudeAIOauth json.RawMessage `json:"claudeAiOauth,omitempty"`
+}
+
+func detectFromCredentialsFile() Mode {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ModeUnknown
+	}
+	path := filepath.Join(home, ".claude", ".credentials.json")
+	data, err := os.ReadFile(path) //nolint:gosec // G304: well-known path under user home
+	if err != nil {
+		return ModeUnknown
+	}
+	var c credentialsFile
+	if err := json.Unmarshal(data, &c); err != nil {
+		return ModeUnknown
+	}
+	if c.APIKey != "" {
+		return ModeAPIKey
+	}
+	if len(c.ClaudeAIOauth) > 0 {
+		return ModeSubscription
+	}
+	return ModeUnknown
+}
+
+// macosKeychainHasClaudeCode returns true when the macOS login keychain
+// has a generic-password entry with service "Claude Code-credentials" —
+// claude-code's storage location for OAuth tokens on darwin. Uses
+// `security find-generic-password` without -w so only entry metadata is
+// listed; the password is never read and no UI prompt is triggered.
+func macosKeychainHasClaudeCode() bool {
+	cmd := exec.Command("security", "find-generic-password", "-s", "Claude Code-credentials")
+	return cmd.Run() == nil
+}

--- a/internal/auth/claudeauth/detect_test.go
+++ b/internal/auth/claudeauth/detect_test.go
@@ -1,0 +1,118 @@
+package claudeauth
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestDetect_EnvOverrideWins asserts the AFLOCK_AUTH_MODE override beats
+// every other signal. Useful for tests, CI, and explicit user override.
+func TestDetect_EnvOverrideWins(t *testing.T) {
+	t.Setenv("AFLOCK_AUTH_MODE", "api_key")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("HOME", t.TempDir())
+	if got := Detect(); got != ModeAPIKey {
+		t.Errorf("expected ModeAPIKey from AFLOCK_AUTH_MODE override, got %q", got)
+	}
+
+	t.Setenv("AFLOCK_AUTH_MODE", "subscription")
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-...")
+	if got := Detect(); got != ModeSubscription {
+		t.Errorf("expected override to beat ANTHROPIC_API_KEY, got %q", got)
+	}
+}
+
+// TestDetect_ApiKeyEnvVar covers the common pay-per-token path: user has
+// ANTHROPIC_API_KEY exported and claude-code is billing it directly.
+func TestDetect_ApiKeyEnvVar(t *testing.T) {
+	t.Setenv("AFLOCK_AUTH_MODE", "")
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-api-...")
+	t.Setenv("HOME", t.TempDir())
+	if got := Detect(); got != ModeAPIKey {
+		t.Errorf("expected ModeAPIKey when ANTHROPIC_API_KEY is set, got %q", got)
+	}
+}
+
+// TestDetect_CredentialsFileApiKey covers the legacy "apiKey" field in
+// ~/.claude/.credentials.json — older claude-code installs stored a flat
+// API key here. Treat presence of the apiKey field as ModeAPIKey.
+func TestDetect_CredentialsFileApiKey(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AFLOCK_AUTH_MODE", "")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	creds := `{"apiKey":"sk-ant-fake-for-tests"}`
+	if err := os.WriteFile(filepath.Join(home, ".claude", ".credentials.json"), []byte(creds), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := Detect(); got != ModeAPIKey {
+		t.Errorf("expected ModeAPIKey from credentials.json apiKey field, got %q", got)
+	}
+}
+
+// TestDetect_CredentialsFileOauth covers the Pro/Max subscription path:
+// ~/.claude/.credentials.json holds a claudeAiOauth object with the
+// access token + refresh token. Presence of the object is enough to
+// signal subscription; we never read the token itself.
+func TestDetect_CredentialsFileOauth(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AFLOCK_AUTH_MODE", "")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	creds := `{"claudeAiOauth":{"accessToken":"redacted","refreshToken":"redacted"}}`
+	if err := os.WriteFile(filepath.Join(home, ".claude", ".credentials.json"), []byte(creds), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := Detect(); got != ModeSubscription {
+		t.Errorf("expected ModeSubscription from claudeAiOauth block, got %q", got)
+	}
+}
+
+// TestDetect_UnknownWhenNoSignal covers the fallback path. No env var,
+// no credentials file, and the macOS keychain probe (when on darwin)
+// finds no entry. We can also reach this branch on Linux when the
+// credentials.json simply doesn't exist.
+func TestDetect_UnknownWhenNoSignal(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AFLOCK_AUTH_MODE", "")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	// Don't create credentials.json. On macOS the keychain probe may
+	// still find a real entry on the developer's machine, so this test
+	// is informational on darwin: if it returns ModeSubscription, that's
+	// the keychain leaking a real signal. We assert only that we don't
+	// falsely return ModeAPIKey here.
+	got := Detect()
+	if got == ModeAPIKey {
+		t.Errorf("expected non-api_key (Unknown or Subscription via keychain), got %q", got)
+	}
+}
+
+// TestDetect_CredentialsFileMalformed asserts we don't panic on a
+// corrupt credentials.json and don't infer the wrong mode from junk.
+func TestDetect_CredentialsFileMalformed(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AFLOCK_AUTH_MODE", "")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".claude", ".credentials.json"), []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got := Detect()
+	if got == ModeAPIKey {
+		t.Errorf("malformed credentials shouldn't yield ModeAPIKey, got %q", got)
+	}
+}

--- a/internal/hooks/handler.go
+++ b/internal/hooks/handler.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/aflock-ai/aflock/internal/attestation"
 	"github.com/aflock-ai/aflock/internal/auth"
+	"github.com/aflock-ai/aflock/internal/auth/claudeauth"
 	"github.com/aflock-ai/aflock/internal/identity"
 	"github.com/aflock-ai/aflock/internal/output"
 	"github.com/aflock-ai/aflock/internal/policy"
@@ -151,6 +152,7 @@ func (h *Handler) handleSessionStart(input *aflock.HookInput) error {
 
 	// Initialize session state
 	sessionState := h.stateManager.Initialize(input.SessionID, pol, policyPath)
+	sessionState.AuthMode = string(claudeauth.Detect())
 
 	// Save agent identity metadata for reuse in PostToolUse attestations
 	sessionState.AgentIdentityMeta = &aflock.AgentIdentityMeta{
@@ -443,6 +445,7 @@ func (h *Handler) handlePreToolUse(input *aflock.HookInput) error {
 		}
 		// Create ephemeral session state
 		sessionState = h.stateManager.Initialize(input.SessionID, pol, policyPath)
+		sessionState.AuthMode = string(claudeauth.Detect())
 	}
 
 	pol := sessionState.Policy
@@ -627,8 +630,13 @@ func (h *Handler) handlePostToolUse(input *aflock.HookInput) error {
 		evaluator := policy.NewEvaluator(sessionState.Policy, filepath.Dir(sessionState.PolicyPath))
 		exceeded, limitName, msg := evaluator.CheckLimits(sessionState.Metrics, "fail-fast")
 		if exceeded {
-			return output.Write(output.PostToolUseBlock(
-				fmt.Sprintf("[aflock] Limit exceeded: %s - %s", limitName, msg)))
+			if evaluator.IsAdvisoryLimit(limitName, sessionState.AuthMode) {
+				fmt.Fprintf(os.Stderr, "[aflock] Limit advisory (auth: %s, not enforced): %s - %s\n",
+					sessionState.AuthMode, limitName, msg)
+			} else {
+				return output.Write(output.PostToolUseBlock(
+					fmt.Sprintf("[aflock] Limit exceeded: %s - %s", limitName, msg)))
+			}
 		}
 	}
 
@@ -1097,8 +1105,13 @@ func (h *Handler) handleSubagentStop(input *aflock.HookInput) error {
 		evaluator := policy.NewEvaluator(childState.Policy, filepath.Dir(childState.PolicyPath))
 		exceeded, limitName, msg := evaluator.CheckLimits(childState.Metrics, "post-hoc")
 		if exceeded {
-			return output.Write(output.StopBlock(
-				fmt.Sprintf("[aflock] Subagent limit exceeded: %s - %s", limitName, msg)))
+			if evaluator.IsAdvisoryLimit(limitName, childState.AuthMode) {
+				fmt.Fprintf(os.Stderr, "[aflock] Subagent limit advisory (auth: %s, not enforced): %s - %s\n",
+					childState.AuthMode, limitName, msg)
+			} else {
+				return output.Write(output.StopBlock(
+					fmt.Sprintf("[aflock] Subagent limit exceeded: %s - %s", limitName, msg)))
+			}
 		}
 	}
 
@@ -1127,13 +1140,27 @@ func (h *Handler) handleSessionEnd(input *aflock.HookInput) error {
 		evaluator := policy.NewEvaluator(sessionState.Policy, filepath.Dir(sessionState.PolicyPath))
 		exceeded, limitName, msg := evaluator.CheckLimits(sessionState.Metrics, "post-hoc")
 		if exceeded {
-			fmt.Fprintf(os.Stderr, "[aflock] Post-hoc limit exceeded: %s - %s\n", limitName, msg)
-			// Record the violation in session state for audit trail
+			advisory := evaluator.IsAdvisoryLimit(limitName, sessionState.AuthMode)
+			if advisory {
+				fmt.Fprintf(os.Stderr, "[aflock] Post-hoc limit advisory (auth: %s, not enforced): %s - %s\n",
+					sessionState.AuthMode, limitName, msg)
+			} else {
+				fmt.Fprintf(os.Stderr, "[aflock] Post-hoc limit exceeded: %s - %s\n", limitName, msg)
+			}
+			// Record either way for the audit trail — advisory crossings
+			// still inform auditors a threshold was passed under a mode
+			// where enforcement was suppressed.
+			decision := aflock.DecisionDeny
+			reason := fmt.Sprintf("post-hoc limit exceeded: %s - %s", limitName, msg)
+			if advisory {
+				decision = aflock.DecisionAllow
+				reason = fmt.Sprintf("post-hoc limit advisory (%s auth): %s - %s", sessionState.AuthMode, limitName, msg)
+			}
 			h.stateManager.RecordAction(sessionState, aflock.ActionRecord{
 				Timestamp: time.Now(),
 				ToolName:  "SessionEnd",
-				Decision:  string(aflock.DecisionDeny),
-				Reason:    fmt.Sprintf("post-hoc limit exceeded: %s - %s", limitName, msg),
+				Decision:  string(decision),
+				Reason:    reason,
 			})
 			if err := h.stateManager.Save(sessionState); err != nil {
 				fmt.Fprintf(os.Stderr, "[aflock] Warning: failed to save session state: %v\n", err)

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/aflock-ai/aflock/internal/attestation"
 	"github.com/aflock-ai/aflock/internal/auth"
+	"github.com/aflock-ai/aflock/internal/auth/claudeauth"
 	"github.com/aflock-ai/aflock/internal/identity"
 	"github.com/aflock-ai/aflock/internal/identity/peercred"
 	"github.com/aflock-ai/aflock/internal/policy"
@@ -239,10 +240,11 @@ func (s *Server) Serve(policyPath string) error {
 	// Initialize session state if we have a policy
 	if s.policy != nil {
 		sessionState := s.stateManager.Initialize(s.sessionID, s.policy, s.policyPath)
+		sessionState.AuthMode = string(claudeauth.Detect())
 		if err := s.stateManager.Save(sessionState); err != nil {
 			fmt.Fprintf(os.Stderr, "[aflock] Warning: failed to save session: %v\n", err)
 		}
-		fmt.Fprintf(os.Stderr, "[aflock] MCP server started with policy: %s\n", s.policy.Name)
+		fmt.Fprintf(os.Stderr, "[aflock] MCP server started with policy: %s (auth: %s)\n", s.policy.Name, sessionState.AuthMode)
 	} else {
 		fmt.Fprintf(os.Stderr, "[aflock] MCP server started (no policy loaded)\n")
 	}
@@ -311,10 +313,11 @@ func (s *Server) ServeHTTP(policyPath string, port int) error {
 	// Initialize session state if we have a policy
 	if s.policy != nil {
 		sessionState := s.stateManager.Initialize(s.sessionID, s.policy, s.policyPath)
+		sessionState.AuthMode = string(claudeauth.Detect())
 		if err := s.stateManager.Save(sessionState); err != nil {
 			fmt.Fprintf(os.Stderr, "[aflock] Warning: failed to save session: %v\n", err)
 		}
-		fmt.Fprintf(os.Stderr, "[aflock] HTTP MCP server starting with policy: %s\n", s.policy.Name)
+		fmt.Fprintf(os.Stderr, "[aflock] HTTP MCP server starting with policy: %s (auth: %s)\n", s.policy.Name, sessionState.AuthMode)
 	} else {
 		fmt.Fprintf(os.Stderr, "[aflock] HTTP MCP server starting (no policy loaded)\n")
 	}
@@ -538,10 +541,11 @@ func (s *Server) ServeUnix(policyPath, socketPath string) error {
 
 	if s.policy != nil {
 		sessionState := s.stateManager.Initialize(s.sessionID, s.policy, s.policyPath)
+		sessionState.AuthMode = string(claudeauth.Detect())
 		if err := s.stateManager.Save(sessionState); err != nil {
 			fmt.Fprintf(os.Stderr, "[aflock] Warning: failed to save session: %v\n", err)
 		}
-		fmt.Fprintf(os.Stderr, "[aflock] MCP server started with policy: %s\n", s.policy.Name)
+		fmt.Fprintf(os.Stderr, "[aflock] MCP server started with policy: %s (auth: %s)\n", s.policy.Name, sessionState.AuthMode)
 	} else {
 		fmt.Fprintf(os.Stderr, "[aflock] MCP server started (no policy loaded)\n")
 	}

--- a/internal/policy/evaluator.go
+++ b/internal/policy/evaluator.go
@@ -1035,3 +1035,30 @@ func (e *Evaluator) CheckLimits(metrics *aflock.SessionMetrics, enforcementMode 
 
 	return false, "", ""
 }
+
+// IsAdvisoryLimit returns true when a CheckLimits violation on limitName
+// should be treated as advisory (logged, not enforced) given the session's
+// claude-code auth mode. The cost-based limits (maxSpendUSD, maxTokensIn,
+// maxTokensOut) drop to advisory under non-api_key modes because local
+// token-count × public-rate math cannot reproduce Anthropic's subscription
+// billing. maxTurns and maxToolCalls stay enforced — those metrics aren't
+// $-dependent.
+//
+// authMode comes from SessionState.AuthMode, populated at session init by
+// claudeauth.Detect(). An unknown mode is treated like subscription so we
+// err on the side of advising rather than falsely denying when the auth
+// signal is ambiguous. Closes #111.
+func (e *Evaluator) IsAdvisoryLimit(limitName, authMode string) bool {
+	if authMode == authModeAPIKey {
+		return false
+	}
+	switch limitName {
+	case "maxSpendUSD", "maxTokensIn", "maxTokensOut":
+		return true
+	}
+	return false
+}
+
+// authModeAPIKey mirrors claudeauth.ModeAPIKey without importing the
+// package — keeps policy free of darwin-specific keychain probe deps.
+const authModeAPIKey = "api_key"

--- a/internal/policy/evaluator_authmode_test.go
+++ b/internal/policy/evaluator_authmode_test.go
@@ -1,0 +1,58 @@
+package policy
+
+import (
+	"testing"
+)
+
+// TestIsAdvisoryLimit_CostLimitsUnderSubscription proves the table
+// CodexBar-style local-scan metrics use: cost-based limits drop to
+// advisory under subscription mode because JSONL × public rates can't
+// reproduce Anthropic's subscription billing.
+func TestIsAdvisoryLimit_CostLimitsUnderSubscription(t *testing.T) {
+	e := &Evaluator{}
+	cases := []struct {
+		limit    string
+		authMode string
+		want     bool
+		reason   string
+	}{
+		// Cost-based limits: advisory under non-api_key
+		{"maxSpendUSD", "subscription", true, "spend under subscription is unenforceable"},
+		{"maxTokensIn", "subscription", true, "token-in undercounts under subscription"},
+		{"maxTokensOut", "subscription", true, "token-out undercounts under subscription"},
+		{"maxSpendUSD", "unknown", true, "unknown auth defaults to advisory"},
+		{"maxTokensIn", "", true, "empty auth string defaults to advisory"},
+		// Cost-based limits: enforced under api_key
+		{"maxSpendUSD", "api_key", false, "spend under api_key is the actual bill"},
+		{"maxTokensIn", "api_key", false, "token-in under api_key is real billing"},
+		{"maxTokensOut", "api_key", false, "token-out under api_key is real billing"},
+		// Non-cost limits: enforced regardless of auth mode
+		{"maxTurns", "subscription", false, "turns count accurately in JSONL under both modes"},
+		{"maxTurns", "api_key", false, "turns count accurately in JSONL under both modes"},
+		{"maxToolCalls", "subscription", false, "tool calls are tracked by aflock directly"},
+		{"maxToolCalls", "api_key", false, "tool calls are tracked by aflock directly"},
+	}
+	for _, c := range cases {
+		t.Run(c.limit+"/"+c.authMode, func(t *testing.T) {
+			got := e.IsAdvisoryLimit(c.limit, c.authMode)
+			if got != c.want {
+				t.Errorf("IsAdvisoryLimit(%q, %q) = %v, want %v (%s)",
+					c.limit, c.authMode, got, c.want, c.reason)
+			}
+		})
+	}
+}
+
+// TestIsAdvisoryLimit_UnknownLimitName guards against silent advisory
+// promotion for limits we don't recognize. If a future limit is added
+// to the policy schema but not added to IsAdvisoryLimit's switch, it
+// stays enforced (false) — safer default than silently letting it
+// through.
+func TestIsAdvisoryLimit_UnknownLimitName(t *testing.T) {
+	e := &Evaluator{}
+	for _, mode := range []string{"api_key", "subscription", "unknown", ""} {
+		if e.IsAdvisoryLimit("maxBananas", mode) {
+			t.Errorf("unknown limit name should not become advisory under mode %q", mode)
+		}
+	}
+}

--- a/internal/replay/simulate.go
+++ b/internal/replay/simulate.go
@@ -128,7 +128,9 @@ func Simulate(session *Session, pol *aflock.Policy, policyPath string) (*Simulat
 		// PostToolUse — check fail-fast limits
 		if pol.Limits != nil {
 			exceeded, limitName, msg := evaluator.CheckLimits(sessionState.Metrics, "fail-fast")
-			if exceeded && !report.LimitExceeded {
+			// Replay preserves the recorded session's auth mode so cost-based
+			// advisory limits don't trip LimitExceeded.
+			if exceeded && !evaluator.IsAdvisoryLimit(limitName, sessionState.AuthMode) && !report.LimitExceeded {
 				report.LimitExceeded = true
 				report.LimitMessage = fmt.Sprintf("%s: %s", limitName, msg)
 			}
@@ -174,7 +176,7 @@ func Simulate(session *Session, pol *aflock.Policy, policyPath string) (*Simulat
 	// ── Phase 4: SessionEnd — post-hoc limit check ──
 	if pol.Limits != nil {
 		exceeded, limitName, msg := evaluator.CheckLimits(sessionState.Metrics, "post-hoc")
-		if exceeded && !report.LimitExceeded {
+		if exceeded && !evaluator.IsAdvisoryLimit(limitName, sessionState.AuthMode) && !report.LimitExceeded {
 			report.LimitExceeded = true
 			report.LimitMessage = fmt.Sprintf("post-hoc: %s: %s", limitName, msg)
 		}

--- a/internal/verify/verifier.go
+++ b/internal/verify/verifier.go
@@ -270,13 +270,21 @@ func (v *Verifier) verifySessionWithDepth(sessionID string, depth int) (*Result,
 		evaluator := policy.NewEvaluator(sessionState.Policy, filepath.Dir(sessionState.PolicyPath))
 		exceeded, limitName, msg := evaluator.CheckLimits(sessionState.Metrics, "post-hoc")
 		if exceeded {
-			result.Success = false
-			result.Checks = append(result.Checks, CheckResult{
-				Name:    "limits:" + limitName,
-				Passed:  false,
-				Message: msg,
-			})
-			result.Errors = append(result.Errors, msg)
+			if evaluator.IsAdvisoryLimit(limitName, sessionState.AuthMode) {
+				result.Checks = append(result.Checks, CheckResult{
+					Name:    "limits:" + limitName,
+					Passed:  true,
+					Message: fmt.Sprintf("advisory (auth: %s, not enforced): %s", sessionState.AuthMode, msg),
+				})
+			} else {
+				result.Success = false
+				result.Checks = append(result.Checks, CheckResult{
+					Name:    "limits:" + limitName,
+					Passed:  false,
+					Message: msg,
+				})
+				result.Errors = append(result.Errors, msg)
+			}
 		} else {
 			result.Checks = append(result.Checks, CheckResult{
 				Name:   "limits:post-hoc",

--- a/pkg/aflock/types.go
+++ b/pkg/aflock/types.go
@@ -510,6 +510,14 @@ type SessionState struct {
 	// chain-validation work for SPIRE/Fulcio (#62) can branch Stop-gate
 	// behavior without a state-shape migration.
 	SigningMode string `json:"signing_mode,omitempty"`
+	// AuthMode records how claude-code authenticated for this session:
+	// "api_key" (pay-per-token, public-rate billing matches local math),
+	// "subscription" (Pro/Max OAuth, Anthropic uses internal accounting
+	// that local math cannot reproduce), or "unknown" when detection was
+	// inconclusive. Cost-based limits (maxSpendUSD, maxTokensIn,
+	// maxTokensOut) only enforce when AuthMode == "api_key"; under the
+	// other modes they become advisory. Closes #111.
+	AuthMode string `json:"auth_mode,omitempty"`
 }
 
 // AgentIdentityMeta stores agent identity metadata in session state.


### PR DESCRIPTION
Closes #111. Standalone PR targeting `dev` — no JSONL/tracker dependency.

`internal/auth/claudeauth.Detect()` picks the auth mode from env vars / `~/.claude/.credentials.json` / macOS Keychain (no password prompt). `SessionState.AuthMode` carries it through. `Evaluator.IsAdvisoryLimit` drops `maxSpendUSD` / `maxTokensIn` / `maxTokensOut` to advisory under non-`api_key`; `maxTurns` and `maxToolCalls` stay enforced. All CheckLimits call sites updated.

JSONL-based token/cost tracking deliberately out of scope here — to be revisited separately.

## Test plan
- [ ] `go test ./...` clean
- [ ] `AFLOCK_AUTH_MODE` override beats other signals
- [ ] state.json shows `auth_mode` after a real session
- [ ] Subscription session exceeding `maxSpendUSD` logs advisory, does NOT deny
- [ ] API-key session exceeding `maxSpendUSD` denies (unchanged)