### PR TITLE
fix: multi-Claude safety — exact session attribution and ancestry-gated propagation

### DIFF
--- a/internal/hooks/handler.go
+++ b/internal/hooks/handler.go
@@ -131,7 +131,7 @@ func (h *Handler) handleSessionStart(input *aflock.HookInput) error {
 	// Discover agent identity. If the policy has identity constraints
 	// (AllowedModels), a discovery failure must block the session — otherwise
 	// the constraint is silently bypassed (issue #60 / H7).
-	agentIdentity, err := identity.DiscoverAgentIdentity()
+	agentIdentity, err := identity.DiscoverAgentIdentityForSession(input.SessionID, input.TranscriptPath)
 	if err != nil {
 		if pol != nil && pol.Identity != nil && len(pol.Identity.AllowedModels) > 0 {
 			output.ExitWithError(fmt.Sprintf("[aflock] Identity discovery failed and policy requires allowedModels: %v", err))
@@ -165,6 +165,7 @@ func (h *Handler) handleSessionStart(input *aflock.HookInput) error {
 		ModelVersion: agentIdentity.ModelVersion,
 		IdentityHash: agentIdentity.IdentityHash,
 		PolicyDigest: agentIdentity.PolicyDigest,
+		ModelSource:  agentIdentity.DiscoverySource,
 		Environment: func() string {
 			if agentIdentity.Environment != nil {
 				return agentIdentity.Environment.Type
@@ -179,8 +180,12 @@ func (h *Handler) handleSessionStart(input *aflock.HookInput) error {
 	}
 
 	// Check for propagation from a parent session (sublayout delegation).
-	// If found, inherit materials and attenuate limits.
-	if prop, propErr := h.stateManager.ReadPropagation(policyPath); propErr != nil {
+	// If found, inherit materials and attenuate limits. Only records written
+	// by one of this process's own ancestors are consumed — with several
+	// Claude instances running concurrently, an unrelated session's
+	// SessionStart must not steal another parent's handoff (which would also
+	// corrupt that parent's state when SubagentStop merges the wrong child).
+	if prop, propErr := h.stateManager.ReadPropagationForChild(policyPath, identity.ProcessChain(os.Getppid())); propErr != nil {
 		fmt.Fprintf(os.Stderr, "[aflock] Warning: failed to read propagation: %v\n", propErr)
 	} else if prop != nil {
 		sessionState.ParentSessionID = prop.ParentSessionID
@@ -683,8 +688,13 @@ func (h *Handler) createAttestation(sessionState *aflock.SessionState, input *af
 	// If the saved model is "unknown", try re-discovering — SessionStart may
 	// have failed to find the model (e.g., new project with no session files)
 	// but PostToolUse might succeed if Claude session files now exist.
+	// Likewise when the model was attributed by the machine-global PID/mtime
+	// heuristic (ModelSource == pid_trace): with concurrent Claude instances
+	// that guess can be wrong, so keep re-resolving from this session's own
+	// transcript until exact attribution lands.
 	var agentIdentity *identity.AgentIdentity
-	if meta := sessionState.AgentIdentityMeta; meta != nil && meta.Model != "" && meta.Model != "unknown" {
+	if meta := sessionState.AgentIdentityMeta; meta != nil && meta.Model != "" && meta.Model != "unknown" &&
+		meta.ModelSource != identity.DiscoveryMethodPIDTrace {
 		agentIdentity = &identity.AgentIdentity{
 			Model:        meta.Model,
 			ModelVersion: meta.ModelVersion,
@@ -704,17 +714,22 @@ func (h *Handler) createAttestation(sessionState *aflock.SessionState, input *af
 			}
 		}
 	} else {
-		// Saved identity has unknown model — try fresh discovery
-		agentIdentity, _ = identity.DiscoverAgentIdentity()
+		// Saved identity is unknown or heuristically attributed — try fresh
+		// discovery scoped to this session's own transcript.
+		agentIdentity, _ = identity.DiscoverAgentIdentityForSession(input.SessionID, input.TranscriptPath)
 
 		// Persist re-discovered identity back to session state so state.json
 		// stays consistent with attestations (fixes "unknown" model lingering).
-		if agentIdentity != nil && agentIdentity.Model != "" && agentIdentity.Model != "unknown" {
+		if agentIdentity != nil && agentIdentity.Model != "" && agentIdentity.Model != "unknown" &&
+			(sessionState.AgentIdentityMeta == nil ||
+				sessionState.AgentIdentityMeta.Model != agentIdentity.Model ||
+				sessionState.AgentIdentityMeta.ModelSource != agentIdentity.DiscoverySource) {
 			sessionState.AgentIdentityMeta = &aflock.AgentIdentityMeta{
 				Model:        agentIdentity.Model,
 				ModelVersion: agentIdentity.ModelVersion,
 				IdentityHash: agentIdentity.IdentityHash,
 				PolicyDigest: agentIdentity.PolicyDigest,
+				ModelSource:  agentIdentity.DiscoverySource,
 				Environment: func() string {
 					if agentIdentity.Environment != nil {
 						return agentIdentity.Environment.Type

--- a/internal/identity/agent.go
+++ b/internal/identity/agent.go
@@ -58,6 +58,11 @@ type AgentIdentity struct {
 	// IdentityHash is the computed transitive identity hash
 	IdentityHash string `json:"identityHash,omitempty"`
 
+	// DiscoverySource records which mechanism attributed the Model (see the
+	// DiscoveryMethod* constants). Metadata only — not part of the identity
+	// hash derivation.
+	DiscoverySource string `json:"discoverySource,omitempty"`
+
 	// SPIFFEID is the SPIFFE ID derived from this identity
 	SPIFFEID spiffeid.ID `json:"-"`
 
@@ -228,6 +233,18 @@ func DiscoverAgentIdentity() (*AgentIdentity, error) {
 	return discoverAgentIdentity(DiscoverFromMCPSocket, nil)
 }
 
+// DiscoverAgentIdentityForSession discovers the agent identity for a
+// specific hook invocation, preferring the transcript path Claude Code
+// supplied in the hook input over the machine-global "most recently
+// modified session file" heuristic. With multiple Claude instances running
+// concurrently the heuristic frequently attributes another session's model;
+// the transcript path is exact — it is the calling session's own file.
+func DiscoverAgentIdentityForSession(sessionID, transcriptPath string) (*AgentIdentity, error) {
+	return discoverAgentIdentity(func() (string, *ProcessMetadata, error) {
+		return DiscoverForSession(sessionID, transcriptPath)
+	}, nil)
+}
+
 // DiscoverAgentIdentityFromPID discovers the agent identity starting from a
 // kernel-attested peer PID (e.g. obtained via SO_PEERCRED on Linux or
 // LOCAL_PEERPID on macOS for an accepted UDS connection).
@@ -277,6 +294,7 @@ func discoverAgentIdentity(discover func() (string, *ProcessMetadata, error), pe
 		identity.SessionPath = meta.SessionPath
 		identity.ClaudePID = meta.ClaudePID
 		identity.ProcessChain = meta.ProcessChain
+		identity.DiscoverySource = meta.DiscoveryMethod
 	}
 
 	identity.ModelVersion = parseModelVersion(identity.Model)

--- a/internal/identity/discover.go
+++ b/internal/identity/discover.go
@@ -494,7 +494,7 @@ type ProcessInfo struct {
 //
 //nolint:gocognit,gocyclo // MCP socket discovery requires complex process parsing
 func DiscoverFromMCPSocket() (string, *ProcessMetadata, error) {
-	return discoverFromPID(os.Getppid(), "pid_trace", nil)
+	return discoverFromPID(os.Getppid(), DiscoveryMethodPIDTrace, nil)
 }
 
 // DiscoverFromPID discovers the agent model and collects process metadata
@@ -950,4 +950,86 @@ func getProcessEnvironmentMacOS(pid int) (map[string]string, error) {
 	}
 
 	return env, nil
+}
+
+// Discovery method markers recorded in ProcessMetadata.DiscoveryMethod and
+// surfaced as AgentIdentity.DiscoverySource.
+const (
+	// DiscoveryMethodTranscript marks model attribution read from the hook's
+	// own transcript file — exact even with concurrent Claude instances.
+	DiscoveryMethodTranscript = "transcript_path"
+	// DiscoveryMethodPIDTrace marks the machine-global process-tree + mtime
+	// heuristic — ambiguous when multiple Claude instances run concurrently.
+	DiscoveryMethodPIDTrace = "pid_trace"
+)
+
+// ProcessChain returns the chain of PIDs from startPID up toward init (max
+// 10 levels). Exported for callers that need to verify process ancestry,
+// e.g. matching a propagation record's ParentPID against the consumer's own
+// ancestors (multi-Claude safety).
+func ProcessChain(startPID int) []int {
+	return getProcessChain(startPID)
+}
+
+// DiscoverForSession resolves the model and session info for a specific hook
+// invocation using the transcript path Claude Code supplied on stdin. Unlike
+// the PID/mtime heuristics above, this is exact under concurrent Claude
+// instances: the transcript file *is* the calling session, so a neighbouring
+// session's more recently flushed transcript can never be mis-attributed.
+//
+// When the transcript has no model yet (a fresh session before the first
+// assistant turn) it falls back to the machine-global heuristic, but keeps
+// the hook's own session identity and marks the result DiscoveryMethodPIDTrace
+// so callers can re-resolve later.
+func DiscoverForSession(sessionID, transcriptPath string) (string, *ProcessMetadata, error) {
+	if transcriptPath != "" {
+		if model, err := extractModelFromSession(transcriptPath); err == nil && model != "" {
+			meta := &ProcessMetadata{
+				AflockPID:       os.Getpid(),
+				ParentPID:       os.Getppid(),
+				SessionID:       sessionID,
+				SessionPath:     transcriptPath,
+				Model:           model,
+				DiscoveryMethod: DiscoveryMethodTranscript,
+				UserID:          os.Getuid(),
+			}
+			if meta.SessionID == "" {
+				meta.SessionID = strings.TrimSuffix(filepath.Base(transcriptPath), ".jsonl")
+			}
+			meta.Hostname, _ = os.Hostname()
+			// Best-effort process chain for attestation metadata only — the
+			// model attribution above never depends on it.
+			for _, pid := range getProcessChain(os.Getppid()) {
+				cmd, cmdErr := getProcessCommand(pid)
+				if cmdErr != nil {
+					continue
+				}
+				info := ProcessInfo{PID: pid, Command: cmd}
+				if strings.Contains(cmd, "claude") && !strings.Contains(cmd, "node") {
+					info.IsClaude = true
+					if meta.ClaudePID == 0 {
+						meta.ClaudePID = pid
+					}
+				}
+				meta.ProcessChain = append(meta.ProcessChain, info)
+			}
+			return model, meta, nil
+		}
+		fmt.Fprintf(os.Stderr, "[aflock] Transcript %s has no model yet; falling back to PID heuristic (ambiguous with concurrent Claude instances)\n", transcriptPath)
+	}
+
+	// Fallback: machine-global heuristic. Keep the hook's own session
+	// identity — only the model is a hint here — and the DiscoveryMethod
+	// marker lets PostToolUse re-resolve from the transcript once the first
+	// assistant turn lands.
+	model, meta, err := DiscoverFromMCPSocket()
+	if meta != nil {
+		if sessionID != "" {
+			meta.SessionID = sessionID
+		}
+		if transcriptPath != "" {
+			meta.SessionPath = transcriptPath
+		}
+	}
+	return model, meta, err
 }

--- a/internal/identity/discover_session_test.go
+++ b/internal/identity/discover_session_test.go
@@ -1,0 +1,112 @@
+package identity
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// Multi-Claude safety: DiscoverForSession must attribute the model from the
+// hook's OWN transcript, never from whichever session file in the project
+// was flushed most recently (the failure mode with concurrent instances).
+
+func TestDiscoverForSession_ExactTranscriptBeatsNewerNeighbor(t *testing.T) {
+	t.Setenv("HOME", t.TempDir()) // isolate any heuristic fallback
+	tmp := t.TempDir()
+
+	own := filepath.Join(tmp, "sess-own.jsonl")
+	other := filepath.Join(tmp, "sess-other.jsonl")
+
+	writeJSONLFile(t, own, []map[string]any{
+		{"message": map[string]any{"model": "claude-opus-4-5-20251101"}},
+	})
+	// A concurrent session's transcript, flushed later — the old mtime
+	// heuristic would have picked this one.
+	time.Sleep(10 * time.Millisecond)
+	writeJSONLFile(t, other, []map[string]any{
+		{"message": map[string]any{"model": "claude-sonnet-4-20250514"}},
+	})
+
+	model, meta, err := DiscoverForSession("sess-own", own)
+	if err != nil {
+		t.Fatalf("DiscoverForSession: %v", err)
+	}
+	if model != "claude-opus-4-5-20251101" {
+		t.Fatalf("model = %q, want the OWN transcript's model claude-opus-4-5-20251101", model)
+	}
+	if meta.SessionID != "sess-own" {
+		t.Errorf("SessionID = %q, want sess-own", meta.SessionID)
+	}
+	if meta.SessionPath != own {
+		t.Errorf("SessionPath = %q, want %q", meta.SessionPath, own)
+	}
+	if meta.DiscoveryMethod != DiscoveryMethodTranscript {
+		t.Errorf("DiscoveryMethod = %q, want %q", meta.DiscoveryMethod, DiscoveryMethodTranscript)
+	}
+}
+
+func TestDiscoverForSession_DerivesSessionIDFromFilename(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	tmp := t.TempDir()
+
+	transcript := filepath.Join(tmp, "abc-123-def.jsonl")
+	writeJSONLFile(t, transcript, []map[string]any{
+		{"model": "claude-opus-4-5-20251101"},
+	})
+
+	_, meta, err := DiscoverForSession("", transcript)
+	if err != nil {
+		t.Fatalf("DiscoverForSession: %v", err)
+	}
+	if meta.SessionID != "abc-123-def" {
+		t.Errorf("SessionID = %q, want abc-123-def (derived from filename)", meta.SessionID)
+	}
+}
+
+func TestDiscoverForSession_NoModelYetDoesNotAdoptNeighborIdentity(t *testing.T) {
+	t.Setenv("HOME", t.TempDir()) // heuristic fallback cannot find real ~/.claude
+	tmp := t.TempDir()
+
+	own := filepath.Join(tmp, "sess-own.jsonl")
+	other := filepath.Join(tmp, "sess-other.jsonl")
+
+	// Fresh session: transcript exists but has no assistant turn yet.
+	writeJSONLFile(t, own, []map[string]any{
+		{"type": "summary"},
+	})
+	time.Sleep(10 * time.Millisecond)
+	writeJSONLFile(t, other, []map[string]any{
+		{"message": map[string]any{"model": "claude-sonnet-4-20250514"}},
+	})
+
+	model, meta, err := DiscoverForSession("sess-own", own)
+
+	// The fallback heuristic may or may not resolve a model depending on the
+	// environment, but it must NEVER be marked exact, and it must keep the
+	// hook's own session identity rather than adopting the neighbor's.
+	if err == nil {
+		if meta == nil {
+			t.Fatal("nil meta with nil error")
+		}
+		if meta.DiscoveryMethod == DiscoveryMethodTranscript {
+			t.Errorf("model-less transcript must not report exact transcript attribution (model=%q)", model)
+		}
+		if meta.SessionID != "sess-own" {
+			t.Errorf("SessionID = %q, want sess-own (must not adopt neighbor's session)", meta.SessionID)
+		}
+		if meta.SessionPath != own {
+			t.Errorf("SessionPath = %q, want %q", meta.SessionPath, own)
+		}
+	}
+}
+
+func TestDiscoverForSession_EmptyTranscriptPathFallsBack(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	// No transcript supplied (older Claude Code, MCP mode): behaves like the
+	// legacy heuristic — and must not panic or fabricate exact attribution.
+	_, meta, err := DiscoverForSession("some-session", "")
+	if err == nil && meta != nil && meta.DiscoveryMethod == DiscoveryMethodTranscript {
+		t.Error("no transcript path must not yield transcript-exact attribution")
+	}
+}

--- a/internal/state/propagation.go
+++ b/internal/state/propagation.go
@@ -82,8 +82,14 @@ func (m *Manager) writePropagationRecord(parentState *aflock.SessionState, sub *
 		return fmt.Errorf("create propagation dir: %w", err)
 	}
 
+	// Housekeeping: purge long-expired records and orphaned consumption
+	// markers so the shared directory doesn't accumulate stale entries that
+	// widen the window for wrong FIFO picks.
+	m.CleanStalePropagation()
+
 	rec := aflock.PropagationRecord{
 		ParentSessionID: parentState.SessionID,
+		ParentPID:       os.Getppid(),
 		PolicyPath:      parentState.PolicyPath,
 		Materials:       parentState.Materials,
 		ParentMetrics:   parentState.Metrics,
@@ -116,17 +122,39 @@ func (m *Manager) writePropagationRecord(parentState *aflock.SessionState, sub *
 }
 
 // ReadPropagation reads and consumes a single propagation file for the
-// given policy path. Returns nil if no file exists or all that exist are
-// expired.
+// given policy path, with no ancestry filtering (any live record for the
+// policy matches). Prefer ReadPropagationForChild in hook consumers so a
+// concurrent, unrelated session cannot claim another parent's record.
+func (m *Manager) ReadPropagation(policyPath string) (*aflock.PropagationRecord, error) {
+	return m.readPropagation(policyPath, nil)
+}
+
+// ReadPropagationForChild reads and consumes a single propagation file for
+// the given policy path, but only claims records whose ParentPID appears in
+// ancestorPIDs — the consumer's own process ancestry. Records written by
+// other parents are left on disk for their rightful children, so multiple
+// concurrent Claude sessions sharing one policy path cannot steal each
+// other's handoffs (and then corrupt each other's state when SubagentStop
+// merges the wrong child into a live, unrelated parent). Records with
+// ParentPID == 0 (older aflock builds) are accepted for compatibility.
+func (m *Manager) ReadPropagationForChild(policyPath string, ancestorPIDs []int) (*aflock.PropagationRecord, error) {
+	return m.readPropagation(policyPath, ancestorPIDs)
+}
+
+// readPropagation implements ReadPropagation / ReadPropagationForChild.
+// Returns nil if no file exists or all that exist are expired or belong to
+// a different parent.
 //
 // Multi-file claim: parents may have written several files (issue #26 gap
-// 6), one per spawn. ReadPropagation enumerates all files matching the
-// policy prefix, picks the oldest first (FIFO so children consume in
-// spawn order), and atomically claims it via rename. Concurrent readers
-// racing on the same file resolve via rename's atomicity — only one wins,
-// the other tries the next file. Expired records are removed in passing so
-// stale state doesn't block fresh children indefinitely.
-func (m *Manager) ReadPropagation(policyPath string) (*aflock.PropagationRecord, error) {
+// 6), one per spawn. readPropagation enumerates all files matching the
+// policy prefix, oldest first (FIFO so children consume in spawn order),
+// reads each candidate BEFORE claiming so non-matching records can be left
+// intact for their rightful child, then atomically claims the chosen one
+// via rename. Concurrent readers racing on the same file resolve via
+// rename's atomicity — only one wins, the other tries the next file.
+// Records are write-once under unique nonce filenames, so content cannot
+// change between the read and the claim.
+func (m *Manager) readPropagation(policyPath string, ancestorPIDs []int) (*aflock.PropagationRecord, error) {
 	prefix := propagationKeyPrefix(policyPath)
 	dir := propagationBaseDir()
 
@@ -171,6 +199,33 @@ func (m *Manager) ReadPropagation(policyPath string) (*aflock.PropagationRecord,
 
 	for _, c := range candidates {
 		path := filepath.Join(dir, c.name)
+
+		data, err := os.ReadFile(path) //nolint:gosec // G304: path derived from validated entry under propagation dir
+		if err != nil {
+			if os.IsNotExist(err) {
+				// Another reader claimed this file — try the next one.
+				continue
+			}
+			return nil, fmt.Errorf("read propagation: %w", err)
+		}
+
+		var rec aflock.PropagationRecord
+		parseErr := json.Unmarshal(data, &rec)
+		if parseErr == nil {
+			// Expired records are silently skipped — don't waste a fresh
+			// spawn on stale state. Remove best-effort and keep scanning.
+			if rec.IsExpiredPropagation(PropagationTTL) {
+				_ = os.Remove(path)
+				continue
+			}
+			// Ancestry gate (multi-Claude safety): when the consumer supplied
+			// its process chain and the record names its writer's Claude PID,
+			// only claim records written by one of our own ancestors.
+			if ancestorPIDs != nil && rec.ParentPID != 0 && !containsPID(ancestorPIDs, rec.ParentPID) {
+				continue
+			}
+		}
+
 		claimed := filepath.Join(dir, fmt.Sprintf("%s.consumed.%d.%d", c.name, os.Getpid(), time.Now().UnixNano()))
 		if err := os.Rename(path, claimed); err != nil {
 			if os.IsNotExist(err) {
@@ -179,30 +234,25 @@ func (m *Manager) ReadPropagation(policyPath string) (*aflock.PropagationRecord,
 			}
 			return nil, fmt.Errorf("claim propagation: %w", err)
 		}
-
-		data, err := os.ReadFile(claimed) //nolint:gosec // G304: path derived from validated entry under propagation dir
-		if err != nil {
-			_ = os.Remove(claimed)
-			return nil, fmt.Errorf("read propagation: %w", err)
-		}
-
-		var rec aflock.PropagationRecord
-		if err := json.Unmarshal(data, &rec); err != nil {
-			_ = os.Remove(claimed)
-			return nil, fmt.Errorf("parse propagation: %w", err)
-		}
-
 		_ = os.Remove(claimed)
 
-		// Expired records are silently skipped — don't waste a fresh spawn
-		// on stale state. Continue scanning for a live one.
-		if rec.IsExpiredPropagation(PropagationTTL) {
-			continue
+		if parseErr != nil {
+			return nil, fmt.Errorf("parse propagation: %w", parseErr)
 		}
 		return &rec, nil
 	}
 
 	return nil, nil
+}
+
+// containsPID reports whether pid appears in pids.
+func containsPID(pids []int, pid int) bool {
+	for _, p := range pids {
+		if p == pid {
+			return true
+		}
+	}
+	return false
 }
 
 // containsConsumedMarker reports whether the filename has the ".consumed."

--- a/internal/state/propagation_multiclaude_test.go
+++ b/internal/state/propagation_multiclaude_test.go
@@ -1,0 +1,139 @@
+package state
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/aflock-ai/aflock/pkg/aflock"
+)
+
+// Multi-Claude safety: a child session must only consume a propagation
+// record written by one of its OWN ancestor processes. With two concurrent
+// Claude sessions sharing a policy path, the old FIFO-by-prefix claim let an
+// unrelated SessionStart steal a parent's handoff — inheriting its materials
+// and attenuated limits, and later corrupting the parent's state when
+// SubagentStop merged the wrong child.
+
+// writeRawPropagation writes a record directly so tests can control ParentPID.
+func writeRawPropagation(t *testing.T, policyPath string, rec *aflock.PropagationRecord) {
+	t.Helper()
+	dir := propagationBaseDir()
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatalf("mkdir propagation: %v", err)
+	}
+	name, err := propagationFilename(policyPath)
+	if err != nil {
+		t.Fatalf("propagation filename: %v", err)
+	}
+	data, err := json.Marshal(rec)
+	if err != nil {
+		t.Fatalf("marshal record: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name), data, 0600); err != nil {
+		t.Fatalf("write record: %v", err)
+	}
+}
+
+func TestPropagation_ChildOnlyConsumesOwnParentRecord(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	m := NewManager(t.TempDir())
+	policyPath := "/project/.aflock"
+
+	// Parent A wrote first (FIFO would pick it), parent B second.
+	writeRawPropagation(t, policyPath, &aflock.PropagationRecord{
+		ParentSessionID: "parent-A", ParentPID: 11111, CreatedAt: time.Now(),
+	})
+	time.Sleep(10 * time.Millisecond)
+	writeRawPropagation(t, policyPath, &aflock.PropagationRecord{
+		ParentSessionID: "parent-B", ParentPID: 22222, CreatedAt: time.Now(),
+	})
+
+	// A child of parent B must get B's record even though A's is older…
+	rec, err := m.ReadPropagationForChild(policyPath, []int{999, 22222})
+	if err != nil {
+		t.Fatalf("ReadPropagationForChild: %v", err)
+	}
+	if rec == nil || rec.ParentSessionID != "parent-B" {
+		t.Fatalf("got %+v, want parent-B's record", rec)
+	}
+
+	// …and A's record must still be on disk for A's own child.
+	rec, err = m.ReadPropagationForChild(policyPath, []int{11111})
+	if err != nil {
+		t.Fatalf("ReadPropagationForChild(A): %v", err)
+	}
+	if rec == nil || rec.ParentSessionID != "parent-A" {
+		t.Fatalf("got %+v, want parent-A's record left intact", rec)
+	}
+}
+
+func TestPropagation_UnrelatedSessionCannotStealRecord(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	m := NewManager(t.TempDir())
+	policyPath := "/project/.aflock"
+
+	writeRawPropagation(t, policyPath, &aflock.PropagationRecord{
+		ParentSessionID: "parent-A", ParentPID: 11111, CreatedAt: time.Now(),
+	})
+
+	// A concurrent, unrelated session (no matching ancestor) gets nothing…
+	rec, err := m.ReadPropagationForChild(policyPath, []int{33333, 44444})
+	if err != nil {
+		t.Fatalf("ReadPropagationForChild: %v", err)
+	}
+	if rec != nil {
+		t.Fatalf("unrelated session stole record: %+v", rec)
+	}
+
+	// …and the record survives for the rightful child.
+	rec, err = m.ReadPropagationForChild(policyPath, []int{11111})
+	if err != nil {
+		t.Fatalf("ReadPropagationForChild(rightful): %v", err)
+	}
+	if rec == nil || rec.ParentSessionID != "parent-A" {
+		t.Fatalf("rightful child got %+v, want parent-A's record", rec)
+	}
+}
+
+func TestPropagation_LegacyRecordWithoutParentPIDIsConsumed(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	m := NewManager(t.TempDir())
+	policyPath := "/project/.aflock"
+
+	// Record from an older aflock build: no parent_pid field.
+	writeRawPropagation(t, policyPath, &aflock.PropagationRecord{
+		ParentSessionID: "parent-legacy", CreatedAt: time.Now(),
+	})
+
+	rec, err := m.ReadPropagationForChild(policyPath, []int{42})
+	if err != nil {
+		t.Fatalf("ReadPropagationForChild: %v", err)
+	}
+	if rec == nil || rec.ParentSessionID != "parent-legacy" {
+		t.Fatalf("got %+v, want legacy record accepted for compatibility", rec)
+	}
+}
+
+func TestPropagation_WriteStampsParentPID(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	m := NewManager(t.TempDir())
+
+	parent := testParentState()
+	if err := m.WritePropagation(parent); err != nil {
+		t.Fatalf("WritePropagation: %v", err)
+	}
+
+	rec, err := m.ReadPropagation(parent.PolicyPath)
+	if err != nil {
+		t.Fatalf("ReadPropagation: %v", err)
+	}
+	if rec == nil {
+		t.Fatal("ReadPropagation returned nil")
+	}
+	if rec.ParentPID != os.Getppid() {
+		t.Errorf("ParentPID = %d, want writer's Claude PID %d", rec.ParentPID, os.Getppid())
+	}
+}

--- a/pkg/aflock/types.go
+++ b/pkg/aflock/types.go
@@ -611,6 +611,12 @@ type AgentIdentityMeta struct {
 	Environment  string `json:"environment,omitempty"`
 	PolicyDigest string `json:"policy_digest,omitempty"`
 	IdentityHash string `json:"identity_hash"`
+	// ModelSource records how Model was attributed: "transcript_path" (exact,
+	// read from the hook's own transcript file), "pid_trace" (machine-global
+	// process-tree + mtime heuristic — can be wrong when multiple Claude
+	// instances run concurrently, so PostToolUse keeps re-resolving it), or
+	// "" (state written by an older aflock build).
+	ModelSource string `json:"model_source,omitempty"`
 }
 
 // PropagationRecord is written by a parent session's PreToolUse(Agent) hook
@@ -633,6 +639,13 @@ type PropagationRecord struct {
 	// over to the child so its PostToolUse attestations can stamp it into
 	// the predicate (issue #26 gap 1).
 	AttestationPrefix string `json:"attestation_prefix,omitempty"`
+	// ParentPID is the OS process ID of the Claude process that spawned the
+	// child (the writing hook's os.Getppid()). Consumers verify this PID is
+	// in their own process ancestry before claiming the record, so a
+	// concurrent, unrelated session cannot steal another parent's handoff
+	// (multi-Claude safety). Zero in records written by older aflock builds —
+	// those are accepted for backward compatibility.
+	ParentPID int `json:"parent_pid,omitempty"`
 }
 
 // IsExpiredPropagation checks if the propagation record has exceeded the given TTL.


### PR DESCRIPTION
Running two or more Claude Code sessions concurrently broke aflock in two ways:

- **Wrong identity**: hooks attributed the model from the most-recently-flushed session file in the project dir. Now discovery uses the hook input's own `transcript_path` (exact); the heuristic survives only as a marked fallback (`model_source`) that PostToolUse re-resolves once the transcript has its first assistant turn.
- **Stolen handoffs**: any SessionStart within 60s could claim another parent's propagation record FIFO — inheriting its materials/limits and later corrupting the parent's state at SubagentStop. Records now carry the writer's Claude `parent_pid`, and children only claim records written by one of their own process ancestors; non-matching records stay on disk for the rightful child. Legacy records (no pid) still accepted. Stale records are GC'd on write.

Tests: transcript-exact attribution beats a newer neighbor; unrelated sessions can't steal records; legacy compat. Full suite + lint green.

Follow-ups worth separate issues: machine-global `AFLOCK_POLICY` overriding cwd, fixed `--unix`/`--http` endpoints colliding for a second instance, and the shared step-attestation namespace.