### PR TITLE
fix(state): auto-populate session merkleRoot at SessionEnd so Phase 3 fires

### DIFF
--- a/internal/hooks/handler.go
+++ b/internal/hooks/handler.go
@@ -1141,6 +1141,17 @@ func (h *Handler) handleSessionEnd(input *aflock.HookInput) error {
 		}
 	}
 
+	// Auto-populate the session Merkle root so Phase 3 verification fires on
+	// real sessions without the policy author having to set
+	// materialsFrom.session.merkleRoot ahead of time (issue #119).
+	if err := h.stateManager.ComputeSessionMerkleRoot(sessionState); err != nil {
+		fmt.Fprintf(os.Stderr, "[aflock] Warning: compute session merkle root: %v\n", err)
+	} else if sessionState.SessionMerkleRoot != "" {
+		if err := h.stateManager.Save(sessionState); err != nil {
+			fmt.Fprintf(os.Stderr, "[aflock] Warning: save session merkle root: %v\n", err)
+		}
+	}
+
 	// Log final metrics
 	fmt.Fprintf(os.Stderr, "[aflock] Session ended. Metrics: turns=%d, toolCalls=%d\n",
 		sessionState.Metrics.Turns, sessionState.Metrics.ToolCalls)

--- a/internal/hooks/handler_test.go
+++ b/internal/hooks/handler_test.go
@@ -1305,6 +1305,36 @@ func TestHandleSessionEnd_PrintsMetrics(t *testing.T) {
 	}
 }
 
+// Issue #119: SessionEnd must auto-compute and persist the session Merkle root
+// over recorded actions so verify-time Phase 3 has something to bind to.
+func TestHandleSessionEnd_PopulatesSessionMerkleRoot(t *testing.T) {
+	h := newTestHandler(t)
+	ss := seedSession(t, h, "session-merkle-end", &aflock.Policy{Name: "test"})
+	h.stateManager.RecordAction(ss, aflock.ActionRecord{
+		Timestamp: time.Now(), ToolName: "Read", ToolUseID: "a1", Decision: "allow",
+	})
+	h.stateManager.RecordAction(ss, aflock.ActionRecord{
+		Timestamp: time.Now(), ToolName: "Edit", ToolUseID: "a2", Decision: "allow",
+	})
+	if err := h.stateManager.Save(ss); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	captureStdout(t, func() {
+		if err := h.handleSessionEnd(&aflock.HookInput{SessionID: "session-merkle-end"}); err != nil {
+			t.Fatalf("handleSessionEnd: %v", err)
+		}
+	})
+
+	reloaded, err := h.stateManager.Load("session-merkle-end")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if reloaded.SessionMerkleRoot == "" {
+		t.Fatal("expected non-empty SessionMerkleRoot after SessionEnd, got empty")
+	}
+}
+
 // ----- Notification: returns empty -----
 
 func TestHandleNotification_ReturnsEmpty(t *testing.T) {

--- a/internal/state/session.go
+++ b/internal/state/session.go
@@ -11,6 +11,7 @@ import (
 	"syscall"
 	"time"
 
+	aflockMerkle "github.com/aflock-ai/aflock/internal/merkle"
 	"github.com/aflock-ai/aflock/pkg/aflock"
 )
 
@@ -200,6 +201,31 @@ func (m *Manager) RecordAction(state *aflock.SessionState, record aflock.ActionR
 		state.Metrics.Tools = make(map[string]int)
 	}
 	state.Metrics.Tools[record.ToolName]++
+}
+
+// ComputeSessionMerkleRoot builds the RFC 6962 Merkle root over the session's
+// recorded actions and writes it to state.SessionMerkleRoot. Empty actions
+// list leaves the field untouched (no root to commit). Used at SessionEnd so
+// Phase 3 materials verification fires on real sessions without the policy
+// author having to set materialsFrom.session.merkleRoot up front (issue #119).
+func (m *Manager) ComputeSessionMerkleRoot(state *aflock.SessionState) error {
+	if state == nil || len(state.Actions) == 0 {
+		return nil
+	}
+	entries := make([][]byte, 0, len(state.Actions))
+	for i, action := range state.Actions {
+		data, err := json.Marshal(action)
+		if err != nil {
+			return fmt.Errorf("marshal action %d: %w", i, err)
+		}
+		entries = append(entries, data)
+	}
+	root, err := aflockMerkle.BuildRoot(entries)
+	if err != nil {
+		return fmt.Errorf("build merkle root: %w", err)
+	}
+	state.SessionMerkleRoot = root
+	return nil
 }
 
 // AttestationsDir returns the attestations directory for a session.

--- a/internal/state/session_test.go
+++ b/internal/state/session_test.go
@@ -309,3 +309,42 @@ func TestLoadMetrics(t *testing.T) {
 		t.Error("Metrics should be nil for nonexistent session")
 	}
 }
+
+// Issue #119: ComputeSessionMerkleRoot must derive a non-empty root from a
+// session's recorded actions so verify-time Phase 3 has something to bind to
+// without the policy author setting materialsFrom.session.merkleRoot up front.
+func TestComputeSessionMerkleRoot(t *testing.T) {
+	m := NewManager(t.TempDir())
+	ts := time.Date(2026, 5, 19, 12, 0, 0, 0, time.UTC)
+
+	t.Run("empty actions leaves field empty", func(t *testing.T) {
+		s := &aflock.SessionState{SessionID: "s1", Actions: nil}
+		if err := m.ComputeSessionMerkleRoot(s); err != nil {
+			t.Fatalf("ComputeSessionMerkleRoot: %v", err)
+		}
+		if s.SessionMerkleRoot != "" {
+			t.Errorf("expected empty root for empty actions, got %q", s.SessionMerkleRoot)
+		}
+	})
+
+	t.Run("non-empty actions produce stable root", func(t *testing.T) {
+		actions := []aflock.ActionRecord{
+			{Timestamp: ts, ToolName: "Read", ToolUseID: "a1", Decision: "allow"},
+			{Timestamp: ts, ToolName: "Edit", ToolUseID: "a2", Decision: "allow"},
+		}
+		s1 := &aflock.SessionState{SessionID: "s1", Actions: actions}
+		s2 := &aflock.SessionState{SessionID: "s2", Actions: actions}
+		if err := m.ComputeSessionMerkleRoot(s1); err != nil {
+			t.Fatalf("compute s1: %v", err)
+		}
+		if err := m.ComputeSessionMerkleRoot(s2); err != nil {
+			t.Fatalf("compute s2: %v", err)
+		}
+		if s1.SessionMerkleRoot == "" {
+			t.Fatal("expected non-empty root")
+		}
+		if s1.SessionMerkleRoot != s2.SessionMerkleRoot {
+			t.Errorf("same actions produced different roots: %q vs %q", s1.SessionMerkleRoot, s2.SessionMerkleRoot)
+		}
+	})
+}

--- a/internal/verify/identity_test.go
+++ b/internal/verify/identity_test.go
@@ -823,6 +823,46 @@ func TestVerifySession_MerklePass(t *testing.T) {
 	}
 }
 
+// Issue #119: when SessionEnd auto-populated sessionState.SessionMerkleRoot
+// the verifier must run Phase 3 against that root, even without policy
+// declaring materialsFrom — closing the "Phase 3 never fires on real sessions"
+// gap. Tampering with state.json afterwards must surface here.
+func TestVerifySession_MerklePass_AutoPopulatedRoot(t *testing.T) {
+	tmpDir := t.TempDir()
+	actions := []aflock.ActionRecord{
+		{Timestamp: time.Now(), ToolName: "Read", ToolUseID: "tu_1", Decision: "allow"},
+		{Timestamp: time.Now(), ToolName: "Edit", ToolUseID: "tu_2", Decision: "allow"},
+	}
+	root := buildMerkleRootFromActions(t, actions)
+
+	ss := &aflock.SessionState{
+		SessionID:         "sess-merkle-auto",
+		StartedAt:         time.Now().Add(-5 * time.Minute),
+		Policy:            &aflock.Policy{Name: "no-materialsFrom", Version: "1.0"},
+		Actions:           actions,
+		Metrics:           &aflock.SessionMetrics{},
+		SessionMerkleRoot: root, // simulates SessionEnd auto-populate
+	}
+	writeSessionState(t, tmpDir, "sess-merkle-auto", ss)
+
+	result, err := newTestVerifier(tmpDir).VerifySession("sess-merkle-auto")
+	if err != nil {
+		t.Fatalf("VerifySession: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("expected success, got errors: %v", result.Errors)
+	}
+	found := false
+	for _, c := range result.Checks {
+		if c.Name == "materials:merkle" && c.Passed {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected materials:merkle check to fire from auto-populated root")
+	}
+}
+
 func TestVerifySession_MerkleFail_TamperedAction(t *testing.T) {
 	tmpDir := t.TempDir()
 	originalActions := []aflock.ActionRecord{

--- a/internal/verify/verifier.go
+++ b/internal/verify/verifier.go
@@ -193,8 +193,12 @@ func (v *Verifier) verifySessionWithDepth(sessionID string, depth int) (*Result,
 		}
 	}
 
-	// Check 0.5: Materials binding / Merkle tree (Phase 3)
-	if sessionState.Policy.MaterialsFrom != nil && sessionState.Policy.MaterialsFrom.Session != nil {
+	// Check 0.5: Materials binding / Merkle tree (Phase 3). The check runs
+	// when the policy declares a session materials binding OR when SessionEnd
+	// auto-recorded a root in state — the latter catches post-hoc state
+	// tampering even when the policy didn't pre-commit a root (issue #119).
+	if (sessionState.Policy.MaterialsFrom != nil && sessionState.Policy.MaterialsFrom.Session != nil) ||
+		sessionState.SessionMerkleRoot != "" {
 		merkleErrors := verifySessionMerkle(sessionState)
 		if len(merkleErrors) > 0 {
 			result.Success = false
@@ -1721,15 +1725,20 @@ func evaluateSessionRego(sessionState *aflock.SessionState) []string {
 // verifySessionMerkle checks the Merkle tree root over session actions (Phase 3).
 // It serializes each ActionRecord to JSON, builds a Merkle tree using RFC 6962 hashing
 // with JCS canonicalization, and compares the computed root against the expected root
-// stored in policy.MaterialsFrom.Session.MerkleRoot.
+// stored in policy.MaterialsFrom.Session.MerkleRoot. If the policy doesn't declare
+// an expected root, the auto-computed sessionState.SessionMerkleRoot (written at
+// SessionEnd) is used as the expected value, which catches post-hoc tampering of
+// state.json (issue #119).
 func verifySessionMerkle(sessionState *aflock.SessionState) []string {
-	if sessionState.Policy.MaterialsFrom == nil || sessionState.Policy.MaterialsFrom.Session == nil {
-		return nil
+	expectedRoot := ""
+	if sessionState.Policy.MaterialsFrom != nil && sessionState.Policy.MaterialsFrom.Session != nil {
+		expectedRoot = sessionState.Policy.MaterialsFrom.Session.MerkleRoot
 	}
-
-	expectedRoot := sessionState.Policy.MaterialsFrom.Session.MerkleRoot
 	if expectedRoot == "" {
-		return nil // No expected root — nothing to verify
+		expectedRoot = sessionState.SessionMerkleRoot
+	}
+	if expectedRoot == "" {
+		return nil // No expected root and none auto-recorded — nothing to verify.
 	}
 
 	if len(sessionState.Actions) == 0 {

--- a/pkg/aflock/types.go
+++ b/pkg/aflock/types.go
@@ -510,6 +510,11 @@ type SessionState struct {
 	// chain-validation work for SPIRE/Fulcio (#62) can branch Stop-gate
 	// behavior without a state-shape migration.
 	SigningMode string `json:"signing_mode,omitempty"`
+	// SessionMerkleRoot is the RFC 6962 Merkle root computed over JCS-canonical
+	// session.Actions at SessionEnd. Auto-populated so Phase 3 materials checks
+	// fire on real sessions without needing the policy author to manually set
+	// materialsFrom.session.merkleRoot up front (issue #119).
+	SessionMerkleRoot string `json:"session_merkle_root,omitempty"`
 }
 
 // AgentIdentityMeta stores agent identity metadata in session state.


### PR DESCRIPTION
Closes #119 (Merkle auto-populate part).

Phase 3 / Merkle verification never fired on real sessions because nothing computed `policy.materialsFrom.session.merkleRoot` — only the simulator declared one by hand. Live `aflock verify` would silently skip the materials check.

- New `state.Manager.ComputeSessionMerkleRoot` builds the RFC 6962 root over `state.Actions`.
- `SessionState` gains a `session_merkle_root` field; `handleSessionEnd` populates it and re-saves.
- `verifySessionMerkle` falls back to `sessionState.SessionMerkleRoot` when the policy didn't pre-commit a root, so post-hoc tampering of `state.json` still trips Phase 3.
- Tests in `state`, `verify`, and `hooks` cover compute / verify-with-auto-root / SessionEnd-populates flows.

The placeholder-expansion piece (`${CLAUDE_SESSION_PATH}`, `${GIT_TREE_HASH}`) is left for a follow-up since no live code path currently reads `Session.Path` / `Git.TreeHash`, so expansion would be inert.