### PR TITLE
fix(policy): expand ${...} placeholders at Load

### DIFF
--- a/docs/reference/policy-schema.md
+++ b/docs/reference/policy-schema.md
@@ -173,3 +173,19 @@ Each limit is an object: `{ "value": number, "enforcement": "fail-fast" | "post-
   "organizations": ["Example Corp"]
 }
 ```
+
+### Placeholders
+
+`materialsFrom.session.path` and `materialsFrom.git.treeHash` expand
+`${NAME}`-style references against the environment at policy-load time, so
+the same policy file works across runs without hand-editing. Strict by
+design: unknown names and unset env vars both fail Load — silent fallback
+to the literal `${...}` string was the original [#134](https://github.com/aflock-ai/aflock/issues/134) bug.
+
+| Placeholder | Resolves from env | Set by |
+|-------------|-------------------|--------|
+| `${CLAUDE_SESSION_PATH}` | `CLAUDE_SESSION_PATH` | Hooks / verify CLI before `policy.Load` (claude-code session JSONL path) |
+| `${GIT_TREE_HASH}` | `GIT_TREE_HASH` | Caller, typically `git rev-parse HEAD^{tree}` |
+
+Other fields (grants globs, artifact URIs) currently pass through unchanged
+and will join this list when their runtime enforcement lands.

--- a/internal/policy/placeholders.go
+++ b/internal/policy/placeholders.go
@@ -1,0 +1,131 @@
+package policy
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/aflock-ai/aflock/pkg/aflock"
+)
+
+// ErrUnknownPlaceholder is returned when a policy references a placeholder
+// not in allowedPlaceholders. Strict by design: typos in placeholder names
+// previously silenced into "literal string never matches anything" bugs at
+// verify time.
+var ErrUnknownPlaceholder = errors.New("unknown placeholder in policy")
+
+// ErrUnsetPlaceholder is returned when a known placeholder references an
+// environment variable that isn't set at Load time. Leaving the literal in
+// place is the original #134 bug — the verifier would compare a literal
+// "${CLAUDE_SESSION_PATH}" against real paths and never match. Better to
+// fail loudly so the operator wires the env var than to silently degrade.
+var ErrUnsetPlaceholder = errors.New("placeholder env var not set")
+
+// allowedPlaceholders maps the placeholder name (without ${} or $) to the
+// environment variable that should resolve it. Keeping this list explicit
+// (rather than letting any env var leak in via os.ExpandEnv) means a typo
+// in a policy fails Load instead of silently becoming an empty string.
+//
+// Document new entries in docs/reference/policy-schema.md so users learn
+// what's available before they paste paper examples and wonder why verify
+// is returning "Materials binding failed".
+var allowedPlaceholders = map[string]string{
+	"CLAUDE_SESSION_PATH": "CLAUDE_SESSION_PATH",
+	"GIT_TREE_HASH":       "GIT_TREE_HASH",
+}
+
+// expandPlaceholders walks the policy's placeholder-bearing fields and
+// substitutes shell-style ${NAME} references with values from the
+// environment. Called from Load after JSON unmarshal so every consumer
+// (verifier, hooks, MCP server) sees fully-resolved values without each
+// having to call os.Expand on its own — paper §4.4 / issue #134.
+//
+// Currently expands only MaterialsFrom.Session.Path and
+// MaterialsFrom.Git.TreeHash, which are the two slots the paper example
+// uses. Other policy fields (Grants.Storage globs, ArtifactMaterial URIs)
+// are not yet enforced at runtime and don't need expansion until they are.
+func expandPlaceholders(p *aflock.Policy, getenv func(string) string) error {
+	if p == nil || p.MaterialsFrom == nil {
+		return nil
+	}
+
+	if p.MaterialsFrom.Session != nil {
+		expanded, err := expandString(p.MaterialsFrom.Session.Path, getenv)
+		if err != nil {
+			return fmt.Errorf("materialsFrom.session.path: %w", err)
+		}
+		p.MaterialsFrom.Session.Path = expanded
+	}
+
+	if p.MaterialsFrom.Git != nil {
+		expanded, err := expandString(p.MaterialsFrom.Git.TreeHash, getenv)
+		if err != nil {
+			return fmt.Errorf("materialsFrom.git.treeHash: %w", err)
+		}
+		p.MaterialsFrom.Git.TreeHash = expanded
+	}
+
+	return nil
+}
+
+// expandString substitutes ${NAME} references against allowedPlaceholders.
+// Unknown names return ErrUnknownPlaceholder; known names with an unset env
+// var return ErrUnsetPlaceholder. Plain literals (no ${} markers) pass
+// through unchanged so policies without placeholders keep working.
+//
+// We hand-roll instead of using os.Expand because os.Expand silently
+// resolves unset vars to "" — the exact silent-degrade behavior #134 is
+// closing.
+func expandString(s string, getenv func(string) string) (string, error) {
+	if !strings.Contains(s, "${") {
+		return s, nil
+	}
+
+	var out strings.Builder
+	i := 0
+	for i < len(s) {
+		if i+1 < len(s) && s[i] == '$' && s[i+1] == '{' {
+			end := strings.Index(s[i+2:], "}")
+			if end < 0 {
+				// Unterminated ${... — treat as literal so we don't change
+				// behavior on accidental dollar-sign content.
+				out.WriteString(s[i:])
+				break
+			}
+			name := s[i+2 : i+2+end]
+			envName, ok := allowedPlaceholders[name]
+			if !ok {
+				return "", fmt.Errorf("%w: ${%s} (allowed: %v)",
+					ErrUnknownPlaceholder, name, allowedNames())
+			}
+			val := getenv(envName)
+			if val == "" {
+				return "", fmt.Errorf("%w: $%s referenced via ${%s}",
+					ErrUnsetPlaceholder, envName, name)
+			}
+			out.WriteString(val)
+			i += 2 + end + 1
+			continue
+		}
+		out.WriteByte(s[i])
+		i++
+	}
+	return out.String(), nil
+}
+
+// allowedNames returns the sorted list of placeholder names for error
+// messages. Sorted output keeps error strings deterministic across Go
+// versions / map-iter randomization.
+func allowedNames() []string {
+	names := make([]string, 0, len(allowedPlaceholders))
+	for k := range allowedPlaceholders {
+		names = append(names, k)
+	}
+	// Tiny list — insertion sort beats importing sort.
+	for i := 1; i < len(names); i++ {
+		for j := i; j > 0 && names[j-1] > names[j]; j-- {
+			names[j-1], names[j] = names[j], names[j-1]
+		}
+	}
+	return names
+}

--- a/internal/policy/placeholders_test.go
+++ b/internal/policy/placeholders_test.go
@@ -1,0 +1,131 @@
+package policy
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/aflock-ai/aflock/pkg/aflock"
+)
+
+// TestExpandPlaceholders_PaperExample loads the policy shape lifted directly
+// from paper §4.4 (the original #134 motivating case) and confirms both
+// placeholders resolve to the env values a real session would have set.
+func TestExpandPlaceholders_PaperExample(t *testing.T) {
+	env := map[string]string{
+		"CLAUDE_SESSION_PATH": "/home/me/.claude/projects/p/abc.jsonl",
+		"GIT_TREE_HASH":       "a1b2c3d4e5",
+	}
+	p := &aflock.Policy{
+		MaterialsFrom: &aflock.MaterialsPolicy{
+			Session: &aflock.SessionMaterial{Path: "${CLAUDE_SESSION_PATH}"},
+			Git:     &aflock.GitMaterial{TreeHash: "${GIT_TREE_HASH}"},
+		},
+	}
+
+	if err := expandPlaceholders(p, mapGetenv(env)); err != nil {
+		t.Fatalf("expandPlaceholders: %v", err)
+	}
+	if got, want := p.MaterialsFrom.Session.Path, env["CLAUDE_SESSION_PATH"]; got != want {
+		t.Errorf("Session.Path = %q, want %q", got, want)
+	}
+	if got, want := p.MaterialsFrom.Git.TreeHash, env["GIT_TREE_HASH"]; got != want {
+		t.Errorf("Git.TreeHash = %q, want %q", got, want)
+	}
+}
+
+// TestExpandPlaceholders_UnknownPlaceholder_HardFails — strict mode is the
+// whole point. A typo like ${CLAUDE_SESSION_PTH} silently resolving to
+// empty string is the bug #134 closes; an explicit error is what we want.
+func TestExpandPlaceholders_UnknownPlaceholder_HardFails(t *testing.T) {
+	p := &aflock.Policy{
+		MaterialsFrom: &aflock.MaterialsPolicy{
+			Session: &aflock.SessionMaterial{Path: "${CLAUDE_SESSION_PTH}"}, // typo
+		},
+	}
+	err := expandPlaceholders(p, mapGetenv(map[string]string{}))
+	if err == nil {
+		t.Fatal("typo'd placeholder must fail Load")
+	}
+	if !errors.Is(err, ErrUnknownPlaceholder) {
+		t.Errorf("wrong error: %v (want ErrUnknownPlaceholder)", err)
+	}
+}
+
+// TestExpandPlaceholders_UnsetKnown_HardFails — known placeholder with an
+// unset env var is also strict. Leaving the literal in place was the
+// original bug: the verifier compared literal "${X}" against real values
+// and never matched.
+func TestExpandPlaceholders_UnsetKnown_HardFails(t *testing.T) {
+	p := &aflock.Policy{
+		MaterialsFrom: &aflock.MaterialsPolicy{
+			Session: &aflock.SessionMaterial{Path: "${CLAUDE_SESSION_PATH}"},
+		},
+	}
+	err := expandPlaceholders(p, mapGetenv(map[string]string{})) // empty env
+	if err == nil {
+		t.Fatal("unset known placeholder must fail Load")
+	}
+	if !errors.Is(err, ErrUnsetPlaceholder) {
+		t.Errorf("wrong error: %v (want ErrUnsetPlaceholder)", err)
+	}
+}
+
+// TestExpandPlaceholders_NoPlaceholder_PassesThrough — policies without any
+// ${...} must keep working unchanged. Regression guard against ever turning
+// the placeholder check into a required-field check.
+func TestExpandPlaceholders_NoPlaceholder_PassesThrough(t *testing.T) {
+	p := &aflock.Policy{
+		MaterialsFrom: &aflock.MaterialsPolicy{
+			Session: &aflock.SessionMaterial{Path: "/literal/path.jsonl"},
+			Git:     &aflock.GitMaterial{TreeHash: "deadbeef"},
+		},
+	}
+	if err := expandPlaceholders(p, mapGetenv(map[string]string{})); err != nil {
+		t.Fatalf("literal-only policy must not error: %v", err)
+	}
+	if p.MaterialsFrom.Session.Path != "/literal/path.jsonl" {
+		t.Errorf("literal mutated: %q", p.MaterialsFrom.Session.Path)
+	}
+}
+
+// TestLoad_ExpandsPlaceholders is the end-to-end Load wiring test. Drives
+// the real policy.Load entry point with a synthetic env, confirming the
+// loaded *Policy has expanded values — what every downstream consumer
+// (verifier, hooks, MCP) sees.
+func TestLoad_ExpandsPlaceholders(t *testing.T) {
+	t.Setenv("CLAUDE_SESSION_PATH", "/synthetic/session.jsonl")
+	t.Setenv("GIT_TREE_HASH", "feedface")
+
+	dir := t.TempDir()
+	body := `{
+	  "version": "1.0",
+	  "name": "paper-example",
+	  "materialsFrom": {
+	    "session": { "path": "${CLAUDE_SESSION_PATH}" },
+	    "git":     { "treeHash": "${GIT_TREE_HASH}" }
+	  }
+	}`
+	policyPath := filepath.Join(dir, ".aflock")
+	if err := os.WriteFile(policyPath, []byte(body), 0600); err != nil {
+		t.Fatalf("write policy: %v", err)
+	}
+
+	pol, _, err := Load(policyPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got, want := pol.MaterialsFrom.Session.Path, "/synthetic/session.jsonl"; got != want {
+		t.Errorf("Session.Path = %q, want %q (placeholder didn't expand at Load)", got, want)
+	}
+	if got, want := pol.MaterialsFrom.Git.TreeHash, "feedface"; got != want {
+		t.Errorf("Git.TreeHash = %q, want %q", got, want)
+	}
+}
+
+// mapGetenv returns a getenv func backed by an explicit map — lets tests
+// avoid os.Setenv / t.Setenv when they just want to drive the helper.
+func mapGetenv(m map[string]string) func(string) string {
+	return func(k string) string { return m[k] }
+}

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -66,6 +66,13 @@ func Load(path string) (*aflock.Policy, string, error) {
 		return nil, "", fmt.Errorf("parse policy: %w", err)
 	}
 
+	// Resolve ${...} placeholders against the environment (paper §4.4 / #134).
+	// Done after unmarshal so every consumer (verifier, hooks, MCP) sees
+	// fully-expanded values rather than literal placeholder strings.
+	if err := expandPlaceholders(&policy, os.Getenv); err != nil {
+		return nil, "", fmt.Errorf("expand placeholders: %w", err)
+	}
+
 	// Bind the digest to the exact file bytes the user signed/reviewed
 	// (issue #61 / L5). Re-marshaling the parsed struct would normalize
 	// whitespace, key order, and number formatting, producing a digest that


### PR DESCRIPTION
Closes #134.

Paper §4.4 uses `${CLAUDE_SESSION_PATH}` / `${GIT_TREE_HASH}` in `materialsFrom`, but the loader never expanded them — the literal `${...}` strings landed in the verifier and never matched a real path. `policy.Load` now walks `MaterialsFrom.Session.Path` + `MaterialsFrom.Git.TreeHash` and substitutes the two documented placeholders against the environment. Unknown names and unset known env vars both fail Load (strict, no silent empty-string degrade).

Docs: `docs/reference/policy-schema.md` gains a Placeholders section.