### PR TITLE
fix(verify): enforce sublayout namespacing on child attestations

### DIFF
--- a/internal/verify/sublayout_namespacing_test.go
+++ b/internal/verify/sublayout_namespacing_test.go
@@ -1,0 +1,146 @@
+package verify
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeActionEnvelope drops a DSSE-shaped envelope into dir containing
+// a predicate with the given sublayoutBinding. Returns the file path.
+// binding may be nil to model an attestation that omits the field
+// entirely (which the namespacing check must tolerate).
+func writeActionEnvelope(t *testing.T, dir, fname string, binding map[string]any) string {
+	t.Helper()
+	pred := map[string]any{"toolName": "Read"}
+	if binding != nil {
+		pred["sublayoutBinding"] = binding
+	}
+	stmt := map[string]any{
+		"_type":         "https://in-toto.io/Statement/v1",
+		"predicateType": "https://aflock.ai/attestations/action/v0.1",
+		"predicate":     pred,
+		"subject":       []map[string]any{},
+	}
+	payload, err := json.Marshal(stmt)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	env := map[string]any{
+		"payloadType": "application/vnd.in-toto+json",
+		"payload":     base64.StdEncoding.EncodeToString(payload),
+		"signatures":  []map[string]string{{"keyid": "k", "sig": "c2ln"}},
+	}
+	data, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("marshal env: %v", err)
+	}
+	p := filepath.Join(dir, fname)
+	if err := os.WriteFile(p, data, 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	return p
+}
+
+// TestVerifySublayoutNamespacing_AllMatch is the happy path: every
+// attestation's sublayoutBinding names this sublayout, so the check
+// returns no messages.
+func TestVerifySublayoutNamespacing_AllMatch(t *testing.T) {
+	dir := t.TempDir()
+	writeActionEnvelope(t, dir, "a.intoto.json", map[string]any{
+		"name":   "research-agent",
+		"prefix": "research/",
+	})
+	writeActionEnvelope(t, dir, "b.intoto.json", map[string]any{
+		"name":   "research-agent",
+		"prefix": "research/",
+	})
+	msgs := verifySublayoutNamespacing(dir, "research-agent", "research/")
+	if len(msgs) != 0 {
+		t.Errorf("expected no violations, got %v", msgs)
+	}
+}
+
+// TestVerifySublayoutNamespacing_NameMismatch — the core failure
+// mode the paper's Phase 6 filter catches: an attestation whose
+// binding names a different sublayout slipped into this child's
+// directory.
+func TestVerifySublayoutNamespacing_NameMismatch(t *testing.T) {
+	dir := t.TempDir()
+	writeActionEnvelope(t, dir, "a.intoto.json", map[string]any{
+		"name": "research-agent",
+	})
+	writeActionEnvelope(t, dir, "b.intoto.json", map[string]any{
+		"name": "evil-agent", // mismatched
+	})
+	msgs := verifySublayoutNamespacing(dir, "research-agent", "")
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 violation, got %d: %v", len(msgs), msgs)
+	}
+	if !strings.Contains(msgs[0], "evil-agent") || !strings.Contains(msgs[0], "research-agent") {
+		t.Errorf("expected violation to mention both names, got: %s", msgs[0])
+	}
+}
+
+// TestVerifySublayoutNamespacing_PrefixMismatch — when the sublayout
+// declares an AttestationPrefix, every binding must carry it too.
+// An attestation with the right name but wrong prefix still fails.
+func TestVerifySublayoutNamespacing_PrefixMismatch(t *testing.T) {
+	dir := t.TempDir()
+	writeActionEnvelope(t, dir, "a.intoto.json", map[string]any{
+		"name":   "research-agent",
+		"prefix": "wrong/",
+	})
+	msgs := verifySublayoutNamespacing(dir, "research-agent", "research/")
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 violation, got %d: %v", len(msgs), msgs)
+	}
+	if !strings.Contains(msgs[0], "prefix") {
+		t.Errorf("violation must mention prefix, got: %s", msgs[0])
+	}
+}
+
+// TestVerifySublayoutNamespacing_PrefixOptional — when the sublayout
+// itself declares no AttestationPrefix, the check ignores binding
+// prefixes entirely (only the name is enforced). Otherwise legacy
+// policies that rely on name-based grouping would suddenly fail.
+func TestVerifySublayoutNamespacing_PrefixOptional(t *testing.T) {
+	dir := t.TempDir()
+	writeActionEnvelope(t, dir, "a.intoto.json", map[string]any{
+		"name":   "research-agent",
+		"prefix": "anything-goes/",
+	})
+	msgs := verifySublayoutNamespacing(dir, "research-agent", "")
+	if len(msgs) != 0 {
+		t.Errorf("expected no violations when sublayout declares no prefix, got %v", msgs)
+	}
+}
+
+// TestVerifySublayoutNamespacing_NoBindingSkipped — attestation types
+// that don't stamp sublayoutBinding (e.g. step attestations) must not
+// trigger a violation. Only attestations that DO claim a binding are
+// validated.
+func TestVerifySublayoutNamespacing_NoBindingSkipped(t *testing.T) {
+	dir := t.TempDir()
+	writeActionEnvelope(t, dir, "no-binding.intoto.json", nil)
+	writeActionEnvelope(t, dir, "with-binding.intoto.json", map[string]any{
+		"name": "research-agent",
+	})
+	msgs := verifySublayoutNamespacing(dir, "research-agent", "")
+	if len(msgs) != 0 {
+		t.Errorf("expected no violations, got %v", msgs)
+	}
+}
+
+// TestVerifySublayoutNamespacing_EmptyDir — verifying an empty
+// directory is a no-op, not an error. Avoids spurious failures for
+// children that haven't recorded attestations yet.
+func TestVerifySublayoutNamespacing_EmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	if msgs := verifySublayoutNamespacing(dir, "research-agent", "research/"); len(msgs) != 0 {
+		t.Errorf("expected no violations for empty dir, got %v", msgs)
+	}
+}

--- a/internal/verify/verifier.go
+++ b/internal/verify/verifier.go
@@ -1536,6 +1536,47 @@ func topoSortSteps(steps map[string]aflock.Step) ([]string, error) {
 //  3. Recursively verifies the child session against the sublayout's policy
 //  4. Accumulates child spend toward parent metrics
 //
+// verifySublayoutNamespacing enforces paper §5 invariant #3 — every
+// child attestation that carries a sublayoutBinding must name THIS
+// sublayout. Reads each *.intoto.json envelope under attestDir, parses
+// the predicate, and validates the embedded binding's `name` (and
+// `prefix` when the sublayout declares one). Attestations without a
+// sublayoutBinding are skipped: only action attestations stamp the
+// field today, so other kinds (e.g. step attestations) pass through.
+//
+// Closes the gap from issue #147 where the paper's Phase 6 prefix
+// filter (`A_s = {a in A : a.prefix == s.name}`) was implicit only —
+// the recursive verify trusted the child session's stored
+// AttestationPrefix rather than re-checking each attestation.
+func verifySublayoutNamespacing(attestDir, subName, subPrefix string) []string {
+	statements, _ := loadAttestationStatements(attestDir)
+	var msgs []string
+	for i, s := range statements {
+		stmt, ok := s.(map[string]any)
+		if !ok {
+			continue
+		}
+		pred, ok := stmt["predicate"].(map[string]any)
+		if !ok {
+			continue
+		}
+		binding, ok := pred["sublayoutBinding"].(map[string]any)
+		if !ok {
+			// Not a sublayout-bound attestation (e.g. step attestation).
+			continue
+		}
+		if gotName, _ := binding["name"].(string); gotName != subName {
+			msgs = append(msgs, fmt.Sprintf("attestation %d sublayoutBinding.name=%q, expected %q", i, gotName, subName))
+		}
+		if subPrefix != "" {
+			if gotPrefix, _ := binding["prefix"].(string); gotPrefix != subPrefix {
+				msgs = append(msgs, fmt.Sprintf("attestation %d sublayoutBinding.prefix=%q, expected %q", i, gotPrefix, subPrefix))
+			}
+		}
+	}
+	return msgs
+}
+
 //nolint:gocognit // sublayout verification requires many checks
 func (v *Verifier) verifySublayouts(parentState *aflock.SessionState, depth int) []string {
 	if len(parentState.Policy.Sublayouts) == 0 {
@@ -1567,6 +1608,20 @@ func (v *Verifier) verifySublayouts(parentState *aflock.SessionState, depth int)
 			}
 
 			childFound = true
+
+			// Phase 6 namespacing invariant (paper Listing 1
+			// `A_s = {a in A : a.prefix == s.name}`, §5 invariant #3):
+			// every child attestation that carries a sublayoutBinding
+			// must name THIS sublayout. Without this check a forged
+			// or misattributed attestation could land in the wrong
+			// sublayout slot and still pass verify because the
+			// recursive call only looks at the child session, not
+			// at the binding the attestation claims (issue #147).
+			if msgs := verifySublayoutNamespacing(v.stateManager.AttestationsDir(childID), sub.Name, sub.AttestationPrefix); len(msgs) > 0 {
+				for _, m := range msgs {
+					errors = append(errors, fmt.Sprintf("sublayout %q [%s]: %s", sub.Name, childID, m))
+				}
+			}
 
 			// Stage an Inherit overlay for the recursive verify if the
 			// sublayout declares any. verifySessionWithDepth consumes it


### PR DESCRIPTION
Closes #147.

Adds `verifySublayoutNamespacing` and calls it from `verifySublayouts` after each child binds to a sublayout. For every child attestation that carries a `sublayoutBinding` predicate field, we now assert `binding.name == sub.Name` and (when declared) `binding.prefix == sub.AttestationPrefix`.

Closes the gap from paper Listing 1 Phase 6 — `A_s = {a in A : a.prefix == s.name}` — that was implicit only. Attestations missing a binding (e.g. step attestations) are skipped, so the change is non-breaking for non-sublayout flows.

## Test plan
- [x] new `internal/verify/sublayout_namespacing_test.go` covers happy path, name mismatch, prefix mismatch, prefix-optional, no-binding-skipped, empty-dir
- [x] `go test ./...` clean
