### PR TITLE
fix(mcp): enforce policy Expires in MCP mode (closes #136)

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -223,6 +223,13 @@ func (s *Server) Serve(policyPath string) error {
 		}
 	}
 
+	// Refuse to start with an already-expired policy (#136). Mirrors hooks
+	// mode (handler.go) and verify CLI; MCP mode previously skipped this and
+	// served past Expires.
+	if err := s.errPolicyExpired(); err != nil {
+		return err
+	}
+
 	// Identity discovery + policy-digest binding per paper §3.1.
 	s.initAgentIdentity()
 
@@ -290,6 +297,11 @@ func (s *Server) ServeHTTP(policyPath string, port int) error {
 			s.policy = pol
 			s.policyPath = path
 		}
+	}
+
+	// Refuse to start with an already-expired policy (#136).
+	if err := s.errPolicyExpired(); err != nil {
+		return err
 	}
 
 	// Identity discovery + policy-digest binding per paper §3.1. Mirrors
@@ -442,6 +454,11 @@ func (s *Server) ServeUnix(policyPath, socketPath string) error {
 		}
 	}
 
+	// Refuse to start with an already-expired policy (#136).
+	if err := s.errPolicyExpired(); err != nil {
+		return err
+	}
+
 	// Refuse to start if the socket path already exists. Lstat (not Stat)
 	// so a dangling symlink also blocks us — an attacker pre-creating either
 	// a file or a symlink at the path could otherwise win the bind race.
@@ -551,6 +568,22 @@ func (s *Server) ServeUnix(policyPath, socketPath string) error {
 	// uses, just over a socket whose peer is kernel-attested.
 	stdioServer := server.NewStdioServer(s.mcpServer)
 	return stdioServer.Listen(context.Background(), conn, conn)
+}
+
+// errPolicyExpired returns a formatted error if the loaded policy has passed
+// its Expires deadline. Returns nil if no policy is loaded or no Expires is
+// set. Used at server startup (Serve/ServeHTTP/ServeUnix) to fail closed
+// before any session state is initialized, and inside long-lived handlers
+// (get_token, check_tool) so a policy that expires mid-session stops serving.
+//
+// Hooks mode and the verify CLI enforce Expires elsewhere (handler.go,
+// verifier.go); without this check, MCP mode silently served expired
+// policies — issue #136.
+func (s *Server) errPolicyExpired() error {
+	if s.policy == nil || !s.policy.IsExpired() {
+		return nil
+	}
+	return fmt.Errorf("policy %q expired at %s", s.policy.Name, s.policy.Expires.Format(time.RFC3339))
 }
 
 // computePolicyDigest returns the SHA-256 digest of the loaded policy.
@@ -720,6 +753,13 @@ func (s *Server) initAuth() error {
 func (s *Server) handleGetToken(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	if s.tokenIssuer == nil {
 		return mcp.NewToolResultError("Token issuer not initialized"), nil
+	}
+
+	// Refuse to mint a token once the policy has expired (#136). The JWT TTL
+	// alone is not enough: a long-lived HTTP server can outlive the policy
+	// itself, and we must not extend authorization past Expires.
+	if err := s.errPolicyExpired(); err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
 	}
 
 	// Track whether this call authenticated via bootstrap, so we can clear
@@ -979,6 +1019,19 @@ func (s *Server) handleCheckTool(ctx context.Context, request mcp.CallToolReques
 
 	if s.policy == nil {
 		return mcp.NewToolResultText(`{"allowed": true, "reason": "No policy loaded"}`), nil
+	}
+
+	// Expired policies deny everything (#136). Without this, an expired
+	// policy still evaluates its rules and returns allow for tools in the
+	// allowlist — which silently extends authorization past Expires.
+	if err := s.errPolicyExpired(); err != nil {
+		result := map[string]any{
+			"allowed":  false,
+			"decision": string(aflock.DecisionDeny),
+			"reason":   err.Error(),
+		}
+		data, _ := json.MarshalIndent(result, "", "  ")
+		return mcp.NewToolResultText(string(data)), nil
 	}
 
 	inputJSON, _ := json.Marshal(toolInputMap)

--- a/internal/mcp/server_expires_test.go
+++ b/internal/mcp/server_expires_test.go
@@ -1,0 +1,102 @@
+package mcp
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/aflock-ai/aflock/internal/auth"
+	"github.com/aflock-ai/aflock/pkg/aflock"
+)
+
+func expiredPolicy(name string) *aflock.Policy {
+	past := time.Now().Add(-time.Hour)
+	return &aflock.Policy{
+		Version: "1.0",
+		Name:    name,
+		Expires: &past,
+		Tools:   &aflock.ToolsPolicy{Allow: []string{"Bash"}},
+	}
+}
+
+// TestHandleCheckTool_ExpiredPolicyDenies — without the expiry check,
+// Bash would return allowed=true because it's in the allowlist. The fix
+// must turn that into a hard deny.
+func TestHandleCheckTool_ExpiredPolicyDenies(t *testing.T) {
+	s := newTestServerWithPolicy(t, expiredPolicy("expired"))
+	result, err := s.handleCheckTool(context.Background(),
+		newTestRequest(map[string]any{"tool_name": "Bash"}))
+	if err != nil {
+		t.Fatalf("handleCheckTool: %v", err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(result.Content[0].(mcp.TextContent).Text), &parsed); err != nil {
+		t.Fatalf("parse response: %v", err)
+	}
+	if parsed["allowed"] != false || parsed["decision"] != "deny" {
+		t.Errorf("expected allowed=false decision=deny, got %v", parsed)
+	}
+	if reason, _ := parsed["reason"].(string); !strings.Contains(reason, "expired") {
+		t.Errorf("reason should mention expiry, got: %s", reason)
+	}
+}
+
+// TestHandleGetToken_ExpiredPolicyRefusesIssuance — a long-running HTTP
+// server can outlive Expires. The JWT TTL alone is not enough; minting a
+// new token past expiry would extend authorization indefinitely. Also
+// verifies the existing authActive invariant: a refused issuance must not
+// flip the auth flag (same property covered by
+// TestHandleGetToken_RollbackOnIssueTokenFailure for a different cause).
+func TestHandleGetToken_ExpiredPolicyRefusesIssuance(t *testing.T) {
+	s := newTestServerWithPolicy(t, expiredPolicy("expired"))
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	s.tokenIssuer = auth.NewTokenIssuerFromSigner(key, "test-signer")
+
+	result, err := s.handleGetToken(context.Background(), callRequest(nil))
+	if err != nil {
+		t.Fatalf("handleGetToken: %v", err)
+	}
+	if result == nil || !result.IsError {
+		t.Fatalf("must return error result on expired policy, got: %+v", result)
+	}
+	if !strings.Contains(result.Content[0].(mcp.TextContent).Text, "expired") {
+		t.Errorf("error must mention expiry, got: %s", result.Content[0].(mcp.TextContent).Text)
+	}
+	if s.authActive.Load() {
+		t.Error("authActive must stay false when issuance is refused")
+	}
+}
+
+// TestServe_RefusesToStartWithExpiredPolicy — startup-time check, the
+// other half of issue #136. Hooks mode/verify CLI already refuse expired
+// policies; this test pins MCP mode to the same behavior.
+func TestServe_RefusesToStartWithExpiredPolicy(t *testing.T) {
+	dir := t.TempDir()
+	expiredPath := filepath.Join(dir, ".aflock")
+	body := `{"version":"1.0","name":"startup-expired","expires":"2020-01-01T00:00:00Z"}`
+	if err := os.WriteFile(expiredPath, []byte(body), 0600); err != nil {
+		t.Fatalf("write policy: %v", err)
+	}
+
+	s := newTestServer(t)
+	err := s.Serve(expiredPath)
+	if err == nil {
+		t.Fatal("Serve must refuse to start with an expired policy")
+	}
+	if !strings.Contains(err.Error(), "expired") {
+		t.Errorf("error must mention expiry, got: %v", err)
+	}
+}


### PR DESCRIPTION
Hooks mode (handler.go) and verify CLI (verifier.go) refuse expired policies, but MCP Serve/ServeHTTP/ServeUnix loaded them, minted JWTs, and signed attestations as if nothing was wrong. Added errPolicyExpired helper called at all three startup paths plus inside handleGetToken (refuse to mint past Expires) and handleCheckTool (return decision=deny with expiry reason). Bumps go.mod to 1.26.3 to match local rookery toolchain — same bump applied on feat/policy-signing-sigstore.