### PR TITLE
fix(identity): enforce allowedModels/allowedEnvironments at SessionStart and PreToolUse

### DIFF
--- a/internal/hooks/handler.go
+++ b/internal/hooks/handler.go
@@ -24,6 +24,7 @@ import (
 	"github.com/aflock-ai/aflock/internal/output"
 	"github.com/aflock-ai/aflock/internal/policy"
 	"github.com/aflock-ai/aflock/internal/state"
+	"github.com/aflock-ai/aflock/internal/verify"
 	"github.com/aflock-ai/aflock/pkg/aflock"
 )
 
@@ -140,11 +141,17 @@ func (h *Handler) handleSessionStart(input *aflock.HookInput) error {
 		return nil
 	}
 
-	// Validate identity against policy constraints (skip if model is unknown in development)
-	if pol.Identity != nil && len(pol.Identity.AllowedModels) > 0 {
-		if agentIdentity.Model != "unknown" && !agentIdentity.Matches(pol.Identity.AllowedModels, nil) {
-			output.ExitWithError(fmt.Sprintf("[aflock] Agent model '%s' not in allowed models: %v",
-				agentIdentity.Model, pol.Identity.AllowedModels))
+	// Enforce full identity policy (allowedModels + allowedEnvironments) at the
+	// runtime gate, not only at post-hoc verify time (issue #121).
+	// Skip if the model wasn't discovered ("unknown") so local dev keeps working.
+	if pol.Identity != nil && agentIdentity.Model != "unknown" {
+		id := verify.IdentityFields{Model: agentIdentity.Model}
+		if agentIdentity.Environment != nil {
+			id.Environment = agentIdentity.Environment.Type
+		}
+		// Tools usage isn't known yet — verifyIdentityConstraints skips requiredTools when Tools==nil.
+		if errs := verify.VerifyIdentityConstraints(id, pol.Identity); len(errs) > 0 {
+			output.ExitWithError(fmt.Sprintf("[aflock] Identity policy violation: %s", strings.Join(errs, "; ")))
 			return nil
 		}
 	}
@@ -448,6 +455,21 @@ func (h *Handler) handlePreToolUse(input *aflock.HookInput) error {
 	pol := sessionState.Policy
 	if pol.IsExpired() {
 		return output.Write(output.PreToolUseDeny(fmt.Sprintf("[aflock] BLOCKED: policy '%s' expired at %s", pol.Name, pol.Expires.Format(time.RFC3339))))
+	}
+
+	// Defense in depth: re-check identity constraints against the persisted
+	// AgentIdentityMeta. SessionStart already enforced this, but state could
+	// have been tampered with between hooks (issue #121).
+	if pol.Identity != nil && sessionState.AgentIdentityMeta != nil &&
+		sessionState.AgentIdentityMeta.Model != "" && sessionState.AgentIdentityMeta.Model != "unknown" {
+		id := verify.IdentityFields{
+			Model:       sessionState.AgentIdentityMeta.Model,
+			Environment: sessionState.AgentIdentityMeta.Environment,
+		}
+		if errs := verify.VerifyIdentityConstraints(id, pol.Identity); len(errs) > 0 {
+			return output.Write(output.PreToolUseDeny(
+				fmt.Sprintf("[aflock] BLOCKED: identity policy violation: %s", strings.Join(errs, "; "))))
+		}
 	}
 
 	// Validate the session JWT (#48). The signing key dies with the

--- a/internal/hooks/handler_test.go
+++ b/internal/hooks/handler_test.go
@@ -2308,6 +2308,50 @@ func TestHandlePreToolUse_IdentityConstraints_NoSessionStart_Denies(t *testing.T
 	}
 }
 
+// Issue #121: PreToolUse must re-check identity policy against the persisted
+// AgentIdentityMeta as defense-in-depth, not only at post-hoc verify time.
+func TestHandlePreToolUse_IdentityConstraints_EnvironmentMismatch_Denies(t *testing.T) {
+	h := newTestHandler(t)
+	pol := &aflock.Policy{
+		Name: "identity-env",
+		Identity: &aflock.IdentityPolicy{
+			AllowedModels:       []string{"claude-*"},
+			AllowedEnvironments: []string{"container:ghcr.io/org/*"},
+		},
+		Tools: &aflock.ToolsPolicy{Allow: []string{"*"}},
+	}
+	ss := seedSession(t, h, "sess-id-env", pol)
+	ss.AgentIdentityMeta = &aflock.AgentIdentityMeta{
+		Model:       "claude-opus-4-5-20251101",
+		Environment: "container:docker.io/evil/image",
+	}
+	if err := h.stateManager.Save(ss); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	got := captureStdout(t, func() {
+		if err := h.handlePreToolUse(&aflock.HookInput{
+			SessionID: "sess-id-env", ToolName: "Read",
+			ToolInput: json.RawMessage(`{"file_path":"/tmp/x"}`),
+		}); err != nil {
+			t.Fatalf("handlePreToolUse: %v", err)
+		}
+	})
+
+	var out aflock.HookOutput
+	if err := json.Unmarshal([]byte(got), &out); err != nil {
+		t.Fatalf("parse: %v (raw: %s)", err, got)
+	}
+	if out.HookSpecificOutput.PermissionDecision != aflock.DecisionDeny {
+		t.Fatalf("expected deny on environment mismatch, got %s (reason=%s)",
+			out.HookSpecificOutput.PermissionDecision, out.HookSpecificOutput.PermissionDecisionReason)
+	}
+	if !strings.Contains(out.HookSpecificOutput.PermissionDecisionReason, "identity policy violation") {
+		t.Errorf("expected identity-policy-violation reason, got: %s",
+			out.HookSpecificOutput.PermissionDecisionReason)
+	}
+}
+
 func TestHandlePreToolUse_NoIdentityConstraints_NoSessionStart_Allows(t *testing.T) {
 	h := newTestHandler(t)
 

--- a/internal/verify/identity_test.go
+++ b/internal/verify/identity_test.go
@@ -12,11 +12,11 @@ import (
 	"github.com/aflock-ai/aflock/pkg/aflock"
 )
 
-// ---- Unit tests for verifyIdentityConstraints ----
+// ---- Unit tests for VerifyIdentityConstraints ----
 
 func TestVerifyIdentityConstraints_NilPolicy(t *testing.T) {
 	id := IdentityFields{Model: "claude-opus-4-5-20251101", Environment: "local"}
-	errors := verifyIdentityConstraints(id, nil)
+	errors := VerifyIdentityConstraints(id, nil)
 	if len(errors) != 0 {
 		t.Errorf("Expected no errors for nil policy, got %v", errors)
 	}
@@ -24,7 +24,7 @@ func TestVerifyIdentityConstraints_NilPolicy(t *testing.T) {
 
 func TestVerifyIdentityConstraints_EmptyPolicy(t *testing.T) {
 	id := IdentityFields{Model: "claude-opus-4-5-20251101", Environment: "local"}
-	errors := verifyIdentityConstraints(id, &aflock.IdentityPolicy{})
+	errors := VerifyIdentityConstraints(id, &aflock.IdentityPolicy{})
 	if len(errors) != 0 {
 		t.Errorf("Expected no errors for empty policy, got %v", errors)
 	}
@@ -85,7 +85,7 @@ func TestVerifyIdentityConstraints_ModelMatch(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			id := IdentityFields{Model: tt.model}
 			pol := &aflock.IdentityPolicy{AllowedModels: tt.allowedModels}
-			errors := verifyIdentityConstraints(id, pol)
+			errors := VerifyIdentityConstraints(id, pol)
 			if tt.wantPass && len(errors) != 0 {
 				t.Errorf("Expected pass, got errors: %v", errors)
 			}
@@ -145,7 +145,7 @@ func TestVerifyIdentityConstraints_EnvironmentMatch(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			id := IdentityFields{Environment: tt.environment}
 			pol := &aflock.IdentityPolicy{AllowedEnvironments: tt.allowed}
-			errors := verifyIdentityConstraints(id, pol)
+			errors := VerifyIdentityConstraints(id, pol)
 			if tt.wantPass && len(errors) != 0 {
 				t.Errorf("Expected pass, got errors: %v", errors)
 			}
@@ -215,7 +215,7 @@ func TestVerifyIdentityConstraints_RequiredTools(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			id := IdentityFields{Tools: tt.tools}
 			pol := &aflock.IdentityPolicy{RequiredTools: tt.requiredTools}
-			errors := verifyIdentityConstraints(id, pol)
+			errors := VerifyIdentityConstraints(id, pol)
 			if tt.wantPass && len(errors) != 0 {
 				t.Errorf("Expected pass, got errors: %v", errors)
 			}
@@ -243,7 +243,7 @@ func TestVerifyIdentityConstraints_MultipleConstraints(t *testing.T) {
 			AllowedEnvironments: []string{"container:ghcr.io/org/*"},
 			RequiredTools:       []string{"Read", "Edit"},
 		}
-		errors := verifyIdentityConstraints(id, pol)
+		errors := VerifyIdentityConstraints(id, pol)
 		if len(errors) != 0 {
 			t.Errorf("Expected pass, got errors: %v", errors)
 		}
@@ -258,7 +258,7 @@ func TestVerifyIdentityConstraints_MultipleConstraints(t *testing.T) {
 			AllowedModels:       []string{"claude-opus-*"},
 			AllowedEnvironments: []string{"local"},
 		}
-		errors := verifyIdentityConstraints(id, pol)
+		errors := VerifyIdentityConstraints(id, pol)
 		if len(errors) != 1 {
 			t.Errorf("Expected 1 error (model mismatch), got %d: %v", len(errors), errors)
 		}
@@ -275,7 +275,7 @@ func TestVerifyIdentityConstraints_MultipleConstraints(t *testing.T) {
 			AllowedEnvironments: []string{"container:ghcr.io/org/*"},
 			RequiredTools:       []string{"Read", "Edit"},
 		}
-		errors := verifyIdentityConstraints(id, pol)
+		errors := VerifyIdentityConstraints(id, pol)
 		// Should have: model mismatch + env mismatch + 2 missing tools = 4 errors
 		if len(errors) != 4 {
 			t.Errorf("Expected 4 errors, got %d: %v", len(errors), errors)
@@ -287,7 +287,7 @@ func TestVerifyIdentityConstraints_EmptyModel(t *testing.T) {
 	// Empty model with allowedModels should not error (graceful for missing data)
 	id := IdentityFields{Model: ""}
 	pol := &aflock.IdentityPolicy{AllowedModels: []string{"claude-opus-*"}}
-	errors := verifyIdentityConstraints(id, pol)
+	errors := VerifyIdentityConstraints(id, pol)
 	if len(errors) != 0 {
 		t.Errorf("Expected no errors for empty model, got %v", errors)
 	}

--- a/internal/verify/verifier.go
+++ b/internal/verify/verifier.go
@@ -174,7 +174,7 @@ func (v *Verifier) verifySessionWithDepth(sessionID string, depth int) (*Result,
 			}
 			sort.Strings(id.Tools)
 		}
-		identityErrors := verifyIdentityConstraints(id, sessionState.Policy.Identity)
+		identityErrors := VerifyIdentityConstraints(id, sessionState.Policy.Identity)
 		if len(identityErrors) > 0 {
 			result.Success = false
 			for _, msg := range identityErrors {
@@ -972,7 +972,7 @@ func (v *Verifier) VerifySteps(pol *aflock.Policy, attestDir, treeHash string) (
 				stepResult.Errors = append(stepResult.Errors, fmt.Sprintf("Identity extraction failed: %v", err))
 				result.Success = false
 			} else if id != nil {
-				identityErrors := verifyIdentityConstraints(*id, pol.Identity)
+				identityErrors := VerifyIdentityConstraints(*id, pol.Identity)
 				for _, msg := range identityErrors {
 					stepResult.Errors = append(stepResult.Errors, msg)
 					result.Success = false
@@ -1761,10 +1761,13 @@ type IdentityFields struct {
 	Tools       []string // may be nil if not available (e.g., step-based verification)
 }
 
-// verifyIdentityConstraints checks identity fields against policy identity constraints.
+// VerifyIdentityConstraints checks identity fields against policy identity constraints.
 // Returns a list of errors for each constraint that fails. Returns nil if all pass
 // or if no identity policy is defined (no constraints = all identities allowed).
-func verifyIdentityConstraints(id IdentityFields, identityPolicy *aflock.IdentityPolicy) []string {
+//
+// Exported so runtime hooks (SessionStart/PreToolUse) can enforce identity
+// constraints up front, not only at post-hoc verify time (issue #121).
+func VerifyIdentityConstraints(id IdentityFields, identityPolicy *aflock.IdentityPolicy) []string {
 	if identityPolicy == nil {
 		return nil
 	}


### PR DESCRIPTION
Closes #121.

Before this PR, the runtime gate only checked `allowedModels` at SessionStart and skipped `allowedEnvironments` / `requiredTools` entirely. The full `verifyIdentityConstraints` only fired at post-hoc `aflock verify`, so a non-Claude binary or wrong environment was allowed to run and only surfaced after the fact.

- Export `verify.VerifyIdentityConstraints` and call it from `handleSessionStart` (full coverage: model + environment).
- Add the same check in `handlePreToolUse` against the persisted `AgentIdentityMeta` as defense-in-depth.
- Preserve the `model == "unknown"` dev escape so local development without identity discovery still works.
- Regression test in `handler_test.go` covers an environment mismatch at PreToolUse.