### PR TITLE
fix(state): pull-rollup in-flight subagent metrics at parent PostToolUse

### DIFF
--- a/internal/hooks/handler.go
+++ b/internal/hooks/handler.go
@@ -659,7 +659,27 @@ func (h *Handler) handlePostToolUse(input *aflock.HookInput) error {
 	// Check fail-fast limits after tool execution
 	if sessionState.Policy != nil && sessionState.Policy.Limits != nil {
 		evaluator := policy.NewEvaluator(sessionState.Policy, filepath.Dir(sessionState.PolicyPath))
-		exceeded, limitName, msg := evaluator.CheckLimits(sessionState.Metrics, "fail-fast")
+
+		// Roll up in-flight subagent metrics into a transient effective view
+		// before the limit check (paper §5 invariant #2, issue #135). Without
+		// this, the parent's fail-fast sees only its own spend; a child
+		// running concurrently can push the combined total past the ceiling
+		// before SubagentStop ever fires and merges. The race window narrows
+		// to one child-tool-call delta, which the issue explicitly accepts.
+		metricsForLimits := sessionState.Metrics
+		if children, listErr := h.stateManager.ListChildSessions(sessionState.SessionID); listErr == nil {
+			rolled, included := rollupUnmergedChildren(sessionState, children)
+			if len(included) > 0 {
+				fmt.Fprintf(os.Stderr,
+					"[aflock] Subagent rollup: including %d in-flight child(ren) %v in fail-fast limit check\n",
+					len(included), included)
+				metricsForLimits = rolled
+			}
+		} else {
+			fmt.Fprintf(os.Stderr, "[aflock] Warning: list child sessions for rollup: %v\n", listErr)
+		}
+
+		exceeded, limitName, msg := evaluator.CheckLimits(metricsForLimits, "fail-fast")
 		if exceeded {
 			if evaluator.IsAdvisoryLimit(limitName, sessionState.AuthMode) {
 				fmt.Fprintf(os.Stderr,
@@ -1682,6 +1702,56 @@ func attenuateLimits(childLimits, parentLimits *aflock.LimitsPolicy, parentMetri
 	}
 
 	return result
+}
+
+// rollupUnmergedChildren returns effective metrics that include in-flight
+// children whose SubagentStop hasn't yet fired. Children already present in
+// parent.ChildSessionIDs are skipped — their metrics were merged into
+// parent.Metrics at SubagentStop and counting them again would double-count
+// (paper §5 invariant #2, issue #135).
+//
+// Mirrors the merge field set in mergeChildIntoParent: TokensIn, TokensOut,
+// CostUSD, ToolCalls. Turns are deliberately not composed across the
+// boundary (each session has its own conversation-turn counter; summing
+// them isn't meaningful and the existing merge also skips them).
+//
+// Returns a new SessionMetrics — does NOT mutate parent.Metrics, because
+// SubagentStop will perform the durable merge later.
+func rollupUnmergedChildren(parent *aflock.SessionState, children []*aflock.SessionState) (*aflock.SessionMetrics, []string) {
+	if parent == nil || parent.Metrics == nil {
+		return nil, nil
+	}
+	merged := make(map[string]bool, len(parent.ChildSessionIDs))
+	for _, cid := range parent.ChildSessionIDs {
+		merged[cid] = true
+	}
+
+	effective := *parent.Metrics
+	if effective.Tools != nil {
+		// Copy the Tools map so callers writing through the returned metrics
+		// can't accidentally mutate the parent's persisted state.
+		copied := make(map[string]int, len(effective.Tools))
+		for k, v := range effective.Tools {
+			copied[k] = v
+		}
+		effective.Tools = copied
+	}
+
+	var included []string
+	for _, child := range children {
+		if child == nil || child.Metrics == nil {
+			continue
+		}
+		if merged[child.SessionID] {
+			continue
+		}
+		effective.TokensIn += child.Metrics.TokensIn
+		effective.TokensOut += child.Metrics.TokensOut
+		effective.CostUSD += child.Metrics.CostUSD
+		effective.ToolCalls += child.Metrics.ToolCalls
+		included = append(included, child.SessionID)
+	}
+	return &effective, included
 }
 
 // mergeChildIntoParent merges the child session's actions, metrics, and

--- a/internal/hooks/subagent_rollup_test.go
+++ b/internal/hooks/subagent_rollup_test.go
@@ -1,0 +1,111 @@
+package hooks
+
+import (
+	"testing"
+
+	"github.com/aflock-ai/aflock/pkg/aflock"
+)
+
+// TestRollupUnmergedChildren_IncludesInFlight is the central correctness
+// claim of #135: a parent's PostToolUse must observe spend from children
+// whose SubagentStop hasn't fired yet, or fail-fast will rubber-stamp a
+// session that's already past the ceiling.
+func TestRollupUnmergedChildren_IncludesInFlight(t *testing.T) {
+	parent := &aflock.SessionState{
+		SessionID: "parent-1",
+		Metrics: &aflock.SessionMetrics{
+			CostUSD:   9.0,
+			TokensIn:  100,
+			TokensOut: 50,
+			ToolCalls: 3,
+		},
+	}
+	child := &aflock.SessionState{
+		SessionID:       "child-1",
+		ParentSessionID: "parent-1",
+		Metrics: &aflock.SessionMetrics{
+			CostUSD:   5.0,
+			TokensIn:  200,
+			TokensOut: 75,
+			ToolCalls: 2,
+		},
+	}
+
+	effective, included := rollupUnmergedChildren(parent, []*aflock.SessionState{child})
+
+	if got, want := effective.CostUSD, 14.0; got != want {
+		t.Errorf("CostUSD = %v, want %v", got, want)
+	}
+	if got, want := effective.TokensIn, int64(300); got != want {
+		t.Errorf("TokensIn = %v, want %v", got, want)
+	}
+	if got, want := effective.TokensOut, int64(125); got != want {
+		t.Errorf("TokensOut = %v, want %v", got, want)
+	}
+	if got, want := effective.ToolCalls, 5; got != want {
+		t.Errorf("ToolCalls = %v, want %v", got, want)
+	}
+	if len(included) != 1 || included[0] != "child-1" {
+		t.Errorf("included = %v, want [child-1]", included)
+	}
+}
+
+// TestRollupUnmergedChildren_SkipsAlreadyMerged proves no double-counting:
+// once SubagentStop has merged a child (recording its ID in
+// parent.ChildSessionIDs), the child's metrics are already in
+// parent.Metrics. Rolling them up again would duplicate the spend.
+func TestRollupUnmergedChildren_SkipsAlreadyMerged(t *testing.T) {
+	parent := &aflock.SessionState{
+		SessionID:       "parent-1",
+		ChildSessionIDs: []string{"child-1"}, // already merged
+		Metrics: &aflock.SessionMetrics{
+			CostUSD: 14.0, // 9 own + 5 from child-1 already merged
+		},
+	}
+	child := &aflock.SessionState{
+		SessionID:       "child-1",
+		ParentSessionID: "parent-1",
+		Metrics:         &aflock.SessionMetrics{CostUSD: 5.0},
+	}
+
+	effective, included := rollupUnmergedChildren(parent, []*aflock.SessionState{child})
+
+	if got, want := effective.CostUSD, 14.0; got != want {
+		t.Errorf("CostUSD = %v (double-counted), want %v", got, want)
+	}
+	if len(included) != 0 {
+		t.Errorf("included = %v, want empty (already merged)", included)
+	}
+}
+
+// TestRollupUnmergedChildren_DoesNotMutateParent guards against a subtle
+// bug where the helper accidentally mutates parent.Metrics in place. The
+// durable merge happens later at SubagentStop; if we mutate the parent
+// here, the SubagentStop merge will double-count.
+func TestRollupUnmergedChildren_DoesNotMutateParent(t *testing.T) {
+	parent := &aflock.SessionState{
+		SessionID: "parent-1",
+		Metrics: &aflock.SessionMetrics{
+			CostUSD: 9.0,
+			Tools:   map[string]int{"Bash": 2},
+		},
+	}
+	child := &aflock.SessionState{
+		SessionID:       "child-1",
+		ParentSessionID: "parent-1",
+		Metrics:         &aflock.SessionMetrics{CostUSD: 5.0},
+	}
+
+	_, _ = rollupUnmergedChildren(parent, []*aflock.SessionState{child})
+
+	if got, want := parent.Metrics.CostUSD, 9.0; got != want {
+		t.Errorf("parent.Metrics.CostUSD mutated: got %v, want %v", got, want)
+	}
+	// Also verify the Tools map wasn't aliased — mutating the returned
+	// effective.Tools must not bleed back into parent.
+	effective, _ := rollupUnmergedChildren(parent, []*aflock.SessionState{child})
+	effective.Tools["Edit"] = 99
+	if _, leaked := parent.Metrics.Tools["Edit"]; leaked {
+		t.Error("Tools map aliased: parent.Metrics.Tools leaked write through effective")
+	}
+}

--- a/internal/state/session.go
+++ b/internal/state/session.go
@@ -248,6 +248,51 @@ func expandPath(path string) string {
 	return path
 }
 
+// ListChildSessions returns all sessions whose ParentSessionID equals
+// parentID. Used by handlePostToolUse to roll up in-flight subagent spend
+// into the parent's fail-fast check (paper §5 invariant #2, issue #135):
+// without this, a child's tokens/cost only land in the parent at
+// SubagentStop, leaving a window where the parent can pass fail-fast while
+// concurrent children blow through the ceiling.
+//
+// Lock-free: Save uses atomic rename, so each child state.json is read
+// either as the previous full version or the next full version, never
+// partial. Callers should treat the snapshot as point-in-time.
+//
+// Unreadable or malformed child state files are skipped silently — one
+// broken neighbor must not block the parent's rollup. The parent's own
+// state is filtered out so a parent can never be rolled up into itself.
+func (m *Manager) ListChildSessions(parentID string) ([]*aflock.SessionState, error) {
+	entries, err := os.ReadDir(m.stateDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read state dir: %w", err)
+	}
+	var children []*aflock.SessionState
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		sid := entry.Name()
+		if sid == parentID {
+			continue
+		}
+		if err := validateSessionID(sid); err != nil {
+			continue
+		}
+		state, loadErr := m.Load(sid)
+		if loadErr != nil || state == nil {
+			continue
+		}
+		if state.ParentSessionID == parentID {
+			children = append(children, state)
+		}
+	}
+	return children, nil
+}
+
 // LoadMetrics loads just the metrics from session state.
 func (m *Manager) LoadMetrics(sessionID string) (*aflock.SessionMetrics, error) {
 	state, err := m.Load(sessionID)

--- a/internal/state/session_test.go
+++ b/internal/state/session_test.go
@@ -88,6 +88,65 @@ func TestManagerSaveLoad(t *testing.T) {
 	}
 }
 
+// TestManagerListChildSessions verifies the enumeration used by the
+// parent-side fail-fast rollup (issue #135). The directory layout is
+// flat: every session is a sibling, and ParentSessionID is the only link.
+func TestManagerListChildSessions(t *testing.T) {
+	tmpDir := t.TempDir()
+	m := NewManager(tmpDir)
+
+	pol := &aflock.Policy{Name: "p", Version: "1"}
+
+	// Parent.
+	parent := m.Initialize("parent-A", pol, "/test/.aflock")
+	if err := m.Save(parent); err != nil {
+		t.Fatalf("save parent: %v", err)
+	}
+
+	// Two children of parent-A.
+	c1 := m.Initialize("child-A1", pol, "/test/.aflock")
+	c1.ParentSessionID = "parent-A"
+	if err := m.Save(c1); err != nil {
+		t.Fatalf("save c1: %v", err)
+	}
+	c2 := m.Initialize("child-A2", pol, "/test/.aflock")
+	c2.ParentSessionID = "parent-A"
+	if err := m.Save(c2); err != nil {
+		t.Fatalf("save c2: %v", err)
+	}
+
+	// Unrelated session (different parent) — must not be returned.
+	other := m.Initialize("child-of-other", pol, "/test/.aflock")
+	other.ParentSessionID = "parent-B"
+	if err := m.Save(other); err != nil {
+		t.Fatalf("save other: %v", err)
+	}
+
+	children, err := m.ListChildSessions("parent-A")
+	if err != nil {
+		t.Fatalf("ListChildSessions: %v", err)
+	}
+	if got, want := len(children), 2; got != want {
+		t.Fatalf("got %d children, want %d", got, want)
+	}
+	seen := map[string]bool{}
+	for _, c := range children {
+		seen[c.SessionID] = true
+		if c.ParentSessionID != "parent-A" {
+			t.Errorf("child %q has wrong ParentSessionID: %q", c.SessionID, c.ParentSessionID)
+		}
+	}
+	if !seen["child-A1"] || !seen["child-A2"] {
+		t.Errorf("missing expected children, got %v", seen)
+	}
+	if seen["child-of-other"] {
+		t.Error("ListChildSessions returned an unrelated session")
+	}
+	if seen["parent-A"] {
+		t.Error("ListChildSessions returned the parent itself")
+	}
+}
+
 func TestManagerLoadNonexistent(t *testing.T) {
 	tmpDir := t.TempDir()
 	m := NewManager(tmpDir)


### PR DESCRIPTION
Paper §5 invariant #2 said sub-agent spend counts toward parent totals, but rollup only fired at SubagentStop. A child running concurrently with its parent would let the parent's fail-fast pass at $9 while the child spent another $5 — parent ceiling $10 was breached the moment SubagentStop finally merged. Parent's PostToolUse now enumerates child sessions (state.Manager.ListChildSessions), sums any whose IDs aren't already in parent.ChildSessionIDs, and feeds the effective metrics into CheckLimits. Race window narrows to one child-tool-call delta, which the issue explicitly accepts.