### PR TITLE
fix(policy): enforce maxWallTimeSeconds at PostToolUse and Stop

### DIFF
--- a/internal/hooks/handler.go
+++ b/internal/hooks/handler.go
@@ -630,6 +630,15 @@ func (h *Handler) handlePostToolUse(input *aflock.HookInput) error {
 			return output.Write(output.PostToolUseBlock(
 				fmt.Sprintf("[aflock] Limit exceeded: %s - %s", limitName, msg)))
 		}
+		// maxWallTimeSeconds isn't represented in SessionMetrics, so check it
+		// against StartedAt separately (issue #120).
+		if !sessionState.StartedAt.IsZero() {
+			elapsed := time.Since(sessionState.StartedAt)
+			if exceeded, limitName, msg := evaluator.CheckWallTime(elapsed, "fail-fast"); exceeded {
+				return output.Write(output.PostToolUseBlock(
+					fmt.Sprintf("[aflock] Limit exceeded: %s - %s", limitName, msg)))
+			}
+		}
 	}
 
 	// Create and store attestation for this tool call
@@ -1100,6 +1109,13 @@ func (h *Handler) handleSubagentStop(input *aflock.HookInput) error {
 			return output.Write(output.StopBlock(
 				fmt.Sprintf("[aflock] Subagent limit exceeded: %s - %s", limitName, msg)))
 		}
+		if !childState.StartedAt.IsZero() {
+			elapsed := time.Since(childState.StartedAt)
+			if exceeded, limitName, msg := evaluator.CheckWallTime(elapsed, "post-hoc"); exceeded {
+				return output.Write(output.StopBlock(
+					fmt.Sprintf("[aflock] Subagent limit exceeded: %s - %s", limitName, msg)))
+			}
+		}
 	}
 
 	return output.Write(output.StopAllow())
@@ -1125,10 +1141,8 @@ func (h *Handler) handleSessionEnd(input *aflock.HookInput) error {
 	// Check post-hoc limits
 	if sessionState.Policy.Limits != nil {
 		evaluator := policy.NewEvaluator(sessionState.Policy, filepath.Dir(sessionState.PolicyPath))
-		exceeded, limitName, msg := evaluator.CheckLimits(sessionState.Metrics, "post-hoc")
-		if exceeded {
+		recordPostHoc := func(limitName, msg string) {
 			fmt.Fprintf(os.Stderr, "[aflock] Post-hoc limit exceeded: %s - %s\n", limitName, msg)
-			// Record the violation in session state for audit trail
 			h.stateManager.RecordAction(sessionState, aflock.ActionRecord{
 				Timestamp: time.Now(),
 				ToolName:  "SessionEnd",
@@ -1137,6 +1151,15 @@ func (h *Handler) handleSessionEnd(input *aflock.HookInput) error {
 			})
 			if err := h.stateManager.Save(sessionState); err != nil {
 				fmt.Fprintf(os.Stderr, "[aflock] Warning: failed to save session state: %v\n", err)
+			}
+		}
+		if exceeded, limitName, msg := evaluator.CheckLimits(sessionState.Metrics, "post-hoc"); exceeded {
+			recordPostHoc(limitName, msg)
+		}
+		if !sessionState.StartedAt.IsZero() {
+			elapsed := time.Since(sessionState.StartedAt)
+			if exceeded, limitName, msg := evaluator.CheckWallTime(elapsed, "post-hoc"); exceeded {
+				recordPostHoc(limitName, msg)
 			}
 		}
 	}

--- a/internal/hooks/handler_test.go
+++ b/internal/hooks/handler_test.go
@@ -483,6 +483,44 @@ func TestHandlePostToolUse_NoSession(t *testing.T) {
 	}
 }
 
+// Issue #120: maxWallTimeSeconds must block at PostToolUse when fail-fast and
+// the session has run longer than the limit — previously the field only set
+// the JWT TTL and never gated tool execution.
+func TestHandlePostToolUse_MaxWallTime_FailFast_Blocks(t *testing.T) {
+	h := newTestHandler(t)
+	pol := &aflock.Policy{
+		Name: "walltime",
+		Limits: &aflock.LimitsPolicy{
+			MaxWallTimeSeconds: &aflock.Limit{Value: 1, Enforcement: "fail-fast"},
+		},
+	}
+	ss := seedSession(t, h, "session-walltime", pol)
+	ss.StartedAt = time.Now().Add(-2 * time.Minute)
+	if err := h.stateManager.Save(ss); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	got := captureStdout(t, func() {
+		if err := h.handlePostToolUse(&aflock.HookInput{
+			SessionID: "session-walltime", ToolName: "Read",
+			ToolInput: json.RawMessage(`{"file_path": "/tmp/x"}`),
+		}); err != nil {
+			t.Fatalf("handlePostToolUse: %v", err)
+		}
+	})
+
+	var out aflock.HookOutput
+	if err := json.Unmarshal([]byte(got), &out); err != nil {
+		t.Fatalf("parse: %v (raw: %s)", err, got)
+	}
+	if out.Decision != "block" {
+		t.Fatalf("expected block decision, got %q (raw=%s)", out.Decision, got)
+	}
+	if !strings.Contains(out.Reason, "maxWallTimeSeconds") {
+		t.Errorf("expected maxWallTimeSeconds in reason, got: %s", out.Reason)
+	}
+}
+
 // ----- PostToolUse: file tracking - Read -----
 
 func TestHandlePostToolUse_TracksFileRead(t *testing.T) {

--- a/internal/policy/evaluator.go
+++ b/internal/policy/evaluator.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/aflock-ai/aflock/pkg/aflock"
 )
@@ -998,6 +999,25 @@ func matchGrantPattern(value string, patterns []string) (bool, string) {
 
 // CheckLimits checks if cumulative metrics exceed policy limits.
 // Returns (exceeded, limitName, message).
+// CheckWallTime reports whether the session has exceeded maxWallTimeSeconds
+// at the given enforcement mode. CheckLimits doesn't see elapsed time so wall-
+// time gating lives in its own helper (issue #120).
+func (e *Evaluator) CheckWallTime(elapsed time.Duration, enforcementMode string) (bool, string, string) {
+	if e.policy.Limits == nil || e.policy.Limits.MaxWallTimeSeconds == nil {
+		return false, "", ""
+	}
+	limit := e.policy.Limits.MaxWallTimeSeconds
+	if limit.Enforcement != enforcementMode {
+		return false, "", ""
+	}
+	current := elapsed.Seconds()
+	if current >= limit.Value {
+		return true, "maxWallTimeSeconds",
+			fmt.Sprintf("maxWallTimeSeconds exceeded: %.0fs >= %.0fs", current, limit.Value)
+	}
+	return false, "", ""
+}
+
 func (e *Evaluator) CheckLimits(metrics *aflock.SessionMetrics, enforcementMode string) (bool, string, string) {
 	if e.policy.Limits == nil {
 		return false, "", ""

--- a/internal/policy/evaluator_test.go
+++ b/internal/policy/evaluator_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/aflock-ai/aflock/pkg/aflock"
 )
@@ -1216,6 +1217,59 @@ func TestCheckLimits(t *testing.T) {
 			}
 			if !tt.wantExceed && msg != "" {
 				t.Errorf("expected empty message when limit not exceeded, got %q", msg)
+			}
+		})
+	}
+}
+
+// Issue #120: maxWallTimeSeconds is parsed but was never enforced beyond the
+// JWT TTL. CheckWallTime gives PostToolUse / Stop a way to actually block.
+func TestCheckWallTime(t *testing.T) {
+	tests := []struct {
+		name        string
+		policy      *aflock.Policy
+		elapsed     time.Duration
+		enforcement string
+		wantExceed  bool
+	}{
+		{
+			name: "under limit",
+			policy: &aflock.Policy{Limits: &aflock.LimitsPolicy{
+				MaxWallTimeSeconds: &aflock.Limit{Value: 60, Enforcement: "fail-fast"},
+			}},
+			elapsed: 30 * time.Second, enforcement: "fail-fast", wantExceed: false,
+		},
+		{
+			name: "over limit fail-fast",
+			policy: &aflock.Policy{Limits: &aflock.LimitsPolicy{
+				MaxWallTimeSeconds: &aflock.Limit{Value: 60, Enforcement: "fail-fast"},
+			}},
+			elapsed: 90 * time.Second, enforcement: "fail-fast", wantExceed: true,
+		},
+		{
+			name: "fail-fast policy skipped at post-hoc mode",
+			policy: &aflock.Policy{Limits: &aflock.LimitsPolicy{
+				MaxWallTimeSeconds: &aflock.Limit{Value: 60, Enforcement: "fail-fast"},
+			}},
+			elapsed: 90 * time.Second, enforcement: "post-hoc", wantExceed: false,
+		},
+		{
+			name: "no limit defined",
+			policy: &aflock.Policy{Limits: &aflock.LimitsPolicy{
+				MaxSpendUSD: &aflock.Limit{Value: 5, Enforcement: "fail-fast"},
+			}},
+			elapsed: 1 * time.Hour, enforcement: "fail-fast", wantExceed: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := NewEvaluator(tt.policy, "")
+			exceeded, name, msg := e.CheckWallTime(tt.elapsed, tt.enforcement)
+			if exceeded != tt.wantExceed {
+				t.Fatalf("exceeded=%v want %v (name=%q msg=%q)", exceeded, tt.wantExceed, name, msg)
+			}
+			if tt.wantExceed && name != "maxWallTimeSeconds" {
+				t.Errorf("limit name=%q want maxWallTimeSeconds", name)
 			}
 		})
 	}


### PR DESCRIPTION
Closes #120 (partial).

`limits.maxWallTimeSeconds` was parsed into `LimitsPolicy` and used only to set the JWT TTL — no hook ever compared elapsed wall-clock against it, so a session could run arbitrarily long once `CheckLimits` (which doesn't know about time) said OK.

- New `Evaluator.CheckWallTime(elapsed, enforcement)` mirroring `CheckLimits` for the wall-time field.
- Wire it into PostToolUse (fail-fast), `handleSubagentStop` (post-hoc), and `handleSessionEnd` (post-hoc).
- Unit tests for `CheckWallTime` and an integration test that backdates `StartedAt` and asserts PostToolUse returns a `block` decision with `maxWallTimeSeconds` in the reason.

Note on `tools.requireApproval`: the issue also lists this as not enforced, but it already is — `EvaluatePreToolUse` returns `DecisionAsk` and `handlePreToolUse` emits `permissionDecision: "ask"` (test: `TestHandlePreToolUse_RequireApproval`). Not changed here.