### PR TITLE
feat: agent-to-agent gate — signed AgentCard verification and peer principal policy

### DIFF
--- a/cmd/aflock/main.go
+++ b/cmd/aflock/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/aflock-ai/aflock/internal/a2a"
 	"github.com/aflock-ai/aflock/internal/hooks"
 	"github.com/aflock-ai/aflock/internal/mcp"
 	"github.com/aflock-ai/aflock/internal/plan"
@@ -318,6 +319,63 @@ stdout on success.`,
 	},
 }
 
+// agent command flags
+var (
+	agentCardIdentities []string
+	agentCardIssuers    []string
+	agentCardRoots      []string
+)
+
+var agentCmd = &cobra.Command{
+	Use:   "agent",
+	Short: "Agent-to-agent identity commands",
+}
+
+var agentVerifyCardCmd = &cobra.Command{
+	Use:   "verify-card <signed-card.json>",
+	Short: "Verify a signed A2A AgentCard and print the signing principal",
+	Long: `Verify a sigstore-a2a signed AgentCard: DSSE signature, certificate
+chain to the trust roots (default: the Sigstore public Fulcio root), and the
+card's binding to the signed statement's subject digest.
+
+Prints the card metadata and the signing principal — kind (agent / human /
+workflow, by SAN taxonomy), identity, and OIDC issuer — as JSON. Exits 1 if
+verification fails or the principal does not match --identity/--issuer.`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		data, err := os.ReadFile(args[0])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Read card: %v\n", err)
+			os.Exit(1)
+		}
+		rootMap := map[string]aflock.Root{}
+		for i, path := range agentCardRoots {
+			rootMap[fmt.Sprintf("root-%d", i)] = aflock.Root{Certificate: path}
+		}
+		roots, err := a2a.LoadRoots(rootMap, "")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Load roots: %v\n", err)
+			os.Exit(1)
+		}
+		res, err := a2a.VerifySignedCard(data, a2a.Options{Roots: roots, Issuers: agentCardIssuers})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Verification failed: %v\n", err)
+			os.Exit(1)
+		}
+		if len(agentCardIdentities) > 0 && !res.Principal.MatchIdentity(agentCardIdentities) {
+			fmt.Fprintf(os.Stderr, "Verification failed: principal %s:%s does not match --identity constraints\n",
+				res.Principal.Kind, res.Principal.ID)
+			os.Exit(1)
+		}
+		out, err := json.MarshalIndent(res, "", "  ")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Marshal result: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println(string(out))
+	},
+}
+
 // plan-to-policy command flags
 var (
 	planPath       string
@@ -617,12 +675,19 @@ func init() {
 	rootCmd.AddCommand(signCmd)
 	rootCmd.AddCommand(policyCmd)
 	policyCmd.AddCommand(policyVerifyCmd)
+	rootCmd.AddCommand(agentCmd)
+	agentCmd.AddCommand(agentVerifyCardCmd)
 	rootCmd.AddCommand(serveCmd)
 	rootCmd.AddCommand(planToPolicyCmd)
 	rootCmd.AddCommand(replayCmd)
 
 	// Add --hook flag as alternative to hook subcommand for backwards compatibility
 	rootCmd.Flags().StringVar(&hookFlag, "hook", "", "Hook event to handle (alternative to 'hook' subcommand)")
+
+	// Agent verify-card flags
+	agentVerifyCardCmd.Flags().StringArrayVar(&agentCardIdentities, "identity", nil, "Required principal pattern (repeatable; optional kind prefix agent:/human:/workflow:)")
+	agentVerifyCardCmd.Flags().StringArrayVar(&agentCardIssuers, "issuer", nil, "Allowed Fulcio OIDC issuer glob (repeatable)")
+	agentVerifyCardCmd.Flags().StringArrayVar(&agentCardRoots, "root", nil, "Trust root PEM file (repeatable; default: Sigstore public Fulcio root)")
 
 	// Verify command flags
 	verifyCmd.Flags().StringVarP(&verifyPolicyPath, "policy", "p", "", "Path to .aflock policy file (enables step-based verification)")

--- a/examples/a2a-policy.aflock
+++ b/examples/a2a-policy.aflock
@@ -1,0 +1,32 @@
+{
+  "version": "1.0",
+  "name": "a2a-gated-agent",
+
+  "tools": {
+    "allow": ["Read", "Grep", "Glob", "WebFetch", "Bash"]
+  },
+
+  "domains": {
+    "allow": ["api.anthropic.com", "agents.partner.example"]
+  },
+
+  "roots": {
+    "partner-ca": "certs/partner-fulcio-root.pem"
+  },
+
+  "agents": {
+    "endpoints": ["https://agents.partner.example/*", "agents.partner.example"],
+    "requireSignedCard": true,
+    "cards": {
+      "partner-triage": "cards/partner-triage.signed.json"
+    },
+    "issuers": ["https://token.actions.githubusercontent.com"],
+    "allow": [
+      "agent:spiffe://judge.testifysec.com/tenant/acme/agent/*",
+      "workflow:https://github.com/partner-org/*"
+    ],
+    "deny": [
+      "human:*"
+    ]
+  }
+}

--- a/internal/a2a/card.go
+++ b/internal/a2a/card.go
@@ -1,0 +1,437 @@
+// Package a2a implements verification of signed A2A AgentCards and the
+// peer-principal taxonomy used by the agents policy section.
+//
+// Wire format: the sigstore-a2a signed card layout — a JSON document
+//
+//	{"agentCard": {...}, "attestations": {"signatureBundle": <sigstore bundle v0.3>}}
+//
+// where the bundle's dsseEnvelope wraps an in-toto Statement whose predicate
+// type is PredicateTypeAgentCard and whose subject digest is the SHA-256 of
+// the RFC 8785 (JCS) canonicalization of the agentCard object, and whose
+// signing certificate is a Fulcio leaf embedded in
+// verificationMaterial.certificate.rawBytes.
+//
+// Principal taxonomy (mirrors the Pushgate/judge agent-principal model —
+// "the SAN type is the assertion"):
+//   - a URI SAN with scheme spiffe://  → PrincipalAgent
+//   - an email SAN                     → PrincipalHuman
+//   - any other URI SAN                → PrincipalWorkflow
+//
+// A leaf carrying both an email SAN and a URI SAN claims two principals and
+// is refused outright.
+//
+// Current limitation (Phase 1): the certificate chain is validated against
+// the trust roots, but Rekor transparency-log inclusion and RFC 3161
+// timestamps in the bundle are not yet verified — chain validity is checked
+// at the certificate's own NotBefore instant, so an expired-but-once-valid
+// Fulcio leaf still verifies. Signature-time proof is roadmap.
+package a2a
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/aflock-ai/aflock/pkg/aflock"
+	"github.com/cyberphone/json-canonicalization/go/src/webpki.org/jsoncanonicalizer"
+	"github.com/gobwas/glob"
+)
+
+// PredicateTypeAgentCard is the in-toto predicate type sigstore-a2a signs.
+const PredicateTypeAgentCard = "https://a2a.openwallet.dev/agentcard/v1"
+
+// Principal kinds — who signed the card, structurally.
+const (
+	PrincipalAgent    = "agent"
+	PrincipalHuman    = "human"
+	PrincipalWorkflow = "workflow"
+)
+
+// oidFulcioIssuer is the Fulcio OIDC issuer certificate extension.
+var oidFulcioIssuer = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 57264, 1, 1}
+
+// Principal is the identity that signed an AgentCard, parsed from the leaf
+// certificate's SANs. Kind is one of the Principal* constants.
+type Principal struct {
+	Kind   string `json:"kind"`
+	ID     string `json:"id"`               // SPIFFE URI, email, or workflow URI
+	Issuer string `json:"issuer,omitempty"` // Fulcio OIDC issuer extension, if present
+}
+
+// Result is a successfully verified signed AgentCard.
+type Result struct {
+	Name       string    `json:"name"`
+	URL        string    `json:"url"`
+	Version    string    `json:"version,omitempty"`
+	Principal  Principal `json:"principal"`
+	CardDigest string    `json:"cardDigest"` // hex SHA-256 of the JCS-canonical card
+}
+
+// Options constrain verification.
+type Options struct {
+	// Roots are the trust anchors for the signing certificate chain. When
+	// empty, the embedded Sigstore public-good Fulcio root is used.
+	Roots []*x509.Certificate
+	// Issuers, when non-empty, are glob patterns the leaf's Fulcio OIDC
+	// issuer extension must match.
+	Issuers []string
+}
+
+// --- wire structures (both camelCase and snake_case accepted) ---
+
+type signedCardWire struct {
+	AgentCard      json.RawMessage `json:"agentCard"`
+	AgentCardSnake json.RawMessage `json:"agent_card"`
+	Attestations   struct {
+		SignatureBundle      json.RawMessage `json:"signatureBundle"`
+		SignatureBundleSnake json.RawMessage `json:"signature_bundle"`
+	} `json:"attestations"`
+}
+
+type bundleWire struct {
+	VerificationMaterial struct {
+		Certificate struct {
+			RawBytes []byte `json:"rawBytes"`
+		} `json:"certificate"`
+		X509CertificateChain struct {
+			Certificates []struct {
+				RawBytes []byte `json:"rawBytes"`
+			} `json:"certificates"`
+		} `json:"x509CertificateChain"`
+	} `json:"verificationMaterial"`
+	DSSEEnvelope struct {
+		Payload     []byte `json:"payload"`
+		PayloadType string `json:"payloadType"`
+		Signatures  []struct {
+			Sig []byte `json:"sig"`
+		} `json:"signatures"`
+	} `json:"dsseEnvelope"`
+}
+
+type statementWire struct {
+	Type    string `json:"_type"`
+	Subject []struct {
+		Name   string            `json:"name"`
+		Digest map[string]string `json:"digest"`
+	} `json:"subject"`
+	PredicateType string `json:"predicateType"`
+}
+
+type agentCardMeta struct {
+	Name    string `json:"name"`
+	URL     string `json:"url"`
+	Version string `json:"version"`
+}
+
+// VerifySignedCard verifies a signed AgentCard document and returns the
+// card metadata plus the signing principal. Every returned error means the
+// card must be treated as unverified.
+func VerifySignedCard(data []byte, opts Options) (*Result, error) {
+	var wire signedCardWire
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return nil, fmt.Errorf("parse signed card: %w", err)
+	}
+	card := wire.AgentCard
+	if len(card) == 0 {
+		card = wire.AgentCardSnake
+	}
+	if len(card) == 0 {
+		return nil, fmt.Errorf("signed card has no agentCard field")
+	}
+	bundleRaw := wire.Attestations.SignatureBundle
+	if len(bundleRaw) == 0 {
+		bundleRaw = wire.Attestations.SignatureBundleSnake
+	}
+	if len(bundleRaw) == 0 {
+		return nil, fmt.Errorf("signed card has no attestations.signatureBundle")
+	}
+
+	var bundle bundleWire
+	if err := json.Unmarshal(bundleRaw, &bundle); err != nil {
+		return nil, fmt.Errorf("parse signature bundle: %w", err)
+	}
+
+	// Leaf certificate: bundle v0.3 uses verificationMaterial.certificate;
+	// older bundles carry an x509CertificateChain.
+	certDER := bundle.VerificationMaterial.Certificate.RawBytes
+	if len(certDER) == 0 && len(bundle.VerificationMaterial.X509CertificateChain.Certificates) > 0 {
+		certDER = bundle.VerificationMaterial.X509CertificateChain.Certificates[0].RawBytes
+	}
+	if len(certDER) == 0 {
+		return nil, fmt.Errorf("signature bundle has no signing certificate")
+	}
+	cert, err := x509.ParseCertificate(certDER)
+	if err != nil {
+		return nil, fmt.Errorf("parse signing certificate: %w", err)
+	}
+
+	env := bundle.DSSEEnvelope
+	if env.PayloadType != "application/vnd.in-toto+json" {
+		return nil, fmt.Errorf("unexpected DSSE payload type %q", env.PayloadType)
+	}
+	if len(env.Payload) == 0 || len(env.Signatures) == 0 {
+		return nil, fmt.Errorf("signature bundle has empty DSSE envelope")
+	}
+
+	// 1 — DSSE signature over the PAE, with the leaf's public key.
+	pae := dssePAE(env.PayloadType, env.Payload)
+	sigOK := false
+	for _, s := range env.Signatures {
+		if verifySignature(cert.PublicKey, pae, s.Sig) {
+			sigOK = true
+			break
+		}
+	}
+	if !sigOK {
+		return nil, fmt.Errorf("DSSE signature does not verify with the embedded certificate")
+	}
+
+	// 2 — chain to the trust roots. Rekor/TSA signature-time proof is not
+	// yet checked (see package comment), so chain validity is evaluated at
+	// the leaf's own NotBefore instant rather than time.Now().
+	roots := opts.Roots
+	if len(roots) == 0 {
+		fulcio, rootErr := fulcioPublicRoot()
+		if rootErr != nil {
+			return nil, rootErr
+		}
+		roots = []*x509.Certificate{fulcio}
+	}
+	pool := x509.NewCertPool()
+	for _, r := range roots {
+		pool.AddCert(r)
+	}
+	if _, err := cert.Verify(x509.VerifyOptions{
+		Roots:       pool,
+		CurrentTime: cert.NotBefore.Add(1),
+		KeyUsages:   []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+	}); err != nil {
+		return nil, fmt.Errorf("signing certificate does not chain to a trusted root: %w", err)
+	}
+
+	// 3 — the statement must bind THIS card: subject digest == SHA-256 of
+	// the JCS-canonical agentCard, and the predicate type must match.
+	var stmt statementWire
+	if err := json.Unmarshal(env.Payload, &stmt); err != nil {
+		return nil, fmt.Errorf("parse in-toto statement: %w", err)
+	}
+	if stmt.PredicateType != PredicateTypeAgentCard {
+		return nil, fmt.Errorf("unexpected predicate type %q (want %s)", stmt.PredicateType, PredicateTypeAgentCard)
+	}
+	canonical, err := jsoncanonicalizer.Transform(card)
+	if err != nil {
+		return nil, fmt.Errorf("canonicalize agent card: %w", err)
+	}
+	digest := sha256.Sum256(canonical)
+	digestHex := hex.EncodeToString(digest[:])
+	digestOK := false
+	for _, sub := range stmt.Subject {
+		if strings.EqualFold(sub.Digest["sha256"], digestHex) {
+			digestOK = true
+			break
+		}
+	}
+	if !digestOK {
+		return nil, fmt.Errorf("agent card does not match the signed statement's subject digest (card tampered?)")
+	}
+
+	// 4 — principal extraction + issuer constraint.
+	principal, err := CertPrincipal(cert)
+	if err != nil {
+		return nil, err
+	}
+	if len(opts.Issuers) > 0 && !matchAnyGlob(opts.Issuers, principal.Issuer) {
+		return nil, fmt.Errorf("card signer's OIDC issuer %q not in allowed issuers", principal.Issuer)
+	}
+
+	var meta agentCardMeta
+	if err := json.Unmarshal(card, &meta); err != nil {
+		return nil, fmt.Errorf("parse agent card fields: %w", err)
+	}
+
+	return &Result{
+		Name:       meta.Name,
+		URL:        meta.URL,
+		Version:    meta.Version,
+		Principal:  principal,
+		CardDigest: digestHex,
+	}, nil
+}
+
+// CertPrincipal parses the signing principal from a leaf certificate's SANs.
+// One principal per leaf: a certificate carrying both an email SAN and a URI
+// SAN is refused — verification never guesses which identity was meant.
+func CertPrincipal(cert *x509.Certificate) (Principal, error) {
+	p := Principal{Issuer: fulcioIssuer(cert)}
+
+	if len(cert.EmailAddresses) > 0 && len(cert.URIs) > 0 {
+		return p, fmt.Errorf("certificate claims two principals (email SAN and URI SAN) — refused")
+	}
+
+	switch {
+	case len(cert.URIs) > 0:
+		uri := cert.URIs[0].String()
+		if strings.HasPrefix(uri, "spiffe://") {
+			p.Kind = PrincipalAgent
+		} else {
+			p.Kind = PrincipalWorkflow
+		}
+		p.ID = uri
+	case len(cert.EmailAddresses) > 0:
+		p.Kind = PrincipalHuman
+		p.ID = cert.EmailAddresses[0]
+	default:
+		return p, fmt.Errorf("certificate carries no principal SAN (no email, no URI)")
+	}
+	return p, nil
+}
+
+// MatchIdentity reports whether the principal matches any of the patterns.
+// A pattern may be prefixed with a kind — "agent:", "human:", "workflow:" —
+// which must then equal the principal's kind; the remainder (or the whole
+// unprefixed pattern) is a glob matched against the principal's ID.
+func (p Principal) MatchIdentity(patterns []string) bool {
+	for _, pattern := range patterns {
+		id := pattern
+		if kind, rest, ok := strings.Cut(pattern, ":"); ok {
+			switch kind {
+			case PrincipalAgent, PrincipalHuman, PrincipalWorkflow:
+				if p.Kind != kind {
+					continue
+				}
+				id = rest
+			}
+		}
+		if g, err := glob.Compile(id); err == nil && g.Match(p.ID) {
+			return true
+		}
+	}
+	return false
+}
+
+// LoadRoots resolves aflock policy roots (file path, inline PEM, or base64
+// DER) into certificates. Relative paths resolve against baseDir.
+func LoadRoots(roots map[string]aflock.Root, baseDir string) ([]*x509.Certificate, error) {
+	var certs []*x509.Certificate
+	for name, root := range roots {
+		val := root.Certificate
+		if val == "" {
+			continue
+		}
+		var der []byte
+		switch {
+		case strings.Contains(val, "-----BEGIN"):
+			block, _ := pem.Decode([]byte(val))
+			if block == nil {
+				return nil, fmt.Errorf("root %q: invalid PEM", name)
+			}
+			der = block.Bytes
+		default:
+			path := val
+			if !strings.HasPrefix(path, "/") && baseDir != "" {
+				path = baseDir + "/" + path
+			}
+			if data, err := os.ReadFile(path); err == nil { //nolint:gosec // G304: path from operator-authored policy
+				block, _ := pem.Decode(data)
+				if block == nil {
+					return nil, fmt.Errorf("root %q: file %s is not PEM", name, path)
+				}
+				der = block.Bytes
+			} else if decoded, b64Err := base64.StdEncoding.DecodeString(val); b64Err == nil {
+				der = decoded
+			} else {
+				return nil, fmt.Errorf("root %q: not a readable file, PEM, or base64: %v", name, err)
+			}
+		}
+		cert, err := x509.ParseCertificate(der)
+		if err != nil {
+			return nil, fmt.Errorf("root %q: parse certificate: %w", name, err)
+		}
+		certs = append(certs, cert)
+	}
+	return certs, nil
+}
+
+// --- internals ---
+
+// dssePAE builds the DSSE v1 pre-authentication encoding.
+func dssePAE(payloadType string, payload []byte) []byte {
+	return fmt.Appendf(nil, "DSSEv1 %d %s %d %s", len(payloadType), payloadType, len(payload), payload)
+}
+
+func verifySignature(pub crypto.PublicKey, message, sig []byte) bool {
+	digest := sha256.Sum256(message)
+	switch key := pub.(type) {
+	case *ecdsa.PublicKey:
+		return ecdsa.VerifyASN1(key, digest[:], sig)
+	case ed25519.PublicKey:
+		return ed25519.Verify(key, message, sig)
+	case *rsa.PublicKey:
+		return rsa.VerifyPKCS1v15(key, crypto.SHA256, digest[:], sig) == nil
+	default:
+		return false
+	}
+}
+
+func fulcioIssuer(cert *x509.Certificate) string {
+	for _, ext := range cert.Extensions {
+		if ext.Id.Equal(oidFulcioIssuer) {
+			return extensionString(ext)
+		}
+	}
+	return ""
+}
+
+func extensionString(ext pkix.Extension) string {
+	var utf8Val string
+	rest, err := asn1.Unmarshal(ext.Value, &utf8Val)
+	if err == nil && len(rest) == 0 {
+		return utf8Val
+	}
+	return string(ext.Value)
+}
+
+func matchAnyGlob(patterns []string, value string) bool {
+	for _, pattern := range patterns {
+		if g, err := glob.Compile(pattern); err == nil && g.Match(value) {
+			return true
+		}
+	}
+	return false
+}
+
+// fulcioPublicRootPEM is the Sigstore public-good Fulcio root CA (same
+// anchor embedded in internal/verify for keyless functionaries).
+const fulcioPublicRootPEM = `-----BEGIN CERTIFICATE-----
+MIIB9zCCAXygAwIBAgIUALZNAPFdxHPwjeDloDwyYChAO/4wCgYIKoZIzj0EAwMw
+KjEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MREwDwYDVQQDEwhzaWdzdG9yZTAeFw0y
+MTEwMDcxMzU2NTlaFw0zMTEwMDUxMzU2NThaMCoxFTATBgNVBAoTDHNpZ3N0b3Jl
+LmRldjERMA8GA1UEAxMIc2lnc3RvcmUwdjAQBgcqhkjOPQIBBgUrgQQAIgNiAAT7
+XeFT4rb3PQGwS4IajtLk3/OlnpGangaBclYpsYBr5i+4ynB07ceb3LP0OIOZdxex
+X69c5iVuyJRQ+Hz05yi+UF3uBWAlHpiS5sh0+H2GHE7SXrk1EC5m1Tr19L9gg92j
+YzBhMA4GA1UdDwEB/wQEAwIBBjAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBRY
+wB5fkUWlZql6zJChkyLQKsXF+jAfBgNVHSMEGDAWgBRYwB5fkUWlZql6zJChkyLQ
+KsXF+jAKBggqhkjOPQQDAwNpADBmAjEAj1nHeXZp+13NWBNa+EDsDP8G1WWg1tCM
+WP/WHPqpaVo0jhsweNFZgSs0eE7wYI4qAjEA2WB9ot98sIkoF3vZYdd3/VtWB5b9
+TNMea7Ix/stJ5TfcLLeABLE4BNJOsQ4vnBHJ
+-----END CERTIFICATE-----`
+
+func fulcioPublicRoot() (*x509.Certificate, error) {
+	block, _ := pem.Decode([]byte(fulcioPublicRootPEM))
+	if block == nil {
+		return nil, fmt.Errorf("decode embedded Fulcio root PEM")
+	}
+	return x509.ParseCertificate(block.Bytes)
+}

--- a/internal/a2a/card_test.go
+++ b/internal/a2a/card_test.go
@@ -1,0 +1,317 @@
+package a2a
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"encoding/hex"
+	"encoding/json"
+	"maps"
+	"math/big"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/cyberphone/json-canonicalization/go/src/webpki.org/jsoncanonicalizer"
+)
+
+// --- fixture helpers -------------------------------------------------------
+
+type testCA struct {
+	cert *x509.Certificate
+	key  *ecdsa.PrivateKey
+}
+
+func newTestCA(t *testing.T) *testCA {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "a2a-test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &testCA{cert: cert, key: key}
+}
+
+type leafOpts struct {
+	uris   []string
+	emails []string
+	issuer string
+}
+
+func (ca *testCA) newLeaf(t *testing.T, opts leafOpts) (*x509.Certificate, *ecdsa.PrivateKey) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:   big.NewInt(2),
+		Subject:        pkix.Name{},
+		NotBefore:      time.Now().Add(-time.Minute),
+		NotAfter:       time.Now().Add(10 * time.Minute),
+		KeyUsage:       x509.KeyUsageDigitalSignature,
+		EmailAddresses: opts.emails,
+	}
+	for _, u := range opts.uris {
+		parsed, parseErr := url.Parse(u)
+		if parseErr != nil {
+			t.Fatal(parseErr)
+		}
+		tmpl.URIs = append(tmpl.URIs, parsed)
+	}
+	if opts.issuer != "" {
+		val, marshalErr := asn1.MarshalWithParams(opts.issuer, "utf8")
+		if marshalErr != nil {
+			t.Fatal(marshalErr)
+		}
+		tmpl.ExtraExtensions = append(tmpl.ExtraExtensions, pkix.Extension{Id: oidFulcioIssuer, Value: val})
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, ca.cert, &key.PublicKey, ca.key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cert, key
+}
+
+var testCard = map[string]any{
+	"protocolVersion": "0.2.9",
+	"name":            "Test Triage Agent",
+	"url":             "https://agents.partner.example/a2a/v1",
+	"version":         "1.0.0",
+}
+
+// signCard assembles a sigstore-a2a-shaped signed card for testCard.
+func signCard(t *testing.T, ca *testCA, opts leafOpts, mutate func(card map[string]any)) []byte {
+	t.Helper()
+	cert, key := ca.newLeaf(t, opts)
+
+	card := map[string]any{}
+	maps.Copy(card, testCard)
+	if mutate != nil {
+		mutate(card)
+	}
+	cardJSON, err := json.Marshal(card)
+	if err != nil {
+		t.Fatal(err)
+	}
+	canonical, err := jsoncanonicalizer.Transform(cardJSON)
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest := sha256.Sum256(canonical)
+
+	statement := map[string]any{
+		"_type": "https://in-toto.io/Statement/v1",
+		"subject": []map[string]any{{
+			"name":   card["name"],
+			"digest": map[string]string{"sha256": hex.EncodeToString(digest[:])},
+		}},
+		"predicateType": PredicateTypeAgentCard,
+		"predicate":     card,
+	}
+	payload, err := json.Marshal(statement)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pae := dssePAE("application/vnd.in-toto+json", payload)
+	paeDigest := sha256.Sum256(pae)
+	sig, err := ecdsa.SignASN1(rand.Reader, key, paeDigest[:])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	signed := map[string]any{
+		"agentCard": card,
+		"attestations": map[string]any{
+			"signatureBundle": map[string]any{
+				"mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+				"verificationMaterial": map[string]any{
+					"certificate": map[string]any{"rawBytes": cert.Raw},
+				},
+				"dsseEnvelope": map[string]any{
+					"payload":     payload,
+					"payloadType": "application/vnd.in-toto+json",
+					"signatures":  []map[string]any{{"sig": sig}},
+				},
+			},
+		},
+	}
+	out, err := json.Marshal(signed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+// --- tests -----------------------------------------------------------------
+
+func TestVerifySignedCard_AgentPrincipal(t *testing.T) {
+	ca := newTestCA(t)
+	data := signCard(t, ca, leafOpts{
+		uris:   []string{"spiffe://judge.testifysec.com/tenant/acme/agent/a1"},
+		issuer: "https://issuer.test.dev",
+	}, nil)
+
+	res, err := VerifySignedCard(data, Options{Roots: []*x509.Certificate{ca.cert}})
+	if err != nil {
+		t.Fatalf("VerifySignedCard: %v", err)
+	}
+	if res.Principal.Kind != PrincipalAgent {
+		t.Errorf("Kind = %q, want agent", res.Principal.Kind)
+	}
+	if res.Principal.ID != "spiffe://judge.testifysec.com/tenant/acme/agent/a1" {
+		t.Errorf("ID = %q", res.Principal.ID)
+	}
+	if res.Principal.Issuer != "https://issuer.test.dev" {
+		t.Errorf("Issuer = %q", res.Principal.Issuer)
+	}
+	if res.URL != "https://agents.partner.example/a2a/v1" {
+		t.Errorf("URL = %q", res.URL)
+	}
+	if res.Name != "Test Triage Agent" {
+		t.Errorf("Name = %q", res.Name)
+	}
+}
+
+func TestVerifySignedCard_PrincipalTaxonomy(t *testing.T) {
+	ca := newTestCA(t)
+
+	human := signCard(t, ca, leafOpts{emails: []string{"cole@example.com"}}, nil)
+	res, err := VerifySignedCard(human, Options{Roots: []*x509.Certificate{ca.cert}})
+	if err != nil {
+		t.Fatalf("human card: %v", err)
+	}
+	if res.Principal.Kind != PrincipalHuman || res.Principal.ID != "cole@example.com" {
+		t.Errorf("human principal = %+v", res.Principal)
+	}
+
+	workflow := signCard(t, ca, leafOpts{
+		uris: []string{"https://github.com/aflock-ai/aflock/.github/workflows/sign.yml@refs/heads/main"},
+	}, nil)
+	res, err = VerifySignedCard(workflow, Options{Roots: []*x509.Certificate{ca.cert}})
+	if err != nil {
+		t.Fatalf("workflow card: %v", err)
+	}
+	if res.Principal.Kind != PrincipalWorkflow {
+		t.Errorf("workflow principal = %+v", res.Principal)
+	}
+}
+
+func TestVerifySignedCard_DualPrincipalRefused(t *testing.T) {
+	ca := newTestCA(t)
+	dual := signCard(t, ca, leafOpts{
+		uris:   []string{"spiffe://td/agent/a"},
+		emails: []string{"who@example.com"},
+	}, nil)
+	if _, err := VerifySignedCard(dual, Options{Roots: []*x509.Certificate{ca.cert}}); err == nil {
+		t.Fatal("certificate with both email and URI SANs must be refused")
+	}
+}
+
+func TestVerifySignedCard_TamperedCardFails(t *testing.T) {
+	ca := newTestCA(t)
+	data := signCard(t, ca, leafOpts{uris: []string{"spiffe://td/agent/a"}}, nil)
+
+	// Tamper: swap the endpoint URL in the (unsigned) agentCard object.
+	var doc map[string]json.RawMessage
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatal(err)
+	}
+	var card map[string]any
+	if err := json.Unmarshal(doc["agentCard"], &card); err != nil {
+		t.Fatal(err)
+	}
+	card["url"] = "https://evil.example/a2a/v1"
+	tampered, err := json.Marshal(card)
+	if err != nil {
+		t.Fatal(err)
+	}
+	doc["agentCard"] = tampered
+	data, err = json.Marshal(doc)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := VerifySignedCard(data, Options{Roots: []*x509.Certificate{ca.cert}}); err == nil {
+		t.Fatal("tampered agentCard must fail subject-digest verification")
+	}
+}
+
+func TestVerifySignedCard_UntrustedRootFails(t *testing.T) {
+	ca := newTestCA(t)
+	other := newTestCA(t)
+	data := signCard(t, ca, leafOpts{uris: []string{"spiffe://td/agent/a"}}, nil)
+	if _, err := VerifySignedCard(data, Options{Roots: []*x509.Certificate{other.cert}}); err == nil {
+		t.Fatal("card chained to a different CA must be refused")
+	}
+}
+
+func TestVerifySignedCard_IssuerConstraint(t *testing.T) {
+	ca := newTestCA(t)
+	data := signCard(t, ca, leafOpts{
+		uris:   []string{"spiffe://td/agent/a"},
+		issuer: "https://issuer.test.dev",
+	}, nil)
+
+	if _, err := VerifySignedCard(data, Options{
+		Roots:   []*x509.Certificate{ca.cert},
+		Issuers: []string{"https://issuer.test.dev"},
+	}); err != nil {
+		t.Fatalf("matching issuer refused: %v", err)
+	}
+	if _, err := VerifySignedCard(data, Options{
+		Roots:   []*x509.Certificate{ca.cert},
+		Issuers: []string{"https://other-issuer.dev"},
+	}); err == nil {
+		t.Fatal("non-matching issuer must be refused")
+	}
+}
+
+func TestPrincipalMatchIdentity(t *testing.T) {
+	agent := Principal{Kind: PrincipalAgent, ID: "spiffe://judge.testifysec.com/tenant/acme/agent/a1"}
+	human := Principal{Kind: PrincipalHuman, ID: "cole@example.com"}
+
+	cases := []struct {
+		p       Principal
+		pattern string
+		want    bool
+	}{
+		{agent, "spiffe://judge.testifysec.com/tenant/acme/agent/*", true},
+		{agent, "agent:spiffe://judge.testifysec.com/tenant/*/agent/*", true},
+		{agent, "human:spiffe://judge.testifysec.com/*", false}, // kind mismatch
+		{agent, "spiffe://other.dev/*", false},
+		{human, "human:*@example.com", true},
+		{human, "agent:*@example.com", false},
+		{human, "*@example.com", true},
+	}
+	for _, c := range cases {
+		if got := c.p.MatchIdentity([]string{c.pattern}); got != c.want {
+			t.Errorf("MatchIdentity(%q) on %+v = %v, want %v", c.pattern, c.p, got, c.want)
+		}
+	}
+}

--- a/internal/hooks/handler.go
+++ b/internal/hooks/handler.go
@@ -536,6 +536,22 @@ func (h *Handler) handlePreToolUse(input *aflock.HookInput) error {
 		}
 	}
 
+	// If tool is allowed, gate agent-to-agent connections (policy.agents):
+	// verify the pinned signed AgentCard for the endpoint and match its
+	// signing principal against the allow/deny patterns. Verified peers are
+	// recorded as materials so the session carries a receipt of who was
+	// contacted.
+	if decision == aflock.DecisionAllow && pol.Agents != nil {
+		agentDecision, agentReason, peerMaterial := evaluator.EvaluateAgentConnection(input.ToolName, input.ToolInput)
+		if agentDecision != aflock.DecisionAllow {
+			decision = agentDecision
+			reason = agentReason
+		} else if peerMaterial != nil {
+			peerMaterial.Timestamp = time.Now()
+			sessionState.Materials = append(sessionState.Materials, *peerMaterial)
+		}
+	}
+
 	// If tool is allowed, also check data flow rules
 	if decision == aflock.DecisionAllow {
 		flowDecision, flowReason, newMaterial := evaluator.EvaluateDataFlow(

--- a/internal/policy/agents.go
+++ b/internal/policy/agents.go
@@ -1,0 +1,174 @@
+package policy
+
+import (
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/aflock-ai/aflock/internal/a2a"
+	"github.com/aflock-ai/aflock/pkg/aflock"
+)
+
+// agentGateState caches verified AgentCards and resolved trust roots for the
+// lifetime of one Evaluator (one hook invocation / one MCP server).
+type agentGateState struct {
+	cards       map[string]cardResult // keyed by card path
+	roots       []*x509.Certificate
+	rootsErr    error
+	rootsLoaded bool
+}
+
+type cardResult struct {
+	res *a2a.Result
+	err error
+}
+
+// EvaluateAgentConnection gates agent-to-agent connections (policy.agents).
+//
+// A tool call is an agent connection when a URL in its input matches one of
+// agents.endpoints. For such calls, the pinned signed AgentCard vouching for
+// that endpoint is verified (signature, chain to policy roots, card digest)
+// and the signing principal — agent / human / workflow, per SAN taxonomy —
+// is matched against agents.deny then agents.allow.
+//
+// Returns the decision, a reason for non-allow, and, for allowed verified
+// (or knowingly unverified) connections, a MaterialClassification recording
+// the peer so the session state carries a receipt of who was contacted.
+func (e *Evaluator) EvaluateAgentConnection(toolName string, toolInput json.RawMessage) (aflock.PermissionDecision, string, *aflock.MaterialClassification) {
+	ap := e.policy.Agents
+	if ap == nil || len(ap.Endpoints) == 0 {
+		return aflock.DecisionAllow, "", nil
+	}
+
+	for _, target := range e.extractURLs(toolName, toolInput) {
+		if !e.matchesAgentEndpoint(ap, target) {
+			continue
+		}
+
+		res, why := e.verifyPeerForEndpoint(ap, target)
+		if res == nil {
+			if ap.RequireSignedCard {
+				return aflock.DecisionDeny, fmt.Sprintf("agent endpoint '%s': %s", target, why), nil
+			}
+			// Unverified peer, permitted by policy — still leave a trace.
+			return aflock.DecisionAllow, "", &aflock.MaterialClassification{
+				Label:  "agent-connection",
+				Source: "unverified|" + target,
+			}
+		}
+
+		p := res.Principal
+		if p.MatchIdentity(ap.Deny) {
+			return aflock.DecisionDeny, fmt.Sprintf("peer agent %s:%s matches agents.deny", p.Kind, p.ID), nil
+		}
+		if len(ap.Allow) > 0 && !p.MatchIdentity(ap.Allow) {
+			return aflock.DecisionDeny, fmt.Sprintf("peer agent %s:%s not in agents.allow", p.Kind, p.ID), nil
+		}
+		return aflock.DecisionAllow, "", &aflock.MaterialClassification{
+			Label:  "agent-connection",
+			Source: fmt.Sprintf("%s|%s|%s", p.Kind, p.ID, target),
+			Digest: map[string]string{"sha256": res.CardDigest},
+		}
+	}
+
+	return aflock.DecisionAllow, "", nil
+}
+
+// extractURLs pulls candidate URLs out of a tool call's input.
+func (e *Evaluator) extractURLs(toolName string, toolInput json.RawMessage) []string {
+	switch toolName {
+	case toolWebFetch:
+		var input aflock.WebFetchToolInput
+		if err := json.Unmarshal(toolInput, &input); err == nil && input.URL != "" {
+			return []string{input.URL}
+		}
+	case "Bash":
+		var input aflock.BashToolInput
+		if err := json.Unmarshal(toolInput, &input); err == nil && input.Command != "" {
+			var urls []string
+			for field := range strings.FieldsSeq(input.Command) {
+				token := strings.Trim(field, `"'();,`)
+				if strings.Contains(token, "://") {
+					urls = append(urls, token)
+				}
+			}
+			return urls
+		}
+	default:
+		if s := e.extractInputForMatching(toolName, toolInput); strings.Contains(s, "://") {
+			return []string{s}
+		}
+	}
+	return nil
+}
+
+// matchesAgentEndpoint reports whether the URL (or its host) matches any
+// agents.endpoints glob.
+func (e *Evaluator) matchesAgentEndpoint(ap *aflock.AgentsPolicy, target string) bool {
+	host := extractDomain(target)
+	for _, pattern := range ap.Endpoints {
+		if e.matcher.MatchGlob(pattern, target) || (host != "" && e.matcher.MatchGlob(pattern, host)) {
+			return true
+		}
+	}
+	return false
+}
+
+// verifyPeerForEndpoint finds a pinned card whose agentCard.url host matches
+// the target's host, verified against the policy roots and issuer
+// constraints. Returns (nil, reason) when no card vouches for the endpoint.
+func (e *Evaluator) verifyPeerForEndpoint(ap *aflock.AgentsPolicy, target string) (*a2a.Result, string) {
+	if len(ap.Cards) == 0 {
+		return nil, "no AgentCards pinned in agents.cards"
+	}
+	if e.a2aState == nil {
+		e.a2aState = &agentGateState{cards: map[string]cardResult{}}
+	}
+	st := e.a2aState
+
+	if !st.rootsLoaded {
+		st.roots, st.rootsErr = a2a.LoadRoots(e.policy.Roots, e.projectRoot)
+		st.rootsLoaded = true
+	}
+	if st.rootsErr != nil {
+		return nil, fmt.Sprintf("failed to load trust roots: %v", st.rootsErr)
+	}
+
+	targetHost := extractDomain(target)
+	var firstErr string
+	for name, path := range ap.Cards {
+		full := path
+		if !strings.HasPrefix(full, "/") && e.projectRoot != "" {
+			full = e.projectRoot + "/" + full
+		}
+		cached, ok := st.cards[full]
+		if !ok {
+			cached = verifyCardFile(full, a2a.Options{Roots: st.roots, Issuers: ap.Issuers})
+			st.cards[full] = cached
+		}
+		if cached.err != nil {
+			if firstErr == "" {
+				firstErr = fmt.Sprintf("card %q failed verification: %v", name, cached.err)
+			}
+			continue
+		}
+		if cardHost := extractDomain(cached.res.URL); cardHost != "" && cardHost == targetHost {
+			return cached.res, ""
+		}
+	}
+	if firstErr != "" {
+		return nil, firstErr
+	}
+	return nil, "no verified AgentCard vouches for this endpoint"
+}
+
+func verifyCardFile(path string, opts a2a.Options) cardResult {
+	data, err := os.ReadFile(path) //nolint:gosec // G304: path from operator-authored policy
+	if err != nil {
+		return cardResult{err: fmt.Errorf("read card: %w", err)}
+	}
+	res, err := a2a.VerifySignedCard(data, opts)
+	return cardResult{res: res, err: err}
+}

--- a/internal/policy/agents_test.go
+++ b/internal/policy/agents_test.go
@@ -1,0 +1,96 @@
+package policy
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/aflock-ai/aflock/pkg/aflock"
+)
+
+// The cryptographic card-verification path is covered by internal/a2a tests;
+// these cover the policy gate around it: endpoint classification, the
+// requireSignedCard decision, and URL extraction from tool inputs.
+
+func agentsPolicy(ap *aflock.AgentsPolicy) *aflock.Policy {
+	return &aflock.Policy{Version: "1.0", Name: "a2a-test", Agents: ap}
+}
+
+func webFetchInput(t *testing.T, url string) json.RawMessage {
+	t.Helper()
+	data, err := json.Marshal(aflock.WebFetchToolInput{URL: url})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+func TestAgentGate_NoAgentsSectionAllows(t *testing.T) {
+	e := NewEvaluator(agentsPolicy(nil), "")
+	decision, _, material := e.EvaluateAgentConnection("WebFetch", webFetchInput(t, "https://agents.partner.example/a2a/v1"))
+	if decision != aflock.DecisionAllow || material != nil {
+		t.Fatalf("no agents section must be a no-op, got %v %v", decision, material)
+	}
+}
+
+func TestAgentGate_NonMatchingEndpointAllows(t *testing.T) {
+	e := NewEvaluator(agentsPolicy(&aflock.AgentsPolicy{
+		Endpoints:         []string{"agents.partner.example"},
+		RequireSignedCard: true,
+	}), "")
+	decision, _, material := e.EvaluateAgentConnection("WebFetch", webFetchInput(t, "https://api.anthropic.com/v1/messages"))
+	if decision != aflock.DecisionAllow || material != nil {
+		t.Fatalf("non-agent endpoint must pass through, got %v %v", decision, material)
+	}
+}
+
+func TestAgentGate_RequireSignedCardDeniesWithoutCard(t *testing.T) {
+	e := NewEvaluator(agentsPolicy(&aflock.AgentsPolicy{
+		Endpoints:         []string{"agents.partner.example"},
+		RequireSignedCard: true,
+	}), "")
+	decision, reason, _ := e.EvaluateAgentConnection("WebFetch", webFetchInput(t, "https://agents.partner.example/a2a/v1"))
+	if decision != aflock.DecisionDeny {
+		t.Fatalf("agent endpoint without a pinned card must be denied, got %v (%s)", decision, reason)
+	}
+}
+
+func TestAgentGate_UnverifiedAllowedLeavesTrace(t *testing.T) {
+	e := NewEvaluator(agentsPolicy(&aflock.AgentsPolicy{
+		Endpoints: []string{"agents.partner.example"},
+		// RequireSignedCard false: connection allowed, but recorded.
+	}), "")
+	decision, _, material := e.EvaluateAgentConnection("WebFetch", webFetchInput(t, "https://agents.partner.example/a2a/v1"))
+	if decision != aflock.DecisionAllow {
+		t.Fatalf("decision = %v, want allow", decision)
+	}
+	if material == nil || material.Label != "agent-connection" {
+		t.Fatalf("unverified agent connection must leave a material trace, got %+v", material)
+	}
+}
+
+func TestAgentGate_MissingCardFileDenies(t *testing.T) {
+	e := NewEvaluator(agentsPolicy(&aflock.AgentsPolicy{
+		Endpoints:         []string{"agents.partner.example"},
+		RequireSignedCard: true,
+		Cards:             map[string]string{"partner": "does-not-exist.json"},
+	}), t.TempDir())
+	decision, reason, _ := e.EvaluateAgentConnection("WebFetch", webFetchInput(t, "https://agents.partner.example/a2a/v1"))
+	if decision != aflock.DecisionDeny {
+		t.Fatalf("unreadable card must fail closed, got %v (%s)", decision, reason)
+	}
+}
+
+func TestAgentGate_BashURLExtraction(t *testing.T) {
+	e := NewEvaluator(agentsPolicy(&aflock.AgentsPolicy{
+		Endpoints:         []string{"agents.partner.example"},
+		RequireSignedCard: true,
+	}), "")
+	input, err := json.Marshal(aflock.BashToolInput{Command: `curl -s "https://agents.partner.example/a2a/v1" | jq .`})
+	if err != nil {
+		t.Fatal(err)
+	}
+	decision, _, _ := e.EvaluateAgentConnection("Bash", input)
+	if decision != aflock.DecisionDeny {
+		t.Fatalf("bash curl to an agent endpoint must hit the gate, got %v", decision)
+	}
+}

--- a/internal/policy/evaluator.go
+++ b/internal/policy/evaluator.go
@@ -30,6 +30,10 @@ type Evaluator struct {
 	matcher      *Matcher
 	bashAnalyzer *BashAnalyzer
 	projectRoot  string // absolute path to project root (where .aflock lives)
+
+	// a2aState lazily caches verified AgentCards + trust roots for the
+	// agents gate (see agents.go).
+	a2aState *agentGateState
 }
 
 // NewEvaluator creates a new policy evaluator.

--- a/pkg/aflock/types.go
+++ b/pkg/aflock/types.go
@@ -148,6 +148,7 @@ type Policy struct {
 	Tools      *ToolsPolicy    `json:"tools,omitempty"`
 	Files      *FilesPolicy    `json:"files,omitempty"`
 	Domains    *DomainsPolicy  `json:"domains,omitempty"`
+	Agents     *AgentsPolicy   `json:"agents,omitempty"`
 	DataFlow   *DataFlowPolicy `json:"dataFlow,omitempty"`
 	Hooks      *HooksConfig    `json:"hooks,omitempty"`
 	Sublayouts []Sublayout     `json:"sublayouts,omitempty"`
@@ -405,6 +406,37 @@ type FilesPolicy struct {
 type DomainsPolicy struct {
 	Allow []string `json:"allow,omitempty"`
 	Deny  []string `json:"deny,omitempty"`
+}
+
+// AgentsPolicy governs agent-to-agent connections: which outbound endpoints
+// count as "talking to another agent", and which peer principals — verified
+// from signed A2A AgentCards — the agent is allowed to talk to.
+//
+// Peer identity patterns in Allow/Deny may be prefixed with a principal kind
+// ("agent:", "human:", "workflow:") that must match the SAN taxonomy of the
+// card's signing certificate; the remainder is a glob matched against the
+// principal ID (SPIFFE URI, email, or workflow URI). Example:
+//
+//	"allow": ["agent:spiffe://judge.testifysec.com/tenant/acme/agent/*"]
+type AgentsPolicy struct {
+	// Endpoints are URL globs (matched against the full URL and its host)
+	// that classify a network tool call as an agent-to-agent connection.
+	// Empty means the agents gate never fires.
+	Endpoints []string `json:"endpoints,omitempty"`
+	// Allow / Deny are peer principal patterns. Deny wins; a non-empty
+	// Allow means the peer must match one of its patterns.
+	Allow []string `json:"allow,omitempty"`
+	Deny  []string `json:"deny,omitempty"`
+	// RequireSignedCard, when true, denies agent connections whose endpoint
+	// has no pinned, verifiable AgentCard.
+	RequireSignedCard bool `json:"requireSignedCard,omitempty"`
+	// Cards maps a name to the path of a pinned signed AgentCard file
+	// (relative paths resolve against the project root). A card vouches for
+	// the endpoint named in its agentCard.url.
+	Cards map[string]string `json:"cards,omitempty"`
+	// Issuers, when non-empty, are glob patterns the card signer's Fulcio
+	// OIDC issuer extension must match.
+	Issuers []string `json:"issuers,omitempty"`
 }
 
 // MaterialsPolicy defines materials binding for provenance.


### PR DESCRIPTION
First slice of A2A security: aflock can now identify and gate which *other agents* an agent talks to.

- New `agents` policy section: `endpoints` classify a network call as an agent-to-agent connection; `cards` pin sigstore-a2a signed AgentCards; `allow`/`deny` match the card's signing principal; `requireSignedCard` fails closed; `issuers` constrain the Fulcio OIDC issuer.
- New `internal/a2a` package verifies the sigstore-a2a wire format (Sigstore bundle v0.3: DSSE over an in-toto statement, subject digest = SHA-256 of the JCS-canonical card, Fulcio leaf) against `policy.roots` (default: Sigstore public root).
- Principal taxonomy mirrors the judge/Pushgate agent-principal model — the SAN type is the assertion: `spiffe://` URI SAN = agent, email SAN = human, other URI = workflow; a leaf claiming two principals is refused. Patterns support kind prefixes (`agent:spiffe://…/tenant/*/agent/*`).
- PreToolUse wires the gate between grants and data-flow; verified peers are recorded as `agent-connection` materials (peer id + card digest) so the session carries a receipt of who was contacted.
- New CLI: `aflock agent verify-card <signed-card.json> [--identity …] [--issuer …] [--root …]`.
- Example policy in `examples/a2a-policy.aflock`; 13 new tests (crypto path + policy gate). Full suite + lint green.

Known limitation (documented in the package): Rekor/RFC3161 signature-time proof is not yet verified — chain validity only. Roadmap: attenuated JWT over A2A + SPIFFE federation.