### PR TITLE
fix(verify): preserve costUSD decimal so Rego %.2f works

### DIFF
--- a/internal/verify/identity_test.go
+++ b/internal/verify/identity_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -687,6 +688,52 @@ deny[msg] {
 	}
 	if !foundRego {
 		t.Error("Expected failing rego check")
+	}
+}
+
+// Regression for issue #122: a whole-number CostUSD (e.g. 5.00) gets marshaled
+// as "5" and OPA reads it as an int, breaking "%.2f" in Rego sprintf with the
+// "%!f(int=N)" debug marker. The verifier patches the JSON before handing it
+// to OPA, so the deny reason must come back cleanly formatted.
+func TestVerifySession_RegoDeny_WholeNumberCost(t *testing.T) {
+	tmpDir := t.TempDir()
+	ss := &aflock.SessionState{
+		SessionID: "sess-rego-whole-cost",
+		StartedAt: time.Now().Add(-5 * time.Minute),
+		Policy: &aflock.Policy{
+			Name:    "rego-test",
+			Version: "1.0",
+			Evaluators: &aflock.EvaluatorsPolicy{
+				Rego: []aflock.RegoEvaluator{{
+					Name: "spend-limit",
+					Policy: `package aflock
+deny[msg] {
+  input.metrics.costUSD > 2.0
+  msg := sprintf("Child spend $%.2f exceeds $2.00 budget", [input.metrics.costUSD])
+}`,
+				}},
+			},
+		},
+		Actions: []aflock.ActionRecord{
+			{Timestamp: time.Now(), ToolName: "Read", ToolUseID: "tu_1", Decision: "allow"},
+		},
+		Metrics: &aflock.SessionMetrics{CostUSD: 5.00},
+	}
+	writeSessionState(t, tmpDir, "sess-rego-whole-cost", ss)
+
+	result, err := newTestVerifier(tmpDir).VerifySession("sess-rego-whole-cost")
+	if err != nil {
+		t.Fatalf("VerifySession: %v", err)
+	}
+	if result.Success {
+		t.Fatal("Expected rego deny")
+	}
+	joined := strings.Join(result.Errors, " | ")
+	if strings.Contains(joined, "%!f") {
+		t.Errorf("deny reason has sprintf format bug: %s", joined)
+	}
+	if !strings.Contains(joined, "$5.00") {
+		t.Errorf("expected formatted $5.00 in deny reason, got: %s", joined)
 	}
 }
 

--- a/internal/verify/verifier.go
+++ b/internal/verify/verifier.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -1666,6 +1667,11 @@ func evaluateSessionAI(sessionState *aflock.SessionState) []string {
 	return errors
 }
 
+// costFloatLexicalFix matches JSON cost fields whose values lack a decimal point
+// (json.Marshal of float64(5.0) emits "5"). OPA reads such numbers as ints and
+// rejects them in Rego "%f" sprintf calls. See issue #122.
+var costFloatLexicalFix = regexp.MustCompile(`("costUSD")\s*:\s*(-?\d+)([,}\]])`)
+
 // evaluateSessionRego runs top-level Rego evaluators against session data (Phase 4).
 // The input to each Rego policy is:
 //
@@ -1692,6 +1698,10 @@ func evaluateSessionRego(sessionState *aflock.SessionState) []string {
 	if err != nil {
 		return []string{fmt.Sprintf("Rego evaluation failed: marshal input: %v", err)}
 	}
+	// json.Marshal drops trailing zeros from whole floats (5.0 → "5"), which OPA
+	// then treats as int — breaking "%.2f" in Rego sprintf. Restore float form
+	// on known float-typed fields. See issue #122.
+	inputJSON = costFloatLexicalFix.ReplaceAll(inputJSON, []byte(`$1:$2.0$3`))
 
 	// Convert aflock evaluators to rego.Policy
 	policies := make([]aflockRego.Policy, len(sessionState.Policy.Evaluators.Rego))


### PR DESCRIPTION
Closes #122.

Go's `json.Marshal` drops trailing zeros from whole floats (`5.0` → `"5"`), so OPA reads `costUSD` as int and Rego sprintf `%.2f` produces `$%!f(int=05)`. The verifier now restores the decimal on `costUSD` before handing JSON to OPA. Visible in simulate-all-phases Test 12 and any session with a whole-dollar child spend.

- Regex normalize `"costUSD"` integers to `N.0` in `evaluateSessionRego`
- Regression test in `identity_test.go` with `CostUSD: 5.00`